### PR TITLE
refactor: replace errcheck exclusion list with explicit error discards

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -17,24 +17,6 @@ linters:
     - misspell
 
   settings:
-    errcheck:
-      exclude-functions:
-        # Keepalive is best-effort.
-        - (*net.TCPConn).SetKeepAlive
-        - (*net.TCPConn).SetKeepAlivePeriod
-        # Deadline errors are non-critical in bridge teardown.
-        - (net.Conn).SetReadDeadline
-        - (net.Conn).SetWriteDeadline
-        - (net.Conn).SetDeadline
-        # CloseNow is always deferred as cleanup.
-        - (*github.com/coder/websocket.Conn).CloseNow
-        # Close on net.Conn/net.Listener is best-effort cleanup.
-        - (net.Conn).Close
-        - (net.Listener).Close
-        - (*net.TCPListener).Close
-        # SendReply is best-effort on error paths.
-        - (github.com/philsphicas/aztunnel/internal/sender/socks5).SendReply
-
     revive:
       rules:
         - name: exported

--- a/internal/relay/control.go
+++ b/internal/relay/control.go
@@ -87,7 +87,7 @@ func runControlLoop(ctx context.Context, cfg ControlConfig) error {
 	if err != nil {
 		return fmt.Errorf("dial control: %w", sanitizeErr(err))
 	}
-	defer ws.CloseNow()
+	defer func() { _ = ws.CloseNow() }()
 
 	cfg.Logger.Info("control channel connected", "entityPath", cfg.EntityPath)
 
@@ -159,7 +159,7 @@ func handleAccept(ctx context.Context, addr string, cfg ControlConfig) error {
 	if err != nil {
 		return fmt.Errorf("dial rendezvous: %w", err)
 	}
-	defer ws.CloseNow()
+	defer func() { _ = ws.CloseNow() }()
 
 	cfg.Handler(ctx, ws)
 	_ = ws.Close(websocket.StatusNormalClosure, "done")

--- a/internal/sender/connect.go
+++ b/internal/sender/connect.go
@@ -31,7 +31,7 @@ func Connect(ctx context.Context, cfg ConnectConfig) error {
 	if err != nil {
 		return err
 	}
-	defer ws.CloseNow()
+	defer func() { _ = ws.CloseNow() }()
 
 	if err := sendEnvelopeAndCheck(ctx, ws, cfg.Target); err != nil {
 		return err

--- a/internal/sender/portforward.go
+++ b/internal/sender/portforward.go
@@ -77,7 +77,7 @@ func forwardConnection(ctx context.Context, conn net.Conn, target string, cfg Po
 	if err != nil {
 		return err
 	}
-	defer ws.CloseNow()
+	defer func() { _ = ws.CloseNow() }()
 
 	// Send envelope and read response.
 	if err := sendEnvelopeAndCheck(ctx, ws, target); err != nil {

--- a/internal/sender/socks5proxy.go
+++ b/internal/sender/socks5proxy.go
@@ -86,7 +86,7 @@ func handleSOCKS5(ctx context.Context, conn net.Conn, cfg SOCKS5Config) error {
 		_ = socks5.SendReply(conn, socks5.RepGeneralFailure, nil)
 		return err
 	}
-	defer ws.CloseNow()
+	defer func() { _ = ws.CloseNow() }()
 
 	// Send envelope and check response.
 	if err := sendEnvelopeAndCheck(ctx, ws, target); err != nil {


### PR DESCRIPTION
## Summary

- Remove the `errcheck` `exclude-functions` list from `.golangci.yml`
- Add explicit `_ = ws.CloseNow()` at the 5 call sites that relied on global suppression
- Makes intent visible at each call site instead of hiding decisions in a config file

All other previously-excluded functions (`SetKeepAlive`, `SetReadDeadline`, `SendReply`, `net.Conn.Close`, etc.) already used `_ =` or `//nolint:errcheck` annotations, so removing the exclusion list has no effect on them.