### PR TITLE
chore: add prettier for markdown and YAML formatting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,14 @@ jobs:
           name: coverage
           path: coverage.txt
 
+  format:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: prettier
+        run: npx --yes prettier --check .
+
   lint:
     runs-on: ubuntu-latest
     steps:

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,4 @@
+bin/
+coverage.txt
+go.sum
+LICENSE

--- a/.prettierrc.yaml
+++ b/.prettierrc.yaml
@@ -1,0 +1,1 @@
+proseWrap: preserve

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ LDFLAGS := -ldflags "-X main.version=$(VERSION)"
 CGO    := $(shell go env CGO_ENABLED)
 RACE   := $(if $(filter 1,$(CGO)),-race,)
 
-.PHONY: build test cover lint clean install docker docker-alpine docker-bookworm help
+.PHONY: build test cover lint clean install docker docker-alpine docker-bookworm fmt fmt-check help
 
 .DEFAULT_GOAL := help
 
@@ -55,6 +55,12 @@ docker-bookworm: ## Build Docker image (bookworm)
 		--build-arg BUILDER_IMAGE=golang:1-bookworm \
 		--build-arg RUNTIME_IMAGE=debian:bookworm-slim \
 		-t aztunnel:bookworm .
+
+fmt: ## Format markdown and YAML with prettier
+	npx --yes prettier --write .
+
+fmt-check: ## Check formatting (same as CI)
+	npx --yes prettier --check .
 
 help: ## Show this help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | \

--- a/README.md
+++ b/README.md
@@ -327,16 +327,16 @@ exists, set `AUTOMEMLIMIT_EXPERIMENT=system`.
 
 ## Environment variables
 
-| Variable                  | Description                                  |
-| ------------------------- | -------------------------------------------- |
-| `AZTUNNEL_RELAY_NAME`     | Azure Relay namespace name                   |
-| `AZTUNNEL_HYCO_NAME`      | Hybrid connection name                       |
-| `AZTUNNEL_KEY_NAME`       | SAS policy name                              |
-| `AZTUNNEL_KEY`            | SAS key value                                |
-| `AZTUNNEL_ARC_RESOURCE_ID`| ARM resource ID of the Arc-connected machine |
-| `GOMEMLIMIT`              | Override automatic memory limit (e.g. `512MiB`) |
-| `AUTOMEMLIMIT`            | Ratio of cgroup limit to use (default `0.9`)  |
-| `AUTOMEMLIMIT_EXPERIMENT` | Comma-separated experiments (e.g. `system`)   |
+| Variable                   | Description                                     |
+| -------------------------- | ----------------------------------------------- |
+| `AZTUNNEL_RELAY_NAME`      | Azure Relay namespace name                      |
+| `AZTUNNEL_HYCO_NAME`       | Hybrid connection name                          |
+| `AZTUNNEL_KEY_NAME`        | SAS policy name                                 |
+| `AZTUNNEL_KEY`             | SAS key value                                   |
+| `AZTUNNEL_ARC_RESOURCE_ID` | ARM resource ID of the Arc-connected machine    |
+| `GOMEMLIMIT`               | Override automatic memory limit (e.g. `512MiB`) |
+| `AUTOMEMLIMIT`             | Ratio of cgroup limit to use (default `0.9`)    |
+| `AUTOMEMLIMIT_EXPERIMENT`  | Comma-separated experiments (e.g. `system`)     |
 
 ## License
 


### PR DESCRIPTION
Add prettier to enforce consistent formatting of markdown and YAML files.

**Changes:**
- `.prettierrc.yaml`: preserve prose wrapping (avoids noisy diffs)
- `.prettierignore`: exclude non-doc files
- CI: add `format` check job (`npx prettier --check`)
- Makefile: add `fmt` and `fmt-check` targets
- README.md: fix env vars table alignment

**Local usage:**
- `make fmt` — auto-fix formatting
- `make fmt-check` — verify formatting (same as CI)

This sets the baseline so that PRs with unformatted tables or YAML will fail CI.