### PR TITLE
feat: add Azure Arc relay support

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Tunnel TCP connections through [Azure Relay Hybrid Connections](https://learn.mi
 - **Port forward** — bind a local port and forward connections to a fixed remote target
 - **SOCKS5 proxy** — run a local SOCKS5 server for dynamic target selection
 - **SSH ProxyCommand** — bridge stdin/stdout for use with `ssh -o ProxyCommand`
+- **Azure Arc support** — connect to Arc-enrolled machines through automatically provisioned relays
 - **Allowlist enforcement** — restrict which targets the listener can reach (CIDR, host:port, wildcard)
 - **Two auth modes** — SAS keys or Entra ID (DefaultAzureCredential)
 
@@ -158,6 +159,49 @@ Host remote-*
     ProxyCommand aztunnel relay-sender connect %h:%p
 ```
 
+## Azure Arc
+
+aztunnel can connect to [Azure Arc-enrolled machines](https://learn.microsoft.com/en-us/azure/azure-arc/servers/overview) through the Azure Relay that Azure provisions automatically when the OpenSSH extension is installed. No separate relay namespace or listener is needed — the Arc agent on the VM acts as the listener.
+
+### Prerequisites
+
+- The target machine must be Arc-enrolled (`Microsoft.HybridCompute/machines`)
+- The `Microsoft.HybridConnectivity` resource provider must be registered on the subscription
+- You need [DefaultAzureCredential](https://learn.microsoft.com/en-us/azure/developer/go/azure-sdk-authentication) access to the machine's ARM resource (e.g., via `az login`)
+- SSH must be running on the target machine
+
+### Arc SSH ProxyCommand
+
+```sh
+ssh -o ProxyCommand="aztunnel arc connect --resource-id /subscriptions/SUB/resourceGroups/RG/providers/Microsoft.HybridCompute/machines/myVM" user@myVM
+```
+
+Or in `~/.ssh/config`:
+
+```
+Host arc-*
+    ProxyCommand aztunnel arc connect --resource-id /subscriptions/SUB/resourceGroups/RG/providers/Microsoft.HybridCompute/machines/%n
+```
+
+### Arc port forward
+
+Forward local port 2222 to SSH on an Arc VM:
+
+```sh
+aztunnel arc port-forward --resource-id /subscriptions/SUB/resourceGroups/RG/providers/Microsoft.HybridCompute/machines/myVM -b 127.0.0.1:2222
+
+# Then connect:
+ssh -p 2222 user@127.0.0.1
+```
+
+### Custom port
+
+If SSH listens on a non-standard port (e.g., 2222):
+
+```sh
+aztunnel arc connect --resource-id /subscriptions/.../machines/myVM --port 2222
+```
+
 ## CLI reference
 
 ```
@@ -168,6 +212,8 @@ Commands:
   relay-sender port-forward             Forward a local port through the relay
   relay-sender socks5-proxy             Run a local SOCKS5 proxy through the relay
   relay-sender connect                  One-shot stdin/stdout connection (ProxyCommand)
+  arc connect                           One-shot connection through an Arc relay (ProxyCommand)
+  arc port-forward                      Forward a local port through an Arc relay
   version                               Print the version
 
 Global flags:
@@ -224,6 +270,31 @@ Flags:
   --hyco string        Hybrid connection name
 ```
 
+### arc connect
+
+```
+aztunnel arc connect [flags]
+
+Flags:
+  --resource-id string   ARM resource ID of the Arc-connected machine
+  --port int             Remote port the service listens on (default 22)
+  --service string       Service name: SSH or WAC (default "SSH")
+```
+
+### arc port-forward
+
+```
+aztunnel arc port-forward [flags]
+
+Flags:
+  --resource-id string       ARM resource ID of the Arc-connected machine
+  --port int                 Remote port the service listens on (default 22)
+  --service string           Service name: SSH or WAC (default "SSH")
+  -b, --bind string          Local bind address:port (default "127.0.0.1:0")
+  --gateway                  Bind to 0.0.0.0 instead of 127.0.0.1
+  --tcp-keepalive duration   TCP keepalive interval (default 30s)
+```
+
 ## Allowlist
 
 The listener's `--allow` flag restricts which targets can be dialed. Entries are matched against the target `host:port` requested by the sender.
@@ -241,12 +312,13 @@ Hostnames are matched literally — no DNS resolution is performed. Use CIDR not
 
 ## Environment variables
 
-| Variable              | Description                |
-| --------------------- | -------------------------- |
-| `AZTUNNEL_RELAY_NAME` | Azure Relay namespace name |
-| `AZTUNNEL_HYCO_NAME`  | Hybrid connection name     |
-| `AZTUNNEL_KEY_NAME`   | SAS policy name            |
-| `AZTUNNEL_KEY`        | SAS key value              |
+| Variable                  | Description                                  |
+| ------------------------- | -------------------------------------------- |
+| `AZTUNNEL_RELAY_NAME`     | Azure Relay namespace name                   |
+| `AZTUNNEL_HYCO_NAME`      | Hybrid connection name                       |
+| `AZTUNNEL_KEY_NAME`       | SAS policy name                              |
+| `AZTUNNEL_KEY`            | SAS key value                                |
+| `AZTUNNEL_ARC_RESOURCE_ID`| ARM resource ID of the Arc-connected machine |
 
 ## License
 

--- a/cmd/aztunnel/arc.go
+++ b/cmd/aztunnel/arc.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+func arcCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "arc",
+		Short: "Connect through Azure Arc managed relays",
+		Long: `The arc command group connects to Azure Arc-enrolled machines through
+the Azure Relay hybrid connection that Azure provisions automatically
+when the OpenSSH extension is installed.
+
+Unlike relay-sender (which requires you to provision your own Azure Relay
+and run an aztunnel listener), arc mode works with any Arc-connected
+machine that has the HybridConnectivity endpoint enabled.`,
+	}
+
+	cmd.PersistentFlags().String("resource-id", "", "ARM resource ID of the Arc-connected machine")
+	cmd.PersistentFlags().Int("port", 22, "remote port the service listens on")
+	cmd.PersistentFlags().String("service", "SSH", "service name (SSH or WAC)")
+
+	cmd.AddCommand(arcConnectCmd())
+	cmd.AddCommand(arcPortForwardCmd())
+
+	return cmd
+}
+
+// resolveResourceID returns the resource ID from --resource-id flag or
+// AZTUNNEL_ARC_RESOURCE_ID env var.
+func resolveResourceID(cmd *cobra.Command) (string, error) {
+	rid, _ := cmd.Flags().GetString("resource-id")
+	if rid != "" {
+		return rid, nil
+	}
+	if rid := os.Getenv("AZTUNNEL_ARC_RESOURCE_ID"); rid != "" {
+		return rid, nil
+	}
+	return "", fmt.Errorf("resource ID is required: use --resource-id or set AZTUNNEL_ARC_RESOURCE_ID")
+}
+
+// arcStdioConn adapts stdin/stdout to net.Conn for use with relay.Bridge.
+type arcStdioConn struct {
+	in  io.ReadCloser
+	out io.WriteCloser
+}
+
+func (c *arcStdioConn) Read(b []byte) (int, error)       { return c.in.Read(b) }
+func (c *arcStdioConn) Write(b []byte) (int, error)      { return c.out.Write(b) }
+func (c *arcStdioConn) Close() error                     { return errors.Join(c.in.Close(), c.out.Close()) }
+func (c *arcStdioConn) LocalAddr() net.Addr              { return arcStubAddr{} }
+func (c *arcStdioConn) RemoteAddr() net.Addr             { return arcStubAddr{} }
+func (c *arcStdioConn) SetDeadline(time.Time) error      { return nil }
+func (c *arcStdioConn) SetReadDeadline(time.Time) error  { return nil }
+func (c *arcStdioConn) SetWriteDeadline(time.Time) error { return nil }
+
+type arcStubAddr struct{}
+
+func (arcStubAddr) Network() string { return "stdio" }
+func (arcStubAddr) String() string  { return "stdio" }

--- a/cmd/aztunnel/arc_connect.go
+++ b/cmd/aztunnel/arc_connect.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"context"
+	"os"
+	"os/signal"
+
+	"github.com/philsphicas/aztunnel/internal/arc"
+	"github.com/philsphicas/aztunnel/internal/relay"
+	"github.com/spf13/cobra"
+)
+
+func arcConnectCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "connect",
+		Short: "One-shot stdin/stdout connection through an Arc relay",
+		Long: `Connect to an Azure Arc-enrolled machine through the automatically
+provisioned Azure Relay. Bridges stdin/stdout with the tunnel, then exits
+when the connection closes. Designed for use as an SSH ProxyCommand.
+
+Example:
+  ssh -o ProxyCommand="aztunnel arc connect --resource-id /subscriptions/.../machines/myVM" user@host`,
+		RunE: runArcConnect,
+	}
+}
+
+func runArcConnect(cmd *cobra.Command, _ []string) error {
+	resourceID, err := resolveResourceID(cmd)
+	if err != nil {
+		return err
+	}
+	port, _ := cmd.Flags().GetInt("port")
+	service, _ := cmd.Flags().GetString("service")
+	logLevel, _ := cmd.Flags().GetString("log-level")
+	logger := newLogger(logLevel)
+
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
+	defer stop()
+
+	client, err := arc.NewClient(logger, nil)
+	if err != nil {
+		return err
+	}
+
+	// Try to get relay credentials directly. If the endpoint doesn't exist
+	// yet, create it and retry.
+	info, err := client.GetRelayCredentials(ctx, resourceID, service)
+	if err != nil {
+		logger.Debug("initial credential request failed, ensuring hybrid connectivity", "error", err)
+		if ensureErr := client.EnsureHybridConnectivity(ctx, resourceID, service, port); ensureErr != nil {
+			return ensureErr
+		}
+		info, err = client.GetRelayCredentials(ctx, resourceID, service)
+		if err != nil {
+			return err
+		}
+	}
+
+	ws, err := arc.DialWithLogger(ctx, info, port, logger)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = ws.CloseNow() }()
+
+	logger.Debug("connected to arc relay", "resource", resourceID)
+
+	stdio := &arcStdioConn{in: os.Stdin, out: os.Stdout}
+	return relay.Bridge(ctx, ws, stdio)
+}

--- a/cmd/aztunnel/arc_port_forward.go
+++ b/cmd/aztunnel/arc_port_forward.go
@@ -1,0 +1,119 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"os"
+	"os/signal"
+	"time"
+
+	"github.com/philsphicas/aztunnel/internal/arc"
+	"github.com/philsphicas/aztunnel/internal/relay"
+	"github.com/spf13/cobra"
+)
+
+func arcPortForwardCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "port-forward",
+		Short: "Forward a local port through an Arc relay",
+		Long: `Start a local TCP listener and forward each connection through the
+Azure Arc managed relay to the remote service.
+
+Example:
+  aztunnel arc port-forward --resource-id /subscriptions/.../machines/myVM -b 127.0.0.1:2222
+  ssh -p 2222 user@127.0.0.1`,
+		RunE: runArcPortForward,
+	}
+
+	cmd.Flags().StringP("bind", "b", "127.0.0.1:0", "local bind address:port")
+	cmd.Flags().Bool("gateway", false, "bind to 0.0.0.0 instead of 127.0.0.1")
+	cmd.Flags().Duration("tcp-keepalive", 30*time.Second, "TCP keepalive interval")
+
+	return cmd
+}
+
+func runArcPortForward(cmd *cobra.Command, _ []string) error {
+	resourceID, err := resolveResourceID(cmd)
+	if err != nil {
+		return err
+	}
+	port, _ := cmd.Flags().GetInt("port")
+	service, _ := cmd.Flags().GetString("service")
+	bind, _ := cmd.Flags().GetString("bind")
+	gateway, _ := cmd.Flags().GetBool("gateway")
+	if gateway {
+		_, p, _ := net.SplitHostPort(bind)
+		if p == "" {
+			p = "0"
+		}
+		bind = "0.0.0.0:" + p
+	}
+	tcpKeepAlive, _ := cmd.Flags().GetDuration("tcp-keepalive")
+	logLevel, _ := cmd.Flags().GetString("log-level")
+	logger := newLogger(logLevel)
+
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
+	defer stop()
+
+	client, err := arc.NewClient(logger, nil)
+	if err != nil {
+		return err
+	}
+
+	// Try to get relay credentials directly. If the endpoint doesn't exist
+	// yet, create it. EnsureHybridConnectivity is only called on first
+	// failure to avoid disrupting the Arc agent's relay listener.
+	if _, err := client.GetRelayCredentials(ctx, resourceID, service); err != nil {
+		logger.Debug("initial credential request failed, ensuring hybrid connectivity", "error", err)
+		if ensureErr := client.EnsureHybridConnectivity(ctx, resourceID, service, port); ensureErr != nil {
+			return ensureErr
+		}
+	}
+
+	ln, err := net.Listen("tcp", bind)
+	if err != nil {
+		return fmt.Errorf("listen %s: %w", bind, err)
+	}
+	defer func() { _ = ln.Close() }()
+	logger.Info("arc port-forward listening", "bind", ln.Addr(), "resource", resourceID, "port", port)
+
+	go func() {
+		<-ctx.Done()
+		_ = ln.Close()
+	}()
+
+	for {
+		conn, err := ln.Accept()
+		if err != nil {
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
+			logger.Warn("accept failed", "error", err)
+			continue
+		}
+
+		go func() {
+			defer func() { _ = conn.Close() }()
+			relay.SetTCPKeepAlive(conn, tcpKeepAlive)
+
+			// Get fresh credentials for each connection to avoid SAS expiry.
+			info, err := client.GetRelayCredentials(ctx, resourceID, service)
+			if err != nil {
+				logger.Warn("get relay credentials failed", "error", err)
+				return
+			}
+
+			ws, err := arc.DialWithLogger(ctx, info, port, logger)
+			if err != nil {
+				logger.Warn("arc relay dial failed", "error", err)
+				return
+			}
+			defer func() { _ = ws.CloseNow() }()
+
+			if err := relay.Bridge(ctx, ws, conn); err != nil {
+				logger.Debug("bridge ended", "error", err)
+			}
+		}()
+	}
+}

--- a/cmd/aztunnel/main.go
+++ b/cmd/aztunnel/main.go
@@ -22,6 +22,7 @@ func main() {
 
 	rootCmd.AddCommand(relayListenerCmd())
 	rootCmd.AddCommand(relaySenderCmd())
+	rootCmd.AddCommand(arcCmd())
 	rootCmd.AddCommand(versionCmd())
 
 	if err := rootCmd.Execute(); err != nil {

--- a/internal/arc/arc.go
+++ b/internal/arc/arc.go
@@ -1,0 +1,309 @@
+// Package arc provides client-side support for connecting through Azure Arc
+// managed Azure Relay hybrid connections.
+//
+// When an Azure Arc-connected machine has the OpenSSH extension installed,
+// Azure automatically provisions an Azure Relay namespace and hybrid
+// connection. The Arc agent on the VM acts as the relay listener, forwarding
+// traffic to the local SSH daemon (or other configured service).
+//
+// This package handles the HybridConnectivity ARM API interactions:
+// ensuring the endpoint and service configuration exist, obtaining relay
+// credentials, and dialing the relay.
+package arc
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"strings"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/streaming"
+	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
+	"github.com/coder/websocket"
+	"github.com/philsphicas/aztunnel/internal/relay"
+)
+
+const (
+	hybridConnectivityAPIVersion = "2023-03-15"
+	defaultExpiresin             = 10800 // 3 hours (maximum)
+	defaultServiceName           = "SSH"
+	defaultPort                  = 22
+)
+
+// RelayInfo holds the relay credentials returned by the listCredentials API.
+type RelayInfo struct {
+	NamespaceName             string `json:"namespaceName"`
+	NamespaceNameSuffix       string `json:"namespaceNameSuffix"`
+	HybridConnectionName      string `json:"hybridConnectionName"`
+	AccessKey                 string `json:"accessKey"`
+	ExpiresOn                 int64  `json:"expiresOn"`
+	ServiceConfigurationToken string `json:"serviceConfigurationToken"`
+}
+
+// Endpoint returns the Azure Relay sb:// endpoint.
+func (r *RelayInfo) Endpoint() string {
+	return "sb://" + r.NamespaceName + "." + r.NamespaceNameSuffix
+}
+
+// listCredentialsResponse is the top-level response from listCredentials.
+type listCredentialsResponse struct {
+	Relay RelayInfo `json:"relay"`
+}
+
+// Client interacts with the HybridConnectivity ARM APIs.
+type Client struct {
+	arm    *arm.Client
+	logger *slog.Logger
+}
+
+// NewClient creates a Client using DefaultAzureCredential.
+// Options may be nil for Azure Public Cloud defaults.
+func NewClient(logger *slog.Logger, options *arm.ClientOptions) (*Client, error) {
+	var credOpts *azidentity.DefaultAzureCredentialOptions
+	if options != nil {
+		credOpts = &azidentity.DefaultAzureCredentialOptions{
+			ClientOptions: options.ClientOptions,
+		}
+	}
+	cred, err := azidentity.NewDefaultAzureCredential(credOpts)
+	if err != nil {
+		return nil, fmt.Errorf("create Azure credential: %w", err)
+	}
+	return NewClientWithCredential(cred, logger, options)
+}
+
+// NewClientWithCredential creates a Client with a specific TokenCredential.
+// Options may be nil for Azure Public Cloud defaults.
+func NewClientWithCredential(cred azcore.TokenCredential, logger *slog.Logger, options *arm.ClientOptions) (*Client, error) {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	armClient, err := arm.NewClient("aztunnel-arc", "v1.0.0", cred, options)
+	if err != nil {
+		return nil, fmt.Errorf("create ARM client: %w", err)
+	}
+	return &Client{arm: armClient, logger: logger}, nil
+}
+
+// EnsureHybridConnectivity creates the HybridConnectivity endpoint and
+// service configuration if they don't already exist. Both calls are
+// idempotent PUTs.
+//
+// CAUTION: Calling this when the endpoint already exists may disrupt the
+// Arc agent's relay listener, causing subsequent connections to fail with
+// 404 "Endpoint does not exist" until the listener recovers. Prefer
+// calling GetRelayCredentials first and only calling this if it fails.
+func (c *Client) EnsureHybridConnectivity(ctx context.Context, resourceID, serviceName string, port int) error {
+	if serviceName == "" {
+		serviceName = defaultServiceName
+	}
+	if port == 0 {
+		port = defaultPort
+	}
+
+	endpointPath := fmt.Sprintf("%s/providers/Microsoft.HybridConnectivity/endpoints/default", resourceID)
+	endpointURL := runtime.JoinPaths(c.arm.Endpoint(), endpointPath) + "?api-version=" + hybridConnectivityAPIVersion
+
+	serviceConfigPath := fmt.Sprintf("%s/providers/Microsoft.HybridConnectivity/endpoints/default/serviceConfigurations/%s",
+		resourceID, serviceName)
+	serviceConfigURL := runtime.JoinPaths(c.arm.Endpoint(), serviceConfigPath) + "?api-version=" + hybridConnectivityAPIVersion
+
+	// Create endpoint.
+	c.logger.Debug("ensuring HybridConnectivity endpoint", "resourceID", resourceID)
+	endpointBody := `{"properties": {"type": "default"}}`
+	if err := c.armPUT(ctx, endpointURL, endpointBody); err != nil {
+		return fmt.Errorf("create HybridConnectivity endpoint: %w", err)
+	}
+
+	// Create service configuration.
+	c.logger.Debug("ensuring service configuration", "service", serviceName, "port", port)
+	serviceBody := fmt.Sprintf(`{"properties": {"serviceName": %q, "port": %d}}`, serviceName, port)
+	if err := c.armPUT(ctx, serviceConfigURL, serviceBody); err != nil {
+		return fmt.Errorf("create service configuration: %w", err)
+	}
+
+	return nil
+}
+
+// GetRelayCredentials obtains relay credentials by calling the
+// listCredentials API.
+func (c *Client) GetRelayCredentials(ctx context.Context, resourceID, serviceName string) (*RelayInfo, error) {
+	if serviceName == "" {
+		serviceName = defaultServiceName
+	}
+
+	credPath := fmt.Sprintf("%s/providers/Microsoft.HybridConnectivity/endpoints/default/listCredentials", resourceID)
+	credURL := runtime.JoinPaths(c.arm.Endpoint(), credPath) + fmt.Sprintf("?expiresin=%d&api-version=%s",
+		defaultExpiresin, hybridConnectivityAPIVersion)
+
+	body := fmt.Sprintf(`{"serviceName": %q}`, serviceName)
+
+	c.logger.Debug("requesting relay credentials", "resourceID", resourceID, "service", serviceName)
+	resp, err := c.armPOST(ctx, credURL, body)
+	if err != nil {
+		return nil, fmt.Errorf("list credentials: %w", err)
+	}
+
+	var result listCredentialsResponse
+	if err := json.Unmarshal(resp, &result); err != nil {
+		return nil, fmt.Errorf("parse credentials response: %w", err)
+	}
+
+	if result.Relay.NamespaceName == "" || result.Relay.HybridConnectionName == "" {
+		return nil, fmt.Errorf("incomplete relay credentials in response")
+	}
+
+	c.logger.Debug("obtained relay credentials",
+		"namespace", result.Relay.NamespaceName,
+		"hybridConnection", result.Relay.HybridConnectionName,
+		"expiresOn", result.Relay.ExpiresOn)
+
+	return &result.Relay, nil
+}
+
+// Dial connects to the Azure Relay using credentials from RelayInfo.
+// Unlike relay.Dial, this does NOT perform the aztunnel envelope exchange —
+// the Arc agent on the VM handles the local TCP connection directly.
+//
+// Authentication uses three HTTP headers on the WebSocket upgrade:
+//   - Servicebusauthorization: the SAS access key
+//   - Service-Configuration-Token: the JWT from listCredentials
+//   - Microsoft-Guestgateway-Target: localhost:{port}
+func Dial(ctx context.Context, info *RelayInfo, port int) (*websocket.Conn, error) {
+	if port == 0 {
+		port = defaultPort
+	}
+	wssHost := info.NamespaceName + "." + info.NamespaceNameSuffix
+
+	connectURL := fmt.Sprintf("wss://%s/$hc/%s?sb-hc-action=connect&sb-hc-id=%s",
+		wssHost,
+		info.HybridConnectionName,
+		newUUID())
+
+	headers := http.Header{}
+	headers.Set("Servicebusauthorization", info.AccessKey)
+	headers.Set("Service-Configuration-Token", info.ServiceConfigurationToken)
+	headers.Set("Microsoft-Guestgateway-Target", fmt.Sprintf("localhost:%d", port))
+
+	ws, _, err := websocket.Dial(ctx, connectURL, &websocket.DialOptions{
+		HTTPHeader: headers,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("dial arc relay: %w", sanitizeErr(err))
+	}
+	return ws, nil
+}
+
+// DialWithLogger is like Dial but logs the connection attempt.
+func DialWithLogger(ctx context.Context, info *RelayInfo, port int, logger *slog.Logger) (*websocket.Conn, error) {
+	logger.Debug("dialing arc relay",
+		"namespace", info.NamespaceName,
+		"hybridConnection", info.HybridConnectionName,
+		"port", port)
+	ws, err := Dial(ctx, info, port)
+	if err != nil {
+		logger.Warn("arc relay dial failed", "error", err)
+		return nil, err
+	}
+	logger.Debug("arc relay connected")
+	return ws, nil
+}
+
+func (c *Client) armPUT(ctx context.Context, rawURL, body string) error {
+	req, err := runtime.NewRequest(ctx, http.MethodPut, rawURL)
+	if err != nil {
+		return err
+	}
+	req.Raw().Header.Set("Content-Type", "application/json")
+	if err := req.SetBody(streaming.NopCloser(strings.NewReader(body)), "application/json"); err != nil {
+		return err
+	}
+	resp, err := c.arm.Pipeline().Do(req)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode >= 400 {
+		return newARMError(resp)
+	}
+	return nil
+}
+
+func (c *Client) armPOST(ctx context.Context, rawURL, body string) ([]byte, error) {
+	req, err := runtime.NewRequest(ctx, http.MethodPost, rawURL)
+	if err != nil {
+		return nil, err
+	}
+	req.Raw().Header.Set("Content-Type", "application/json")
+	if err := req.SetBody(streaming.NopCloser(strings.NewReader(body)), "application/json"); err != nil {
+		return nil, err
+	}
+	resp, err := c.arm.Pipeline().Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode >= 400 {
+		return nil, newARMError(resp)
+	}
+	return io.ReadAll(resp.Body)
+}
+
+func newARMError(resp *http.Response) error {
+	body, _ := io.ReadAll(resp.Body)
+	return fmt.Errorf("ARM API error (HTTP %d): %s", resp.StatusCode, string(body))
+}
+
+// sanitizeErr strips sensitive tokens from WebSocket dial errors.
+func sanitizeErr(err error) error {
+	s := err.Error()
+	// Query-param tokens are delimited by & or whitespace.
+	// Header tokens may contain spaces (e.g. "SharedAccessSignature sr=…"),
+	// so we only split on newline or quote.
+	type redaction struct {
+		prefix     string
+		delimiters string
+	}
+	patterns := []redaction{
+		{"sb-hc-token=", "&\" \n"},
+		{"Servicebusauthorization:", "\"\n"},
+		{"Service-Configuration-Token:", "\"\n"},
+	}
+	for _, p := range patterns {
+		idx := strings.Index(strings.ToLower(s), strings.ToLower(p.prefix))
+		if idx == -1 {
+			continue
+		}
+		afterPrefix := idx + len(p.prefix)
+		// Skip optional whitespace between header name and value.
+		for afterPrefix < len(s) && s[afterPrefix] == ' ' {
+			afterPrefix++
+		}
+		end := strings.IndexAny(s[afterPrefix:], p.delimiters)
+		if end == -1 {
+			s = s[:idx] + p.prefix + "REDACTED"
+		} else {
+			s = s[:idx] + p.prefix + "REDACTED" + s[afterPrefix+end:]
+		}
+	}
+	return fmt.Errorf("%s", s)
+}
+
+// newUUID generates a random UUID v4 string without external dependencies.
+func newUUID() string {
+	var b [16]byte
+	_, _ = rand.Read(b[:])
+	b[6] = (b[6] & 0x0f) | 0x40 // version 4
+	b[8] = (b[8] & 0x3f) | 0x80 // variant 10
+	return fmt.Sprintf("%08x-%04x-%04x-%04x-%012x", b[0:4], b[4:6], b[6:8], b[8:10], b[10:16])
+}
+
+// Bridge re-exports relay.Bridge for convenience.
+var Bridge = relay.Bridge

--- a/internal/arc/arc_test.go
+++ b/internal/arc/arc_test.go
@@ -1,0 +1,347 @@
+package arc
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+)
+
+// fakeCredential implements azcore.TokenCredential for testing.
+type fakeCredential struct{}
+
+func (fakeCredential) GetToken(_ context.Context, _ policy.TokenRequestOptions) (azcore.AccessToken, error) {
+	return azcore.AccessToken{Token: "fake-token"}, nil
+}
+
+// newTestClient creates a Client backed by the given test server.
+// It uses cloud.Configuration to point the ARM endpoint at the test server,
+// so the client's public methods construct correct URLs without any
+// transport-level rewrites.
+func newTestClient(t *testing.T, srv *httptest.Server) *Client {
+	t.Helper()
+	opts := &arm.ClientOptions{
+		ClientOptions: policy.ClientOptions{
+			Cloud: cloud.Configuration{
+				Services: map[cloud.ServiceName]cloud.ServiceConfiguration{
+					cloud.ResourceManager: {
+						Endpoint: srv.URL,
+						Audience: srv.URL,
+					},
+				},
+			},
+			Transport: srv.Client(),
+		},
+	}
+	c, err := NewClientWithCredential(fakeCredential{}, slog.Default(), opts)
+	if err != nil {
+		t.Fatalf("newTestClient: %v", err)
+	}
+	return c
+}
+
+func TestRelayInfoEndpoint(t *testing.T) {
+	r := &RelayInfo{
+		NamespaceName:       "my-relay",
+		NamespaceNameSuffix: "servicebus.windows.net",
+	}
+	want := "sb://my-relay.servicebus.windows.net"
+	if got := r.Endpoint(); got != want {
+		t.Errorf("Endpoint() = %q, want %q", got, want)
+	}
+}
+
+func TestEnsureHybridConnectivity(t *testing.T) {
+	const resourceID = "/subscriptions/sub1/resourceGroups/rg1/providers/Microsoft.HybridCompute/machines/vm1"
+
+	type requestRecord struct {
+		method string
+		path   string
+		query  string
+	}
+
+	t.Run("creates endpoint and service config", func(t *testing.T) {
+		var requests []requestRecord
+		srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			requests = append(requests, requestRecord{
+				method: r.Method,
+				path:   r.URL.Path,
+				query:  r.URL.RawQuery,
+			})
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{}`))
+		}))
+		defer srv.Close()
+
+		c := newTestClient(t, srv)
+		if err := c.EnsureHybridConnectivity(context.Background(), resourceID, "SSH", 2222); err != nil {
+			t.Fatalf("EnsureHybridConnectivity: %v", err)
+		}
+
+		if len(requests) != 2 {
+			t.Fatalf("expected 2 requests, got %d", len(requests))
+		}
+
+		// First PUT: endpoint creation
+		if requests[0].method != http.MethodPut {
+			t.Errorf("request 0: expected PUT, got %s", requests[0].method)
+		}
+		wantPath := resourceID + "/providers/Microsoft.HybridConnectivity/endpoints/default"
+		if requests[0].path != wantPath {
+			t.Errorf("request 0: path = %q, want %q", requests[0].path, wantPath)
+		}
+		if !strings.Contains(requests[0].query, "api-version=2023-03-15") {
+			t.Errorf("request 0: missing api-version in query: %s", requests[0].query)
+		}
+
+		// Second PUT: service configuration
+		if requests[1].method != http.MethodPut {
+			t.Errorf("request 1: expected PUT, got %s", requests[1].method)
+		}
+		wantPath = resourceID + "/providers/Microsoft.HybridConnectivity/endpoints/default/serviceConfigurations/SSH"
+		if requests[1].path != wantPath {
+			t.Errorf("request 1: path = %q, want %q", requests[1].path, wantPath)
+		}
+	})
+
+	t.Run("defaults for empty service and zero port", func(t *testing.T) {
+		var requests []requestRecord
+		srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			requests = append(requests, requestRecord{
+				method: r.Method,
+				path:   r.URL.Path,
+			})
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{}`))
+		}))
+		defer srv.Close()
+
+		c := newTestClient(t, srv)
+		if err := c.EnsureHybridConnectivity(context.Background(), resourceID, "", 0); err != nil {
+			t.Fatalf("EnsureHybridConnectivity: %v", err)
+		}
+
+		if len(requests) != 2 {
+			t.Fatalf("expected 2 requests, got %d", len(requests))
+		}
+
+		// Service config URL should use default "SSH"
+		wantPath := resourceID + "/providers/Microsoft.HybridConnectivity/endpoints/default/serviceConfigurations/SSH"
+		if requests[1].path != wantPath {
+			t.Errorf("request 1: path = %q, want %q", requests[1].path, wantPath)
+		}
+	})
+
+	t.Run("endpoint PUT failure", func(t *testing.T) {
+		srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusForbidden)
+			w.Write([]byte(`{"error": {"code": "AuthorizationFailed"}}`))
+		}))
+		defer srv.Close()
+
+		c := newTestClient(t, srv)
+		err := c.EnsureHybridConnectivity(context.Background(), resourceID, "SSH", 22)
+		if err == nil {
+			t.Fatal("expected error")
+		}
+		if !strings.Contains(err.Error(), "create HybridConnectivity endpoint") {
+			t.Errorf("error should mention endpoint creation: %v", err)
+		}
+	})
+}
+
+func TestGetRelayCredentials(t *testing.T) {
+	const resourceID = "/subscriptions/sub1/resourceGroups/rg1/providers/Microsoft.HybridCompute/machines/vm1"
+
+	validResp := listCredentialsResponse{
+		Relay: RelayInfo{
+			NamespaceName:             "azgnrelay-eastus-l1",
+			NamespaceNameSuffix:       "servicebus.windows.net",
+			HybridConnectionName:      "microsoft.hybridcompute/machines/vm1/abc123",
+			AccessKey:                 "SharedAccessSignature sr=test&sig=test",
+			ExpiresOn:                 9999999999,
+			ServiceConfigurationToken: "eyJ.test.jwt",
+		},
+	}
+
+	t.Run("success", func(t *testing.T) {
+		var capturedPath, capturedQuery, capturedService string
+		srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			capturedPath = r.URL.Path
+			capturedQuery = r.URL.RawQuery
+			var body map[string]string
+			json.NewDecoder(r.Body).Decode(&body)
+			capturedService = body["serviceName"]
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(validResp)
+		}))
+		defer srv.Close()
+
+		c := newTestClient(t, srv)
+		info, err := c.GetRelayCredentials(context.Background(), resourceID, "SSH")
+		if err != nil {
+			t.Fatalf("GetRelayCredentials: %v", err)
+		}
+
+		wantPath := resourceID + "/providers/Microsoft.HybridConnectivity/endpoints/default/listCredentials"
+		if capturedPath != wantPath {
+			t.Errorf("path = %q, want %q", capturedPath, wantPath)
+		}
+		if !strings.Contains(capturedQuery, "expiresin=10800") {
+			t.Errorf("missing expiresin in query: %s", capturedQuery)
+		}
+		if !strings.Contains(capturedQuery, "api-version=2023-03-15") {
+			t.Errorf("missing api-version in query: %s", capturedQuery)
+		}
+		if capturedService != "SSH" {
+			t.Errorf("serviceName = %q, want SSH", capturedService)
+		}
+		if info.NamespaceName != "azgnrelay-eastus-l1" {
+			t.Errorf("namespace = %q, want azgnrelay-eastus-l1", info.NamespaceName)
+		}
+		if info.HybridConnectionName != "microsoft.hybridcompute/machines/vm1/abc123" {
+			t.Errorf("hybridConnection = %q", info.HybridConnectionName)
+		}
+	})
+
+	t.Run("default service name", func(t *testing.T) {
+		var capturedService string
+		srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			var body map[string]string
+			json.NewDecoder(r.Body).Decode(&body)
+			capturedService = body["serviceName"]
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(validResp)
+		}))
+		defer srv.Close()
+
+		c := newTestClient(t, srv)
+		_, err := c.GetRelayCredentials(context.Background(), resourceID, "")
+		if err != nil {
+			t.Fatalf("GetRelayCredentials: %v", err)
+		}
+		if capturedService != "SSH" {
+			t.Errorf("default serviceName = %q, want SSH", capturedService)
+		}
+	})
+
+	t.Run("incomplete response missing namespace", func(t *testing.T) {
+		srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(listCredentialsResponse{
+				Relay: RelayInfo{
+					HybridConnectionName: "some/name",
+				},
+			})
+		}))
+		defer srv.Close()
+
+		c := newTestClient(t, srv)
+		_, err := c.GetRelayCredentials(context.Background(), resourceID, "SSH")
+		if err == nil {
+			t.Fatal("expected error for incomplete response")
+		}
+		if !strings.Contains(err.Error(), "incomplete") {
+			t.Errorf("error should mention incomplete: %v", err)
+		}
+	})
+
+	t.Run("incomplete response missing hybridConnection", func(t *testing.T) {
+		srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(listCredentialsResponse{
+				Relay: RelayInfo{
+					NamespaceName: "ns",
+				},
+			})
+		}))
+		defer srv.Close()
+
+		c := newTestClient(t, srv)
+		_, err := c.GetRelayCredentials(context.Background(), resourceID, "SSH")
+		if err == nil {
+			t.Fatal("expected error for incomplete response")
+		}
+		if !strings.Contains(err.Error(), "incomplete") {
+			t.Errorf("error should mention incomplete: %v", err)
+		}
+	})
+
+	t.Run("API error", func(t *testing.T) {
+		srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusNotFound)
+			w.Write([]byte(`{"error": {"code": "EndpointNotFound"}}`))
+		}))
+		defer srv.Close()
+
+		c := newTestClient(t, srv)
+		_, err := c.GetRelayCredentials(context.Background(), resourceID, "SSH")
+		if err == nil {
+			t.Fatal("expected error for 404")
+		}
+		if !strings.Contains(err.Error(), "list credentials") {
+			t.Errorf("error should mention list credentials: %v", err)
+		}
+	})
+}
+
+func TestARMErrorHandling(t *testing.T) {
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		w.Write([]byte(`{"error": {"code": "ResourceNotFound", "message": "not found"}}`))
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+
+	err := c.armPUT(context.Background(), srv.URL+"/notfound", `{}`)
+	if err == nil {
+		t.Fatal("expected error for 404")
+	}
+	if !strings.Contains(err.Error(), "404") {
+		t.Errorf("error should contain status code: %v", err)
+	}
+}
+
+func TestSanitizeErr(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+	}{
+		{"query param token", "dial wss://host/$hc/path?sb-hc-action=connect&sb-hc-token=SECRET"},
+		{"header with space", "failed: Servicebusauthorization: SharedAccessSignature sr=test&sig=SECRET&se=123"},
+		{"header no space", "failed: Servicebusauthorization:SharedAccessSignature SECRET"},
+		{"config token", "error: Service-Configuration-Token: eyJhbGciOi.SECRET.payload rest"},
+		{"lowercase header", "failed: servicebusauthorization: SECRET"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := sanitizeErr(errString(tt.input))
+			if strings.Contains(err.Error(), "SECRET") {
+				t.Errorf("token not redacted: %v", err)
+			}
+			if !strings.Contains(err.Error(), "REDACTED") {
+				t.Errorf("expected REDACTED in error: %v", err)
+			}
+		})
+	}
+
+	t.Run("no matching patterns", func(t *testing.T) {
+		err := sanitizeErr(errString("connection refused"))
+		if err.Error() != "connection refused" {
+			t.Errorf("expected unchanged error, got %q", err.Error())
+		}
+	})
+}
+
+type errString string
+
+func (e errString) Error() string { return string(e) }


### PR DESCRIPTION
## Summary

Add support for connecting to Azure Arc-enrolled machines through automatically provisioned Azure Relay hybrid connections. This enables SSH and TCP tunneling to Arc machines without requiring direct network access.

## Changes

- **`internal/arc`** — New `Client` built on `arm.Client` for cloud-aware ARM endpoint resolution (supports sovereign clouds). Implements `EnsureHybridConnectivity`, `GetRelayCredentials`, `Dial`/`DialWithLogger` for relay WebSocket connections, and `sanitizeErr` for safe error reporting (strips SAS tokens).
- **`cmd/aztunnel/arc connect`** — One-shot stdin/stdout bridge for use as an SSH `ProxyCommand`.
- **`cmd/aztunnel/arc port-forward`** — Local TCP listener that forwards each connection through the Arc relay, with per-connection credential refresh to handle SAS expiry.
- **`internal/arc/arc_test.go`** — Comprehensive tests (~64% coverage) using `cloud.Configuration` pointed at httptest servers, covering URL construction, defaults, error handling, incomplete response validation, and `sanitizeErr`.
- **`README.md`** — Updated with Arc relay usage documentation.

## Design decisions

- Uses `arm.Client` from the Azure SDK instead of raw pipeline construction, deriving ARM endpoint and auth scope from `cloud.Configuration` for sovereign cloud support.
- `EnsureHybridConnectivity` is only called on first credential failure to avoid disrupting the Arc agent's relay listener.
- Each accepted connection in port-forward mode fetches fresh relay credentials to avoid SAS token expiry.
- Error messages are sanitized to strip access keys before logging or returning to callers.