### PR TITLE
chore: improve Makefile and update Docker Go version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,4 +55,4 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v9
         with:
-          version: v2.1
+          version: v2.10

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,13 +64,13 @@ jobs:
       matrix:
         include:
           - variant: ""
-            builder: golang:1.24-bookworm
+            builder: golang:1-bookworm
             runtime: scratch
           - variant: -alpine
-            builder: golang:1.24-alpine
+            builder: golang:1-alpine
             runtime: alpine
           - variant: -bookworm
-            builder: golang:1.24-bookworm
+            builder: golang:1-bookworm
             runtime: debian:bookworm-slim
     steps:
       - uses: actions/checkout@v6

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG BUILDER_IMAGE=golang:1.24-bookworm
+ARG BUILDER_IMAGE=golang:1-bookworm
 ARG RUNTIME_IMAGE=debian:bookworm-slim
 ARG CGO_ENABLED=0
 

--- a/Makefile
+++ b/Makefile
@@ -1,39 +1,61 @@
 VERSION ?= dev
 LDFLAGS := -ldflags "-X main.version=$(VERSION)"
+CGO    := $(shell go env CGO_ENABLED)
+RACE   := $(if $(filter 1,$(CGO)),-race,)
 
-.PHONY: build test cover lint clean install docker docker-alpine docker-bookworm
+.PHONY: build test cover lint clean install docker docker-alpine docker-bookworm help
 
-build:
+.DEFAULT_GOAL := help
+
+build: ## Build the aztunnel binary
 	go build $(LDFLAGS) -o bin/aztunnel ./cmd/aztunnel
 
-test:
+test: ## Run tests (with -race if CGO is available)
+ifneq ($(RACE),)
 	go test -race ./...
+else
+	@echo "warning: CGO disabled (no C compiler), running tests without -race"
+	go test ./...
+endif
 
-cover:
+cover: ## Run tests with coverage report
+ifneq ($(RACE),)
+	go test -race -coverprofile=coverage.txt ./...
+else
+	@echo "warning: CGO disabled (no C compiler), running coverage without -race"
 	go test -coverprofile=coverage.txt ./...
+endif
 	go tool cover -func=coverage.txt
 
-lint:
+lint: ## Run linters (go vet + golangci-lint)
 	go vet ./...
-	golangci-lint run ./...
+	@if command -v golangci-lint >/dev/null 2>&1; then \
+		golangci-lint run ./...; \
+	else \
+		echo "warning: golangci-lint not found, skipping (install: https://golangci-lint.run/welcome/install/)"; \
+	fi
 
-clean:
+clean: ## Remove build artifacts
 	rm -rf bin/ coverage.txt
 
-install:
+install: ## Install to $$GOPATH/bin
 	go install $(LDFLAGS) ./cmd/aztunnel
 
-docker:
+docker: ## Build Docker image (scratch)
 	docker build --build-arg VERSION=$(VERSION) -t aztunnel .
 
-docker-alpine:
+docker-alpine: ## Build Docker image (alpine)
 	docker build --build-arg VERSION=$(VERSION) \
-		--build-arg BUILDER_IMAGE=golang:1.24-alpine \
+		--build-arg BUILDER_IMAGE=golang:1-alpine \
 		--build-arg RUNTIME_IMAGE=alpine \
 		-t aztunnel:alpine .
 
-docker-bookworm:
+docker-bookworm: ## Build Docker image (bookworm)
 	docker build --build-arg VERSION=$(VERSION) \
-		--build-arg BUILDER_IMAGE=golang:1.24-bookworm \
+		--build-arg BUILDER_IMAGE=golang:1-bookworm \
 		--build-arg RUNTIME_IMAGE=debian:bookworm-slim \
 		-t aztunnel:bookworm .
+
+help: ## Show this help
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | \
+		awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-18s\033[0m %s\n", $$1, $$2}'

--- a/internal/arc/arc.go
+++ b/internal/arc/arc.go
@@ -42,9 +42,9 @@ type RelayInfo struct {
 	NamespaceName             string `json:"namespaceName"`
 	NamespaceNameSuffix       string `json:"namespaceNameSuffix"`
 	HybridConnectionName      string `json:"hybridConnectionName"`
-	AccessKey                 string `json:"accessKey"`
+	AccessKey                 string `json:"accessKey"` //nolint:gosec // G117: deserialized from Azure ARM API
 	ExpiresOn                 int64  `json:"expiresOn"`
-	ServiceConfigurationToken string `json:"serviceConfigurationToken"`
+	ServiceConfigurationToken string `json:"serviceConfigurationToken"` //nolint:gosec // G117: deserialized from Azure ARM API
 }
 
 // Endpoint returns the Azure Relay sb:// endpoint.


### PR DESCRIPTION
- **test/cover**: gracefully fall back when race detector is unavailable (CGO disabled / no C compiler) instead of failing with a cryptic error
- **lint**: warn if golangci-lint is not installed instead of failing
- **help**: add `make help` as default target with auto-generated descriptions
- **Docker Go version**: update builder images from `golang:1.24-*` to `golang:1-*` to track latest stable Go (`go.mod` enforces the minimum version). Updated in Dockerfile, Makefile, and release.yml.
- **CI golangci-lint**: bump from v2.1 to v2.10 to pick up newer linter rules (including gosec G117)
- **gosec G117**: add `//nolint:gosec` annotations on `AccessKey` and `ServiceConfigurationToken` fields in `internal/arc/arc.go` — these are API response fields, not hardcoded secrets