### PR TITLE
fix(arc): smooth first-connection UX after endpoint creation

### DIFF
--- a/cmd/aztunnel/arc_connect.go
+++ b/cmd/aztunnel/arc_connect.go
@@ -2,7 +2,9 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"net/http"
 	"os"
 	"os/signal"
 	"time"
@@ -38,8 +40,14 @@ func (c *ArcConnectCmd) Run(globals *Globals, arcCmd *ArcCmd) error {
 	// Try to get relay credentials directly. If the endpoint doesn't exist
 	// yet, create it and retry.
 	info, err := client.GetRelayCredentials(ctx, resourceID, arcCmd.Service)
+	var setupRan bool
 	if err != nil {
-		logger.Debug("initial credential request failed, ensuring hybrid connectivity", "error", err)
+		if isHybridConnectivitySetupErr(err) {
+			logger.Info("creating Arc HybridConnectivity configuration; the Arc agent may need a moment to register a relay listener")
+			setupRan = true
+		} else {
+			logger.Debug("initial credential request failed, ensuring hybrid connectivity", "error", err)
+		}
 		if ensureErr := client.EnsureHybridConnectivity(ctx, resourceID, arcCmd.Service, arcCmd.Port); ensureErr != nil {
 			return ensureErr
 		}
@@ -52,7 +60,7 @@ func (c *ArcConnectCmd) Run(globals *Globals, arcCmd *ArcCmd) error {
 	target := fmt.Sprintf("%s:%d", resourceID, arcCmd.Port)
 
 	dialStart := time.Now()
-	ws, err := arc.DialWithLogger(ctx, info, arcCmd.Port, logger)
+	ws, err := arc.DialWithOptions(ctx, info, arcCmd.Port, logger, arc.DialOptions{ExplainSetup: setupRan})
 	m.ObserveDialDuration("sender", time.Since(dialStart).Seconds())
 	if err != nil {
 		m.ConnectionError("sender", metrics.DialReason(err, metrics.ReasonRelayFailed))
@@ -65,4 +73,17 @@ func (c *ArcConnectCmd) Run(globals *Globals, arcCmd *ArcCmd) error {
 	stdio := &arcStdioConn{in: os.Stdin, out: os.Stdout}
 	_, bridgeErr := m.TrackedBridge(ctx, ws, stdio, "sender", target)
 	return bridgeErr
+}
+
+// isHybridConnectivitySetupErr reports whether err is an ARM error that
+// indicates the HybridConnectivity endpoint or service configuration needs
+// to be created. We treat 404 (ResourceNotFound) and 412 (PreconditionFailed
+// — used when the endpoint exists but service config is missing) as setup
+// conditions.
+func isHybridConnectivitySetupErr(err error) bool {
+	var armErr *arc.ARMError
+	if !errors.As(err, &armErr) {
+		return false
+	}
+	return armErr.StatusCode == http.StatusNotFound || armErr.StatusCode == http.StatusPreconditionFailed
 }

--- a/cmd/aztunnel/arc_connect_test.go
+++ b/cmd/aztunnel/arc_connect_test.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/philsphicas/aztunnel/internal/arc"
+)
+
+// TestIsHybridConnectivitySetupErr guards the classifier that decides
+// whether to enable the first-connection explanatory logging. Both
+// `arc connect` and `arc port-forward` call this on the initial
+// GetRelayCredentials error; misclassifying it would silently disable
+// (or incorrectly enable) the UX path covered by the rest of this PR.
+func TestIsHybridConnectivitySetupErr(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil error", nil, false},
+		{"non-ARM error", errors.New("boom"), false},
+		{"ARM 404 NotFound (endpoint absent)", &arc.ARMError{StatusCode: http.StatusNotFound, Body: []byte("ResourceNotFound")}, true},
+		{"ARM 412 PreconditionFailed (service config missing)", &arc.ARMError{StatusCode: http.StatusPreconditionFailed, Body: []byte("PreconditionFailed")}, true},
+		{"ARM 401 Unauthorized", &arc.ARMError{StatusCode: http.StatusUnauthorized, Body: []byte("Unauthorized")}, false},
+		{"ARM 403 Forbidden", &arc.ARMError{StatusCode: http.StatusForbidden, Body: []byte("Forbidden")}, false},
+		{"ARM 500 InternalServerError", &arc.ARMError{StatusCode: http.StatusInternalServerError, Body: []byte("InternalServerError")}, false},
+		{"wrapped ARM 404", fmt.Errorf("get credentials: %w", &arc.ARMError{StatusCode: http.StatusNotFound, Body: []byte("ResourceNotFound")}), true},
+		{"wrapped ARM 412", fmt.Errorf("ensure hybrid: %w", &arc.ARMError{StatusCode: http.StatusPreconditionFailed, Body: []byte("PreconditionFailed")}), true},
+		{"wrapped ARM 500", fmt.Errorf("get credentials: %w", &arc.ARMError{StatusCode: http.StatusInternalServerError, Body: []byte("oops")}), false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isHybridConnectivitySetupErr(tt.err)
+			if got != tt.want {
+				t.Errorf("isHybridConnectivitySetupErr(%v) = %v, want %v", tt.err, got, tt.want)
+			}
+		})
+	}
+}

--- a/cmd/aztunnel/arc_port_forward.go
+++ b/cmd/aztunnel/arc_port_forward.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"os"
 	"os/signal"
+	"sync/atomic"
 	"time"
 
 	"github.com/philsphicas/aztunnel/internal/arc"
@@ -53,8 +54,19 @@ func (p *ArcPortForwardCmd) Run(globals *Globals, arcCmd *ArcCmd) error {
 	// Try to get relay credentials directly. If the endpoint doesn't exist
 	// yet, create it. EnsureHybridConnectivity is only called on first
 	// failure to avoid disrupting the Arc agent's relay listener.
+	//
+	// explainOnFirstDial is set when we just created/updated the
+	// HybridConnectivity configuration, so the first inbound connection's
+	// dial can emit an INFO message explaining that the Arc agent may need
+	// time to register a listener. Subsequent dials run quietly.
+	var explainOnFirstDial atomic.Bool
 	if _, err := client.GetRelayCredentials(ctx, resourceID, arcCmd.Service); err != nil {
-		logger.Debug("initial credential request failed, ensuring hybrid connectivity", "error", err)
+		if isHybridConnectivitySetupErr(err) {
+			logger.Info("creating Arc HybridConnectivity configuration; the first forwarded connection may wait while the Arc agent registers a relay listener")
+			explainOnFirstDial.Store(true)
+		} else {
+			logger.Debug("initial credential request failed, ensuring hybrid connectivity", "error", err)
+		}
 		if ensureErr := client.EnsureHybridConnectivity(ctx, resourceID, arcCmd.Service, arcCmd.Port); ensureErr != nil {
 			return ensureErr
 		}
@@ -96,8 +108,9 @@ func (p *ArcPortForwardCmd) Run(globals *Globals, arcCmd *ArcCmd) error {
 				return
 			}
 
+			opts := arc.DialOptions{ExplainSetup: consumeExplainOnFirstDial(&explainOnFirstDial)}
 			dialStart := time.Now()
-			ws, err := arc.DialWithLogger(ctx, info, arcCmd.Port, logger)
+			ws, err := arc.DialWithOptions(ctx, info, arcCmd.Port, logger, opts)
 			m.ObserveDialDuration("sender", time.Since(dialStart).Seconds())
 			if err != nil {
 				logger.Warn("arc relay dial failed", "error", err)
@@ -112,4 +125,12 @@ func (p *ArcPortForwardCmd) Run(globals *Globals, arcCmd *ArcCmd) error {
 			}
 		}()
 	}
+}
+
+// consumeExplainOnFirstDial atomically reads-and-clears the
+// setup-explanation flag. It returns true only on the call that observes
+// the flag still set, so concurrent inbound connections cannot
+// double-emit the setup-specific INFO logging.
+func consumeExplainOnFirstDial(flag *atomic.Bool) bool {
+	return flag.CompareAndSwap(true, false)
 }

--- a/cmd/aztunnel/arc_port_forward_test.go
+++ b/cmd/aztunnel/arc_port_forward_test.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+)
+
+// TestConsumeExplainOnFirstDial guards the UX guarantee that the
+// first-connection explanatory logging is consumed exactly once even
+// when many inbound TCP connections arrive concurrently against
+// `arc port-forward`. A regression here (e.g. swapping CompareAndSwap
+// for a non-atomic load/store) would silently re-emit the setup INFO
+// for every inbound connection.
+func TestConsumeExplainOnFirstDial(t *testing.T) {
+	t.Run("unset flag never returns true", func(t *testing.T) {
+		var flag atomic.Bool
+		if consumeExplainOnFirstDial(&flag) {
+			t.Fatal("expected false when flag was never set")
+		}
+		if consumeExplainOnFirstDial(&flag) {
+			t.Fatal("expected false on repeated call when flag was never set")
+		}
+	})
+
+	t.Run("sequential calls return true once, then false", func(t *testing.T) {
+		var flag atomic.Bool
+		flag.Store(true)
+		if !consumeExplainOnFirstDial(&flag) {
+			t.Fatal("first call should return true")
+		}
+		if consumeExplainOnFirstDial(&flag) {
+			t.Fatal("subsequent call should return false")
+		}
+		if consumeExplainOnFirstDial(&flag) {
+			t.Fatal("further calls should keep returning false")
+		}
+	})
+
+	t.Run("concurrent callers see exactly one true", func(t *testing.T) {
+		const callers = 256
+		var flag atomic.Bool
+		flag.Store(true)
+
+		var trues atomic.Int32
+		var wg sync.WaitGroup
+		start := make(chan struct{})
+		wg.Add(callers)
+		for range callers {
+			go func() {
+				defer wg.Done()
+				<-start
+				if consumeExplainOnFirstDial(&flag) {
+					trues.Add(1)
+				}
+			}()
+		}
+		close(start)
+		wg.Wait()
+
+		if got := trues.Load(); got != 1 {
+			t.Errorf("expected exactly one caller to observe true, got %d", got)
+		}
+		if consumeExplainOnFirstDial(&flag) {
+			t.Error("flag should be cleared after the consuming call")
+		}
+	})
+}

--- a/docs/guides/sender-arc.md
+++ b/docs/guides/sender-arc.md
@@ -236,6 +236,54 @@ This is a quick way to get network access without provisioning a relay
 namespace or deploying a listener — all you need is an Arc-enrolled VM
 with SSH.
 
+## First-connection latency
+
+The first `aztunnel arc connect` (or `arc port-forward`) against a
+machine that has no HybridConnectivity endpoint for the requested
+service will:
+
+1. Create the endpoint and the requested service configuration (SSH by
+   default, or whatever `--service` was passed) on the Arc resource.
+   This step also runs when the endpoint exists but a configuration for
+   the requested `--service` is missing (e.g. first time using
+   `--service WAC` against a machine that previously only had SSH).
+   The `--service` flag applies to both `arc connect` and
+   `arc port-forward`.
+2. Wait for the Arc agent on the VM to discover the new endpoint and
+   register a listener on the Azure Relay hybrid connection.
+
+Step 2 typically takes 30–90 seconds. During this window every dial
+returns HTTP 404 from Azure Relay because no listener is registered yet.
+aztunnel logs a clear INFO line explaining what's happening and retries
+with exponential backoff until the listener appears.
+
+For `arc connect` the dial begins immediately, so the full sequence
+appears on the same invocation:
+
+```
+INFO creating Arc HybridConnectivity configuration; the Arc agent may need a moment to register a relay listener
+INFO waiting for Arc agent to register a relay listener (expected after creating or updating the HybridConnectivity configuration) status=404
+INFO still waiting for Arc agent to register a relay listener elapsed=18s attempts=6
+INFO arc relay connected elapsed=29s attempts=8 lastStatus=404
+```
+
+For `arc port-forward` the explanatory line is emitted up front, but
+the `waiting for Arc agent...` / `arc relay connected` lines only fire
+when the first inbound TCP connection arrives (the dial is per
+inbound connection, not per `aztunnel` invocation):
+
+```
+INFO creating Arc HybridConnectivity configuration; the first forwarded connection may wait while the Arc agent registers a relay listener
+INFO arc port-forward listening bind=127.0.0.1:2222 ...
+# first ssh / curl through the listener:
+INFO waiting for Arc agent to register a relay listener (expected after creating or updating the HybridConnectivity configuration) status=404
+INFO arc relay connected elapsed=27s attempts=7 lastStatus=404
+```
+
+If SSH itself enforces a `ConnectTimeout` shorter than this window, the
+first invocation may fail — re-running it usually succeeds because the
+listener stays registered.
+
 ## Debugging
 
 ```sh

--- a/internal/arc/arc.go
+++ b/internal/arc/arc.go
@@ -204,7 +204,7 @@ func Dial(ctx context.Context, info *RelayInfo, port int) (*websocket.Conn, erro
 	return ws, nil
 }
 
-// Retry parameters for DialWithLogger.
+// Retry parameters for DialWithOptions.
 const (
 	retryInitial    = 1 * time.Second
 	retryMax        = 5 * time.Second
@@ -212,10 +212,47 @@ const (
 	dialTimeout     = 30 * time.Second
 )
 
+// Progress-log timings are vars (not consts) so tests can shorten them
+// without using real time.
+var (
+	// progressLogPeriod controls how often progress INFO logs are emitted
+	// while we wait for the Arc agent to register a relay listener.
+	progressLogPeriod = 15 * time.Second
+	// progressLogQuietDelay is the grace period before emitting the first
+	// progress INFO when DialOptions.ExplainSetup is false. This keeps the
+	// "agent listener is healthy" steady state quiet while still surfacing
+	// real "listener never appears" cases.
+	progressLogQuietDelay = 30 * time.Second
+)
+
+// DialOptions controls DialWithOptions behavior.
+type DialOptions struct {
+	// ExplainSetup enables INFO-level progress logging when the dial
+	// initially returns retryable 404/503 errors. Set this immediately
+	// after creating or updating the HybridConnectivity endpoint, or
+	// after creating a missing service configuration on an existing
+	// endpoint (e.g. first use of a new --service), so the user
+	// understands why the first connection may take a moment while the
+	// Arc agent registers a relay listener.
+	//
+	// When false, per-attempt retries are logged at DEBUG only and the
+	// dial stays silent for the first ~30 seconds. If the listener still
+	// has not appeared after that grace period, a generic progress INFO
+	// is emitted periodically so operator-actionable failures are not
+	// hidden.
+	ExplainSetup bool
+}
+
 // DialWithLogger is like Dial but logs the connection attempt and retries
 // on transient 404/503 errors (no active listener) with exponential backoff
 // until ctx expires.
 func DialWithLogger(ctx context.Context, info *RelayInfo, port int, logger *slog.Logger) (*websocket.Conn, error) {
+	return DialWithOptions(ctx, info, port, logger, DialOptions{})
+}
+
+// DialWithOptions is like DialWithLogger but accepts options that adjust
+// progress logging during retries.
+func DialWithOptions(ctx context.Context, info *RelayInfo, port int, logger *slog.Logger, opts DialOptions) (*websocket.Conn, error) {
 	if port == 0 {
 		port = defaultPort
 	}
@@ -234,7 +271,13 @@ func DialWithLogger(ctx context.Context, info *RelayInfo, port int, logger *slog
 	headers.Set("Microsoft-Guestgateway-Target", fmt.Sprintf("localhost:%d", port))
 
 	delay := retryInitial
+	start := time.Now()
+	attempts := 0
+	var lastStatus int
+	var lastProgressLog time.Time
+	progressLogged := false
 	for {
+		attempts++
 		connectURL := fmt.Sprintf("wss://%s/$hc/%s?sb-hc-action=connect&sb-hc-id=%s",
 			wssHost, info.HybridConnectionName, newUUID())
 
@@ -245,8 +288,26 @@ func DialWithLogger(ctx context.Context, info *RelayInfo, port int, logger *slog
 		cancel()
 
 		if err == nil {
-			logger.Debug("arc relay connected")
+			// Only log success at INFO if we'd already announced a wait —
+			// otherwise we'd suddenly produce a connected line out of nowhere
+			// after a silent transient retry.
+			if progressLogged {
+				logger.Info("arc relay connected",
+					"elapsed", time.Since(start).Truncate(time.Second),
+					"attempts", attempts,
+					"lastStatus", lastStatus)
+			} else {
+				logger.Debug("arc relay connected",
+					"elapsed", time.Since(start).Truncate(time.Second),
+					"attempts", attempts)
+			}
 			return ws, nil
+		}
+
+		// If the parent context was canceled mid-dial, surface the enriched
+		// diagnostic instead of the generic non-retryable websocket error.
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return nil, giveUpErr(attempts, time.Since(start), lastStatus, ctxErr)
 		}
 
 		if resp == nil || !relay.IsRetryableStatus(resp.StatusCode) {
@@ -254,16 +315,69 @@ func DialWithLogger(ctx context.Context, info *RelayInfo, port int, logger *slog
 			return nil, fmt.Errorf("dial arc relay: %w", sanitizeErr(err))
 		}
 
-		logger.Warn("arc relay dial failed (retrying)", "status", resp.StatusCode, "delay", delay, "error", sanitizeErr(err))
+		lastStatus = resp.StatusCode
+		logger.Debug("arc relay dial returned retryable status",
+			"status", resp.StatusCode,
+			"attempt", attempts,
+			"delay", delay,
+			"error", sanitizeErr(err))
+
+		// Progress logging:
+		//   - ExplainSetup=true: emit immediately on first retry, then every
+		//     progressLogPeriod. This is the "we just created (or updated)
+		//     the HybridConnectivity configuration, waiting for the agent
+		//     to register" path -- covers both endpoint creation (404) and
+		//     adding a missing service configuration to an existing
+		//     endpoint (412).
+		//   - ExplainSetup=false: stay quiet for progressLogQuietDelay (covers
+		//     transient hiccups), then emit progress every progressLogPeriod
+		//     so operators see real "listener never appears" cases.
+		if opts.ExplainSetup {
+			if attempts == 1 {
+				logger.Info("waiting for Arc agent to register a relay listener (expected after creating or updating the HybridConnectivity configuration)",
+					"status", resp.StatusCode)
+				lastProgressLog = time.Now()
+				progressLogged = true
+			} else if time.Since(lastProgressLog) >= progressLogPeriod {
+				logger.Info("still waiting for Arc agent to register a relay listener",
+					"elapsed", time.Since(start).Truncate(time.Second),
+					"attempts", attempts)
+				lastProgressLog = time.Now()
+				progressLogged = true
+			}
+		} else if time.Since(start) >= progressLogQuietDelay && time.Since(lastProgressLog) >= progressLogPeriod {
+			logger.Info("still waiting for arc relay listener",
+				"elapsed", time.Since(start).Truncate(time.Second),
+				"attempts", attempts,
+				"lastStatus", lastStatus)
+			lastProgressLog = time.Now()
+			progressLogged = true
+		}
 
 		select {
 		case <-ctx.Done():
-			return nil, fmt.Errorf("dial arc relay: %w", ctx.Err())
+			return nil, giveUpErr(attempts, time.Since(start), lastStatus, ctx.Err())
 		case <-time.After(delay):
 		}
 
 		delay = min(delay*retryMultiplier, retryMax)
 	}
+}
+
+// giveUpErr formats the error returned when ctx terminates while we're
+// retrying the dial. lastStatus is omitted when zero (cancellation arrived
+// before we ever observed a retryable HTTP response).
+func giveUpErr(attempts int, elapsed time.Duration, lastStatus int, cause error) error {
+	noun := "attempts"
+	if attempts == 1 {
+		noun = "attempt"
+	}
+	if lastStatus == 0 {
+		return fmt.Errorf("dial arc relay: gave up after %d %s in %s (no HTTP response): %w",
+			attempts, noun, elapsed.Truncate(time.Second), cause)
+	}
+	return fmt.Errorf("dial arc relay: gave up after %d %s in %s (last status %d): %w",
+		attempts, noun, elapsed.Truncate(time.Second), lastStatus, cause)
 }
 
 func (c *Client) armPUT(ctx context.Context, rawURL, body string) error {
@@ -306,9 +420,22 @@ func (c *Client) armPOST(ctx context.Context, rawURL, body string) ([]byte, erro
 	return io.ReadAll(resp.Body)
 }
 
+// ARMError is returned by Client methods when an ARM API call responds with
+// an HTTP 4xx or 5xx status. Callers can use errors.As to inspect the
+// status code (e.g. to detect first-time setup conditions: 404
+// ResourceNotFound or 412 PreconditionFailed).
+type ARMError struct {
+	StatusCode int
+	Body       []byte
+}
+
+func (e *ARMError) Error() string {
+	return fmt.Sprintf("ARM API error (HTTP %d): %s", e.StatusCode, string(e.Body))
+}
+
 func newARMError(resp *http.Response) error {
 	body, _ := io.ReadAll(resp.Body)
-	return fmt.Errorf("ARM API error (HTTP %d): %s", resp.StatusCode, string(body))
+	return &ARMError{StatusCode: resp.StatusCode, Body: body}
 }
 
 // sanitizedError wraps an error with a redacted message while preserving

--- a/internal/arc/arc_test.go
+++ b/internal/arc/arc_test.go
@@ -314,6 +314,43 @@ func TestARMErrorHandling(t *testing.T) {
 	if !strings.Contains(err.Error(), "404") {
 		t.Errorf("error should contain status code: %v", err)
 	}
+
+	var armErr *ARMError
+	if !errors.As(err, &armErr) {
+		t.Fatalf("expected error to be *ARMError, got %T", err)
+	}
+	if armErr.StatusCode != http.StatusNotFound {
+		t.Errorf("StatusCode = %d, want 404", armErr.StatusCode)
+	}
+	if !strings.Contains(string(armErr.Body), "ResourceNotFound") {
+		t.Errorf("Body should contain ResourceNotFound: %q", string(armErr.Body))
+	}
+}
+
+func TestARMErrorWrappedDetection(t *testing.T) {
+	// Simulates how GetRelayCredentials wraps newARMError into its own
+	// message; callers should still be able to detect the underlying
+	// status code with errors.As.
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		w.Write([]byte(`{"error":{"code":"ResourceNotFound"}}`))
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	const resourceID = "/subscriptions/sub1/resourceGroups/rg1/providers/Microsoft.HybridCompute/machines/vm1"
+	_, err := c.GetRelayCredentials(context.Background(), resourceID, "SSH")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+
+	var armErr *ARMError
+	if !errors.As(err, &armErr) {
+		t.Fatalf("errors.As did not match *ARMError; got %v", err)
+	}
+	if armErr.StatusCode != http.StatusNotFound {
+		t.Errorf("StatusCode = %d, want 404", armErr.StatusCode)
+	}
 }
 
 func TestSanitizeErr(t *testing.T) {
@@ -552,6 +589,337 @@ func TestDialWithLoggerRetry(t *testing.T) {
 		}
 		if !errors.Is(err, context.DeadlineExceeded) {
 			t.Errorf("error should wrap context.DeadlineExceeded, got: %v", err)
+		}
+		// New: error message must include attempts, elapsed, and last status.
+		msg := err.Error()
+		for _, want := range []string{"attempt", "last status 404", "gave up"} {
+			if !strings.Contains(msg, want) {
+				t.Errorf("error message missing %q: %v", want, msg)
+			}
+		}
+	})
+}
+
+func TestDialWithOptionsExplainSetup(t *testing.T) {
+	// Helper to spin up a server that returns 404 N times then accepts a
+	// websocket. Records attempts in a counter.
+	newServerThatRetries := func(failures int) (*httptest.Server, func() int) {
+		var mu sync.Mutex
+		attempts := 0
+		srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			mu.Lock()
+			attempts++
+			n := attempts
+			mu.Unlock()
+			if n <= failures {
+				w.WriteHeader(http.StatusNotFound)
+				return
+			}
+			ws, err := websocket.Accept(w, r, nil)
+			if err != nil {
+				return
+			}
+			defer ws.CloseNow()
+			<-r.Context().Done()
+		}))
+		return srv, func() int { mu.Lock(); defer mu.Unlock(); return attempts }
+	}
+
+	relayInfoFor := func(srv *httptest.Server) *RelayInfo {
+		host := strings.TrimPrefix(srv.URL, "https://")
+		dotIdx := strings.Index(host, ".")
+		return &RelayInfo{
+			NamespaceName:             host[:dotIdx],
+			NamespaceNameSuffix:       host[dotIdx+1:],
+			HybridConnectionName:      "test-hyco",
+			AccessKey:                 "test-key",
+			ServiceConfigurationToken: "test-token",
+		}
+	}
+
+	t.Run("ExplainSetup=true emits INFO on first retry and connected INFO", func(t *testing.T) {
+		srv, _ := newServerThatRetries(1)
+		defer srv.Close()
+
+		origTransport := http.DefaultTransport
+		http.DefaultTransport = &http.Transport{
+			TLSClientConfig: srv.Client().Transport.(*http.Transport).TLSClientConfig,
+		}
+		defer func() { http.DefaultTransport = origTransport }()
+
+		var logBuf strings.Builder
+		logger := slog.New(slog.NewTextHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelInfo}))
+
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+
+		ws, err := DialWithOptions(ctx, relayInfoFor(srv), 22, logger, DialOptions{ExplainSetup: true})
+		if err != nil {
+			t.Fatalf("DialWithOptions: %v", err)
+		}
+		defer ws.CloseNow()
+
+		out := logBuf.String()
+		if !strings.Contains(out, "level=INFO") {
+			t.Errorf("expected INFO log, got: %s", out)
+		}
+		if !strings.Contains(out, "waiting for Arc agent to register") {
+			t.Errorf("expected explanatory INFO, got: %s", out)
+		}
+		if !strings.Contains(out, "arc relay connected") {
+			t.Errorf("expected post-retry connected INFO, got: %s", out)
+		}
+		if strings.Contains(out, "level=WARN") {
+			t.Errorf("retryable 404 should not produce WARN, got: %s", out)
+		}
+	})
+
+	t.Run("ExplainSetup=true emits periodic progress INFO after first retry", func(t *testing.T) {
+		origPeriod := progressLogPeriod
+		progressLogPeriod = 50 * time.Millisecond
+		defer func() { progressLogPeriod = origPeriod }()
+
+		// 2 failures = attempts at ~0s, ~1s, ~3s. The first retry emits
+		// "waiting for Arc agent..." and the second retry (1s later, well
+		// past the shortened 50ms period) emits the periodic
+		// "still waiting for Arc agent..." line we want to cover.
+		srv, _ := newServerThatRetries(2)
+		defer srv.Close()
+
+		origTransport := http.DefaultTransport
+		http.DefaultTransport = &http.Transport{
+			TLSClientConfig: srv.Client().Transport.(*http.Transport).TLSClientConfig,
+		}
+		defer func() { http.DefaultTransport = origTransport }()
+
+		var logBuf strings.Builder
+		logger := slog.New(slog.NewTextHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelInfo}))
+
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+
+		ws, err := DialWithOptions(ctx, relayInfoFor(srv), 22, logger, DialOptions{ExplainSetup: true})
+		if err != nil {
+			t.Fatalf("DialWithOptions: %v", err)
+		}
+		defer ws.CloseNow()
+
+		out := logBuf.String()
+		if !strings.Contains(out, "waiting for Arc agent to register a relay listener (expected after creating or updating the HybridConnectivity configuration)") {
+			t.Errorf("expected first-retry INFO, got: %s", out)
+		}
+		if !strings.Contains(out, "still waiting for Arc agent to register a relay listener") {
+			t.Errorf("expected periodic progress INFO after the first retry, got: %s", out)
+		}
+		if !strings.Contains(out, "arc relay connected") {
+			t.Errorf("expected connected INFO after progress was announced, got: %s", out)
+		}
+	})
+
+	t.Run("ExplainSetup=false stays quiet on 404", func(t *testing.T) {
+		srv, _ := newServerThatRetries(1)
+		defer srv.Close()
+
+		origTransport := http.DefaultTransport
+		http.DefaultTransport = &http.Transport{
+			TLSClientConfig: srv.Client().Transport.(*http.Transport).TLSClientConfig,
+		}
+		defer func() { http.DefaultTransport = origTransport }()
+
+		var logBuf strings.Builder
+		logger := slog.New(slog.NewTextHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelInfo}))
+
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+
+		ws, err := DialWithOptions(ctx, relayInfoFor(srv), 22, logger, DialOptions{ExplainSetup: false})
+		if err != nil {
+			t.Fatalf("DialWithOptions: %v", err)
+		}
+		defer ws.CloseNow()
+
+		out := logBuf.String()
+		// Without ExplainSetup and no progress yet, a transient retry that
+		// succeeds within the quiet window must produce zero INFO lines:
+		// no "waiting", no "arc relay connected", no WARN.
+		if strings.Contains(out, "waiting for Arc agent") {
+			t.Errorf("unexpected explanatory INFO without ExplainSetup: %s", out)
+		}
+		if strings.Contains(out, "arc relay connected") {
+			t.Errorf("transient retry without progress should not log connected INFO, got: %s", out)
+		}
+		if strings.Contains(out, "level=INFO") {
+			t.Errorf("transient retry should be silent at info level, got: %s", out)
+		}
+		if strings.Contains(out, "level=WARN") {
+			t.Errorf("retryable 404 should not produce WARN, got: %s", out)
+		}
+	})
+
+	t.Run("first-attempt success is silent at info level", func(t *testing.T) {
+		srv, _ := newServerThatRetries(0)
+		defer srv.Close()
+
+		origTransport := http.DefaultTransport
+		http.DefaultTransport = &http.Transport{
+			TLSClientConfig: srv.Client().Transport.(*http.Transport).TLSClientConfig,
+		}
+		defer func() { http.DefaultTransport = origTransport }()
+
+		var logBuf strings.Builder
+		logger := slog.New(slog.NewTextHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelInfo}))
+
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+
+		ws, err := DialWithOptions(ctx, relayInfoFor(srv), 22, logger, DialOptions{ExplainSetup: true})
+		if err != nil {
+			t.Fatalf("DialWithOptions: %v", err)
+		}
+		defer ws.CloseNow()
+
+		out := logBuf.String()
+		if strings.Contains(out, "waiting for Arc agent") {
+			t.Errorf("did not expect explanatory INFO when first attempt succeeded: %s", out)
+		}
+		if strings.Contains(out, "arc relay connected") {
+			t.Errorf("first-attempt success should be DEBUG only at info level, got: %s", out)
+		}
+	})
+
+	t.Run("ExplainSetup=false surfaces delayed progress on prolonged 404", func(t *testing.T) {
+		origPeriod, origQuiet := progressLogPeriod, progressLogQuietDelay
+		progressLogPeriod = 50 * time.Millisecond
+		progressLogQuietDelay = 100 * time.Millisecond
+		defer func() {
+			progressLogPeriod = origPeriod
+			progressLogQuietDelay = origQuiet
+		}()
+
+		// Server returns 404 forever.
+		srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusNotFound)
+		}))
+		defer srv.Close()
+
+		origTransport := http.DefaultTransport
+		http.DefaultTransport = &http.Transport{
+			TLSClientConfig: srv.Client().Transport.(*http.Transport).TLSClientConfig,
+		}
+		defer func() { http.DefaultTransport = origTransport }()
+
+		var logBuf strings.Builder
+		logger := slog.New(slog.NewTextHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelInfo}))
+
+		ctx, cancel := context.WithTimeout(context.Background(), 4*time.Second)
+		defer cancel()
+
+		_, err := DialWithOptions(ctx, relayInfoFor(srv), 22, logger, DialOptions{ExplainSetup: false})
+		if err == nil {
+			t.Fatal("expected timeout error")
+		}
+
+		out := logBuf.String()
+		if strings.Contains(out, "waiting for Arc agent to register") {
+			t.Errorf("ExplainSetup=false must not emit the setup-specific INFO, got: %s", out)
+		}
+		if !strings.Contains(out, "still waiting for arc relay listener") {
+			t.Errorf("expected generic progress INFO after quiet delay, got: %s", out)
+		}
+	})
+
+	t.Run("ExplainSetup=false logs connected INFO after generic progress", func(t *testing.T) {
+		origPeriod, origQuiet := progressLogPeriod, progressLogQuietDelay
+		progressLogPeriod = 50 * time.Millisecond
+		progressLogQuietDelay = 100 * time.Millisecond
+		defer func() {
+			progressLogPeriod = origPeriod
+			progressLogQuietDelay = origQuiet
+		}()
+
+		// 2 failures = attempts at ~0s and ~1s (retryInitial). The 2nd
+		// attempt fires after time.Since(start) >= 100ms, so it triggers
+		// the generic progress INFO. The 3rd attempt at ~3s accepts the
+		// websocket, and the success log must be at INFO because a
+		// progress line was already announced.
+		srv, _ := newServerThatRetries(2)
+		defer srv.Close()
+
+		origTransport := http.DefaultTransport
+		http.DefaultTransport = &http.Transport{
+			TLSClientConfig: srv.Client().Transport.(*http.Transport).TLSClientConfig,
+		}
+		defer func() { http.DefaultTransport = origTransport }()
+
+		var logBuf strings.Builder
+		logger := slog.New(slog.NewTextHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelInfo}))
+
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+
+		ws, err := DialWithOptions(ctx, relayInfoFor(srv), 22, logger, DialOptions{ExplainSetup: false})
+		if err != nil {
+			t.Fatalf("DialWithOptions: %v", err)
+		}
+		defer ws.CloseNow()
+
+		out := logBuf.String()
+		if !strings.Contains(out, "still waiting for arc relay listener") {
+			t.Errorf("expected generic progress INFO after quiet delay, got: %s", out)
+		}
+		// Once any progress was announced (even the generic one), a
+		// subsequent success must be reported at INFO so the user sees
+		// the wait resolve.
+		if !strings.Contains(out, "arc relay connected") {
+			t.Errorf("expected connected INFO after progress was announced, got: %s", out)
+		}
+	})
+
+	t.Run("context cancel mid-dial returns enriched error", func(t *testing.T) {
+		// Server blocks the handshake so the dial is in progress when we
+		// cancel the parent context. The dial returns with no resp, but
+		// the new ctx.Err() check should still surface the enriched
+		// "gave up after N attempts" diagnostic.
+		blockCh := make(chan struct{})
+		srv := httptest.NewTLSServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+			select {
+			case <-blockCh:
+			case <-r.Context().Done():
+			}
+		}))
+		defer srv.Close()
+		defer close(blockCh)
+
+		origTransport := http.DefaultTransport
+		http.DefaultTransport = &http.Transport{
+			TLSClientConfig: srv.Client().Transport.(*http.Transport).TLSClientConfig,
+		}
+		defer func() { http.DefaultTransport = origTransport }()
+
+		var logBuf strings.Builder
+		logger := slog.New(slog.NewTextHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelInfo}))
+
+		ctx, cancel := context.WithCancel(context.Background())
+		go func() {
+			time.Sleep(200 * time.Millisecond)
+			cancel()
+		}()
+
+		_, err := DialWithOptions(ctx, relayInfoFor(srv), 22, logger, DialOptions{})
+		if err == nil {
+			t.Fatal("expected error after cancellation")
+		}
+		if !errors.Is(err, context.Canceled) {
+			t.Errorf("expected error to wrap context.Canceled, got: %v", err)
+		}
+		msg := err.Error()
+		for _, want := range []string{"gave up", "attempt", "no HTTP response"} {
+			if !strings.Contains(msg, want) {
+				t.Errorf("error message missing %q: %v", want, msg)
+			}
+		}
+		if strings.Contains(msg, "last status 0") {
+			t.Errorf("error should not include misleading 'last status 0', got: %v", msg)
 		}
 	})
 }


### PR DESCRIPTION
## Problem

When \`aztunnel arc connect\` (or \`arc port-forward\`) runs against a machine that has never had a HybridConnectivity endpoint, aztunnel creates the endpoint on demand and the Arc agent on the VM needs ~30–90s to discover it and register a listener on the Azure Relay hybrid connection. During that window every relay dial returns HTTP 404.

The retry loop already handled this correctly, but each retry emitted a \`WARN msg=\"arc relay dial failed (retrying)\"\` line. From the user's perspective (especially as an ssh \`ProxyCommand\`) it looked like the tool was repeatedly failing, even though it would eventually succeed.

Reported by @philsphicas — reproducible via \`test-arcify.sh\` immediately after creating a fresh Arc machine.

## Fix

- Export typed \`*arc.ARMError{StatusCode, Body}\` via \`errors.As\` so callers can distinguish setup-time 404/412 from other ARM errors.
- New \`arc.DialOptions{ExplainSetup}\` and \`arc.DialWithOptions\`. \`DialWithLogger\` is kept as a shim for backward compatibility.
- \`ExplainSetup=true\` (we just created/updated the endpoint): one explanatory INFO on the first retryable status, then a progress INFO every 15s, and a final \`arc relay connected\` INFO with \`elapsed\` and \`attempts\` on success. Per-retry log downgraded from WARN to DEBUG.
- \`ExplainSetup=false\` (normal operation against an existing endpoint): silent for 30s, then a generic \`still waiting for arc relay listener\` INFO every 15s so real \"listener never appears\" cases are still surfaced.
- If the parent context is canceled mid-dial, return an enriched error including \`attempts\`, \`elapsed\`, and last retryable status instead of the generic non-retryable websocket error.
- \`cmd/aztunnel/arc_connect\` and \`arc_port_forward\` detect the setup case via \`errors.As\` on \`*arc.ARMError\` (404 or 412) and pass \`ExplainSetup=true\` to the dialer. \`arc_port_forward\` uses an \`atomic.Bool\` consumed via \`CompareAndSwap\` so only the first inbound connection's dial carries the explanatory logging.
- Docs: new \"First-connection latency\" section in \`docs/guides/sender-arc.md\` showing the expected output.

## Before / after

**Before** (six retries, all WARN):
\`\`\`
WARN arc relay dial failed (retrying) status=404 attempt=1
WARN arc relay dial failed (retrying) status=404 attempt=2
WARN arc relay dial failed (retrying) status=404 attempt=3
...
Error: dial arc relay: failed to WebSocket dial: expected handshake response status code 101 but got 404
\`\`\`

**After** (live repro against a fresh Arc machine, default \`info\` level):
\`\`\`
INFO creating Arc HybridConnectivity configuration; the Arc agent may need a moment to register a relay listener
INFO waiting for Arc agent to register a relay listener (expected after creating the HybridConnectivity endpoint) status=404
INFO still waiting for Arc agent to register a relay listener elapsed=18s attempts=6
INFO arc relay connected elapsed=29s attempts=8
\`\`\`

Subsequent \`ssh\` invocations against the same machine are completely silent.

## Testing

- \`go test ./...\` ✅ (full suite, including new tests covering \`ExplainSetup\` modes, delayed progress, and ctx-cancel mid-dial).
- \`golangci-lint run ./...\` → 0 issues.
- Live e2e against a freshly created Arc machine produced the clean output above; default ssh options (no \`ConnectTimeout\`) reach the prompt in ~42s.