### PR TITLE
Stream multiplexing for near-zero per-connection setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,20 +94,20 @@ fmt-check: ## Check formatting (same as CI)
 # timeout still covers the whole job (checkout, build, azrelay,
 # backend) so the workflow envelope remains the outer cap if the
 # preceding steps consume too much of it. See golang/go#24929.
-e2e-mock: ## Run e2e scenarios against the in-process mock relay (both auth methods, default delay profile)
-	cd e2e && go test -tags=e2e -timeout=20m -v ./backends/mock/...
+e2e-mock: ## Run e2e scenarios against the in-process mock relay (both auth methods, default delay profile, both mux versions)
+	cd e2e && go test -tags=e2e -timeout=40m -v ./backends/mock/...
 
 e2e-mock-fast: ## Run mock e2e as fast as possible: zero delay profile, no synthetic token-acquisition cost (both auth methods)
-	cd e2e && E2E_DELAY=zero go test -tags=e2e -timeout=20m -v ./backends/mock/...
+	cd e2e && E2E_DELAY=zero go test -tags=e2e -timeout=40m -v ./backends/mock/...
 
 e2e-mock-matrix: ## Run mock e2e over the full auth x delay-profile matrix (both auth methods x the curated functional delay set: zero + default)
-	cd e2e && E2E_DELAY=all go test -tags=e2e -timeout=40m -v ./backends/mock/...
+	cd e2e && E2E_DELAY=all go test -tags=e2e -timeout=60m -v ./backends/mock/...
 
 e2e-azure: build ## Run e2e scenarios against a real Azure Relay namespace (configure via `make e2e-setup`)
 	@cd e2e && { \
 		status=0; \
 		go test -tags=e2e -timeout=20m -v ./azrelay/ || status=$$?; \
-		go test -tags=e2e -timeout=50m -v ./backends/azure/... || status=$$?; \
+		go test -tags=e2e -timeout=90m -v ./backends/azure/... || status=$$?; \
 		exit $$status; \
 	}
 
@@ -194,7 +194,17 @@ space := $(empty) $(empty)
 # `default,default` collapse to one word and add no layer.
 PERF_MOCK_AUTH_LAYER = $(if $(strip $(E2E_AUTH)),,[^/]+/)
 PERF_MOCK_DELAY_LAYER = $(if $(filter all,$(E2E_DELAY)),[^/]+/,$(if $(word 2,$(sort $(subst $(comma),$(space),$(E2E_DELAY)))),[^/]+/,))
-PERF_AXIS_PREFIX_MOCK = $(PERF_MOCK_AUTH_LAYER)$(PERF_MOCK_DELAY_LAYER)
+# Mux: scenarios.RunPerformanceScenarios wraps every perf cell with
+# WithMuxAxis, so a v1/v2 t.Run layer ALWAYS sits between the outer
+# auth/delay cell and the scenario name in the perf subtest path.
+# Other suites (Core/Topology/Reliability/Observability) are NOT
+# wrapped, so this layer applies only to the perf -run patterns
+# below.
+PERF_MOCK_MUX_LAYER = [^/]+/
+PERF_AXIS_PREFIX_MOCK = $(PERF_MOCK_AUTH_LAYER)$(PERF_MOCK_DELAY_LAYER)$(PERF_MOCK_MUX_LAYER)
+# Azure: WithMuxAxis adds a v1/v2 layer for perf scenarios there too,
+# below the always-present auth layer.
+PERF_AXIS_PREFIX_AZURE = [^/]+/[^/]+/
 PERF_ALL_SCENARIOS = ^(ConnectLatency|ShortSession|Serial_Conn|Parallel_Conn|Stream_)
 PERF_SCENARIO_FILTER = $(or $(PERF),$(PERF_ALL_SCENARIOS))
 
@@ -213,7 +223,7 @@ perf-azure: build ## Run performance characterization scenarios against a real A
 	cd e2e && PERF_MATRIX_BACKEND=azure \
 		PERF_MATRIX_GIT_SHA="$$(git rev-parse --short HEAD 2>/dev/null)" \
 		go test -tags=e2e -count=1 -timeout=35m -v \
-		-run='TestE2E_Azure/[^/]+/$(PERF_SCENARIO_FILTER)' \
+		-run='TestE2E_Azure/$(PERF_AXIS_PREFIX_AZURE)$(PERF_SCENARIO_FILTER)' \
 		./backends/azure/
 
 perf: perf-mock perf-azure ## Run performance scenarios against both backends
@@ -287,7 +297,7 @@ perf-placement: ## Sweep the PERF MATRIX across the 3x3 mock sender/listener pla
 		PERF_MATRIX_BACKEND=mock \
 		PERF_MATRIX_GIT_SHA="$$(git rev-parse --short HEAD 2>/dev/null)" \
 		E2E_AUTH=sas E2E_DELAY=$(PERF_PLACEMENT) go test -tags=e2e -count=1 -timeout=20m \
-			-run='TestE2E_Mock/[^/]+/$(PERF_PLACEMENT_SCENARIO)' \
+			-run='TestE2E_Mock/[^/]+/[^/]+/$(PERF_PLACEMENT_SCENARIO)' \
 			./backends/mock/; \
 		status=$$?; \
 		echo; \
@@ -316,7 +326,7 @@ perf-placement-azure: build ## Run the perf scenarios against a real Azure Relay
 		PERF_MATRIX_BACKEND=azure \
 		PERF_MATRIX_GIT_SHA="$$(git rev-parse --short HEAD 2>/dev/null)" \
 		go test -tags=e2e -count=1 -timeout=35m \
-			-run='TestE2E_Azure/[^/]+/$(PERF_SCENARIO_FILTER)' \
+			-run='TestE2E_Azure/$(PERF_AXIS_PREFIX_AZURE)$(PERF_SCENARIO_FILTER)' \
 			./backends/azure/; \
 		status=$$?; \
 		echo; \
@@ -356,7 +366,7 @@ perf-axes-mock: build ## Sweep mock UNPINNED over auth x delay; render named-axi
 		PERF_MATRIX_BACKEND=mock \
 		PERF_MATRIX_GIT_SHA="$$(git rev-parse --short HEAD 2>/dev/null)" \
 		E2E_DELAY=$(PERF_AXES_DELAY) go test -tags=e2e -count=1 -timeout=20m \
-			-run='TestE2E_Mock/[^/]+/[^/]+/$(PERF_AXES_SCENARIO)' \
+			-run='TestE2E_Mock/[^/]+/[^/]+/[^/]+/$(PERF_AXES_SCENARIO)' \
 			./backends/mock/; \
 		status=$$?; \
 		echo; \

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Tunnel TCP connections through [Azure Relay Hybrid Connections](https://learn.mi
 - **Port forward** — bind a local port and forward connections to a fixed remote target
 - **SOCKS5 proxy** — run a local SOCKS5 server for dynamic target selection
 - **SSH ProxyCommand** — bridge stdin/stdout for use with `ssh -o ProxyCommand`
+- **Stream multiplexing** — port-forward and SOCKS5 multiplex many TCP sessions over a single persistent relay WebSocket. The relay rendezvous is dialed lazily on the first connection that needs one (and on every additional session when `--mux-sessions > 1` is required by concurrent load), so each new session's first connection still pays the full rendezvous; subsequent connections that reuse an already-established mux session drop from seconds to milliseconds. See [docs/mux.md](docs/mux.md).
 - **Azure Arc support** — connect to Arc-enrolled machines through automatically provisioned relays
 - **Prometheus metrics** — optional `--metrics-addr` flag exposes connection, byte, and error metrics
 - **Allowlist enforcement** — restrict which targets the listener can reach (CIDR, host:port, wildcard)
@@ -210,6 +211,44 @@ If SSH listens on a non-standard port (e.g., 2222):
 aztunnel arc connect --resource-id /subscriptions/.../machines/myVM --port 2222
 ```
 
+## Stream multiplexing (opt-in)
+
+`relay-sender port-forward` and `relay-sender socks5-proxy` can multiplex
+many TCP sessions over a small pool of persistent relay WebSockets,
+collapsing per-connection setup from ~1–2 s to milliseconds for the
+second-and-later connections. The capability is **opt-in** in this
+release (default flips to on in a future release):
+
+```sh
+aztunnel relay-sender socks5-proxy --max-protocol-version=2 --bind 127.0.0.1:1080
+# or
+AZTUNNEL_MAX_PROTOCOL_VERSION=2 aztunnel relay-sender port-forward 10.0.0.5:5432
+```
+
+The relay rendezvous WebSocket is established **lazily on the first
+connection that needs one** — that first connection still pays the full
+~1–2 second rendezvous, and any **subsequent connection that reuses an
+already-established mux session** drops to ~milliseconds. When
+`--mux-sessions > 1` is configured and concurrent traffic forces the
+pool to grow, each additional session is also dialed lazily on the
+first connection that needs it.
+
+| Flag                          | Default | Notes                                                                                                |
+| ----------------------------- | ------- | ---------------------------------------------------------------------------------------------------- |
+| `--max-protocol-version N`    | `1`     | Highest protocol version the sender will attempt. `2` enables mux. Safe to set against any listener. |
+| `--mux-sessions N`            | `2`     | Cap on persistent rendezvous WebSockets. Only effective with `--max-protocol-version=2`.             |
+| `--max-streams-per-session N` | `256`   | Per-session in-flight stream cap (hidden, advanced). Only effective with `--max-protocol-version=2`. |
+
+Sessions rotate every 6 hours by default for fleet rebalancing across HA
+listeners. Empirical testing shows Azure Relay does not tear down sender
+WebSockets at SAS token expiry, so rotation is purely defensive — not a
+correctness requirement. A v2 sender against a v1-only listener falls
+back automatically (sticky 60 s), so opting in to v2 is safe even
+against a mixed-version listener fleet.
+
+See [docs/mux.md](docs/mux.md) for protocol-version semantics, sizing
+guidance, rotation behaviour, multi-listener affinity caveats, and metrics.
+
 ## CLI reference
 
 ```
@@ -250,12 +289,16 @@ Flags:
 aztunnel relay-sender port-forward <host:port> [flags]
 
 Flags:
-  --relay string       Azure Relay namespace name
+  --relay string           Azure Relay namespace name
   --hyco string            Hybrid connection name
   -b, --bind string        Local bind address:port (default "127.0.0.1:0")
   --gateway                Bind to 0.0.0.0 instead of 127.0.0.1
   --tcp-keepalive duration TCP keepalive interval (default 30s)
+  --max-protocol-version int Highest relay protocol version (1=v1 legacy, 2=v2 mux) (default 1)
+  --mux-sessions int       Maximum persistent relay rendezvous WebSockets (default 2)
 ```
+
+See [docs/mux.md](docs/mux.md) for details on stream multiplexing.
 
 ### relay-sender socks5-proxy
 
@@ -263,12 +306,16 @@ Flags:
 aztunnel relay-sender socks5-proxy [flags]
 
 Flags:
-  --relay string       Azure Relay namespace name
+  --relay string           Azure Relay namespace name
   --hyco string            Hybrid connection name
   -b, --bind string        Local bind address:port (default "127.0.0.1:0")
   --gateway                Bind to 0.0.0.0 instead of 127.0.0.1
   --tcp-keepalive duration TCP keepalive interval (default 30s)
+  --max-protocol-version int Highest relay protocol version (1=v1 legacy, 2=v2 mux) (default 1)
+  --mux-sessions int       Maximum persistent relay rendezvous WebSockets (default 2)
 ```
+
+See [docs/mux.md](docs/mux.md) for details on stream multiplexing.
 
 ### relay-sender connect
 
@@ -315,15 +362,20 @@ aztunnel relay-listener --relay my-ns --hyco my-hyco --metrics-addr :9090
 
 Metrics are served at `/metrics` on the specified address. When neither the flag nor the env var is set, no metrics server is started.
 
-| Metric                                 | Type      | Labels                        | Description                                       |
-| -------------------------------------- | --------- | ----------------------------- | ------------------------------------------------- |
-| `aztunnel_connections_total`           | counter   | `role`, `target`, `status`    | Total connections handled (success/error)         |
-| `aztunnel_connection_errors_total`     | counter   | `role`, `reason`              | Connection failures by reason                     |
-| `aztunnel_bytes_total`                 | counter   | `role`, `target`, `direction` | Bytes transferred through the relay tunnel        |
-| `aztunnel_active_connections`          | gauge     | `role`, `target`              | Currently active bridged connections              |
-| `aztunnel_control_channel_connected`   | gauge     | —                             | 1 if the listener control channel is up, 0 if not |
-| `aztunnel_connection_duration_seconds` | histogram | `role`, `target`              | Duration of completed connections                 |
-| `aztunnel_dial_duration_seconds`       | histogram | `role`                        | Time to establish outbound connections            |
+| Metric                                 | Type      | Labels                        | Description                                                                     |
+| -------------------------------------- | --------- | ----------------------------- | ------------------------------------------------------------------------------- |
+| `aztunnel_connections_total`           | counter   | `role`, `target`, `status`    | Total connections handled (success/error)                                       |
+| `aztunnel_connection_errors_total`     | counter   | `role`, `reason`              | Connection failures by reason                                                   |
+| `aztunnel_bytes_total`                 | counter   | `role`, `target`, `direction` | Bytes transferred through the relay tunnel                                      |
+| `aztunnel_active_connections`          | gauge     | `role`, `target`              | Currently active bridged connections                                            |
+| `aztunnel_control_channel_connected`   | gauge     | —                             | 1 if the listener control channel is up, 0 if not                               |
+| `aztunnel_connection_duration_seconds` | histogram | `role`, `target`              | Duration of completed connections                                               |
+| `aztunnel_dial_duration_seconds`       | histogram | `role`                        | Time to establish outbound connections                                          |
+| `aztunnel_mux_sessions_active`         | gauge     | `role`                        | Currently active mux sessions (sender only)                                     |
+| `aztunnel_mux_stream_open_seconds`     | histogram | `role`                        | Pool admission + smux SYN (excludes per-stream envelope handshake; sender only) |
+| `aztunnel_mux_session_age_seconds`     | histogram | `role`                        | Age of a mux session at rotation or eviction (sender only)                      |
+| `aztunnel_mux_rotations_total`         | counter   | `role`, `reason`              | Mux session lifecycle exits (rotations and evictions) by reason (sender only)   |
+| `aztunnel_mux_pool_saturated_total`    | counter   | `role`                        | Callers that ctx-expired waiting on a mux slot (sender only)                    |
 
 Labels:
 
@@ -331,7 +383,7 @@ Labels:
 - **target**: destination address (e.g. `10.0.0.5:22`)
 - **status**: `success` or `error`
 - **direction**: `to_relay` (local endpoint → relay) or `from_relay` (relay → local endpoint)
-- **reason**: `dial_failed`, `dial_timeout`, `allowlist_rejected`, `relay_failed`, `envelope_error`, `auth_failed`
+- **reason**: `dial_failed`, `dial_timeout`, `allowlist_rejected`, `relay_failed`, `envelope_error`, `auth_failed`, `listener_at_capacity`, `mux_open_failed` (for `aztunnel_connection_errors_total`); `scheduled`, `force_after_grace`, `unsupported`, `pool_closed`, `open_failed` (for `aztunnel_mux_rotations_total`)
 
 Go runtime and process metrics are also included in the output.
 

--- a/cmd/aztunnel/cli.go
+++ b/cmd/aztunnel/cli.go
@@ -52,6 +52,29 @@ type BindFlags struct {
 	TCPKeepAlive time.Duration `name:"tcp-keepalive" help:"TCP keepalive interval." default:"30s"`
 }
 
+// MuxFlags holds stream-multiplexing flags shared across port-forward
+// and socks5-proxy.
+//
+// Whether mux is used is controlled by --max-protocol-version: setting
+// the sender's ceiling to 2 (or higher) opts in to stream multiplexing;
+// the default ceiling of 1 keeps the legacy per-connection rendezvous
+// path (will be raised to 2 in a future release). When mux is in use the
+// sender establishes a persistent relay WebSocket lazily on the first
+// connection that needs one — that first connection still pays the
+// full ~1-2s rendezvous, and subsequent connections reuse the smux
+// session and skip the per-connection rendezvous. With --mux-sessions
+// > 1 each additional session is dialed lazily too.
+//
+// The sender automatically falls back to the v1 path when the listener
+// does not support a requested v2 handshake, so --max-protocol-version=2
+// is always safe even against a mixed listener fleet.
+type MuxFlags struct {
+	MaxProtocolVersion        int           `name:"max-protocol-version" env:"AZTUNNEL_MAX_PROTOCOL_VERSION" help:"Highest aztunnel relay protocol version this sender will attempt. 1 = legacy per-connection rendezvous. 2 = stream multiplexing over a small pool of long-lived rendezvous (lower per-connection latency for many-connection workloads). The sender silently uses a lower version when the listener does not support the requested one, so 2 is always safe to set." default:"${defaultSenderMaxProtocolVersion}"`
+	MuxSessions               int           `name:"mux-sessions" env:"AZTUNNEL_MUX_SESSIONS" help:"Maximum number of persistent relay rendezvous WebSockets the mux pool will maintain. Only effective with --max-protocol-version=2. Larger values may spread concurrent traffic across multiple HA listeners; Azure Relay listener selection is opaque, so empirical testing recommended." default:"2"`
+	MaxStreamsPerSession      int           `name:"max-streams-per-session" env:"AZTUNNEL_MAX_STREAMS_PER_SESSION" help:"Maximum concurrent streams per mux session before back-pressure kicks in. New connections wait for a slot; the port-forward and SOCKS5 paths cap that wait at an internal 60s mux admission timeout, after which the connection is dropped (and aztunnel_mux_pool_saturated_total increments). Only effective with --max-protocol-version=2." default:"256" hidden:""`
+	MuxStreamHandshakeTimeout time.Duration `name:"mux-stream-handshake-timeout" env:"AZTUNNEL_MUX_STREAM_HANDSHAKE_TIMEOUT" help:"Per-stream envelope+response timeout. Must exceed the listener's --connect-timeout because the listener dials the target before writing the response. Only effective with --max-protocol-version=2." default:"60s" hidden:""`
+}
+
 // RelaySenderCmd is a grouping command for relay sender subcommands.
 type RelaySenderCmd struct {
 	PortForward PortForwardCmd `cmd:"" name:"port-forward" help:"Forward a local port through the relay to a specific target."`

--- a/cmd/aztunnel/help.go
+++ b/cmd/aztunnel/help.go
@@ -65,6 +65,8 @@ Relay Sender - Port Forward:
   -b, --bind string                 Local bind address:port (default "127.0.0.1:0")
       --gateway                     Bind to 0.0.0.0 instead of 127.0.0.1
       --tcp-keepalive duration      TCP keepalive interval (default 30s)
+      --max-protocol-version int    Highest relay protocol version to attempt (1=v1 legacy, 2=v2 mux) (default 1)
+      --mux-sessions int            Max persistent relay rendezvous WebSockets (default 2)
 
 Relay Sender - Connect:
   Connect to the relay, tell the listener to dial host:port, then bridge
@@ -85,6 +87,8 @@ Relay Sender - SOCKS5 Proxy:
   -b, --bind string                 Local bind address:port (default "127.0.0.1:0")
       --gateway                     Bind to 0.0.0.0 instead of 127.0.0.1
       --tcp-keepalive duration      TCP keepalive interval (default 30s)
+      --max-protocol-version int    Highest relay protocol version to attempt (1=v1 legacy, 2=v2 mux) (default 1)
+      --mux-sessions int            Max persistent relay rendezvous WebSockets (default 2)
 
 Arc Connect:
   Connect to an Azure Arc-enrolled machine through the automatically
@@ -128,6 +132,8 @@ Environment Variables:
   AZTUNNEL_KEY               SAS key value (optional, overrides Entra)
   AZTUNNEL_ARC_RESOURCE_ID   Arc resource ID (fallback for --resource-id)
   AZTUNNEL_METRICS_ADDR      Metrics server address (fallback for --metrics-addr)
+  AZTUNNEL_MAX_PROTOCOL_VERSION  Highest protocol version (fallback for --max-protocol-version)
+  AZTUNNEL_MUX_SESSIONS      Max persistent relay sessions (fallback for --mux-sessions)
 
 Examples:
   # Start a relay listener allowing only SSH and HTTPS targets

--- a/cmd/aztunnel/main.go
+++ b/cmd/aztunnel/main.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"net"
 	"os"
+	"strconv"
 	"strings"
 
 	// Automatically set GOMEMLIMIT based on cgroup memory limits (container
@@ -15,8 +16,10 @@ import (
 	"github.com/KimMachineGun/automemlimit/memlimit"
 
 	"github.com/alecthomas/kong"
+	"github.com/philsphicas/aztunnel/internal/listener"
 	"github.com/philsphicas/aztunnel/internal/metrics"
 	"github.com/philsphicas/aztunnel/internal/relay"
+	"github.com/philsphicas/aztunnel/internal/sender"
 	"github.com/willabides/kongplete"
 )
 
@@ -33,6 +36,20 @@ func main() {
 		kong.UsageOnError(),
 		kong.ConfigureHelp(kong.HelpOptions{Compact: true}),
 		kong.Help(customHelpPrinter),
+		// Inject release-tracked defaults into kong tag substitutions so a
+		// single Go constant remains the source of truth across:
+		//   - the kong CLI default (resolved here),
+		//   - the sender library zero-value normalization
+		//     (NormalizeSenderMaxProtocolVersion in internal/sender),
+		//   - the protocol_version_test.go pin.
+		// This makes the 0.5.0 sender-default flip a single-constant change
+		// (see internal/sender/protocol_version.go DefaultSenderMaxProtocolVersion);
+		// help.go and docs/*.md still need the matching prose update, asserted
+		// by TestHelpDefault_MatchesSenderMaxProtocolVersionConstant.
+		kong.Vars{
+			"defaultSenderMaxProtocolVersion":   strconv.Itoa(sender.DefaultSenderMaxProtocolVersion),
+			"defaultListenerMaxProtocolVersion": strconv.Itoa(listener.DefaultListenerMaxProtocolVersion),
+		},
 	)
 
 	kongplete.Complete(parser)

--- a/cmd/aztunnel/port_forward.go
+++ b/cmd/aztunnel/port_forward.go
@@ -14,6 +14,7 @@ import (
 type PortForwardCmd struct {
 	AuthFlags
 	BindFlags
+	MuxFlags
 	Target string `arg:"" required:"" help:"Target host:port."`
 }
 
@@ -47,14 +48,18 @@ func (p *PortForwardCmd) Run(globals *Globals) error {
 	defer stop()
 
 	cfg := sender.PortForwardConfig{
-		Endpoint:      endpoint,
-		EntityPath:    hyco,
-		TokenProvider: tp,
-		ClientOptions: opts,
-		Target:        p.Target,
-		BindAddress:   bind,
-		TCPKeepAlive:  p.TCPKeepAlive,
-		Logger:        logger,
+		Endpoint:                  endpoint,
+		EntityPath:                hyco,
+		TokenProvider:             tp,
+		ClientOptions:             opts,
+		Target:                    p.Target,
+		BindAddress:               bind,
+		TCPKeepAlive:              p.TCPKeepAlive,
+		Logger:                    logger,
+		MuxStreamHandshakeTimeout: p.MuxStreamHandshakeTimeout,
+		MaxProtocolVersion:        p.MaxProtocolVersion,
+		MuxSessions:               p.MuxSessions,
+		MaxStreamsPerSession:      p.MaxStreamsPerSession,
 	}
 	if cfg.Metrics, err = resolveMetrics(ctx, globals.MetricsAddr, globals.MetricsMaxTargets, logger); err != nil {
 		return err

--- a/cmd/aztunnel/protocol_version_test.go
+++ b/cmd/aztunnel/protocol_version_test.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/alecthomas/kong"
+	"github.com/philsphicas/aztunnel/internal/listener"
+	"github.com/philsphicas/aztunnel/internal/sender"
+)
+
+// TestKongDefault_MaxProtocolVersion_TracksConstants asserts that the
+// kong-parsed default for --max-protocol-version on both sender and
+// listener subcommands matches the in-tree DefaultSenderMaxProtocolVersion
+// / DefaultListenerMaxProtocolVersion constants.
+//
+// This is the pin that makes the 0.5.0 sender-default flip a single-line
+// change: bump DefaultSenderMaxProtocolVersion and every code path
+// (sender library normalization, the CLI default surfaced by kong's
+// ${defaultSenderMaxProtocolVersion} substitution, this test) updates
+// in lockstep. Without this pin, kong's hardcoded `default:"1"` tag
+// would silently lag the constant.
+func TestKongDefault_MaxProtocolVersion_TracksConstants(t *testing.T) {
+	// CLI is a package-level var, so each parse builds its own struct.
+	var c struct {
+		Globals
+		RelayListener RelayListenerCmd `cmd:"" name:"relay-listener"`
+		RelaySender   RelaySenderCmd   `cmd:"" name:"relay-sender"`
+	}
+
+	vars := kong.Vars{
+		"defaultSenderMaxProtocolVersion":   strconv.Itoa(sender.DefaultSenderMaxProtocolVersion),
+		"defaultListenerMaxProtocolVersion": strconv.Itoa(listener.DefaultListenerMaxProtocolVersion),
+	}
+
+	parser, err := kong.New(&c, vars)
+	if err != nil {
+		t.Fatalf("kong.New: %v", err)
+	}
+
+	// Drive the sender port-forward path with the minimum args kong
+	// needs to satisfy required positional/flag fields;
+	// --max-protocol-version is omitted so kong fills it from the
+	// substituted default. The test only inspects the parsed value,
+	// so we never call Run() and no auth is needed.
+	if _, err := parser.Parse([]string{
+		"relay-sender", "port-forward", "10.0.0.1:22",
+		"--relay", "test-namespace",
+		"--hyco", "test-hyco",
+	}); err != nil {
+		t.Fatalf("kong.Parse (sender): %v", err)
+	}
+	if got, want := c.RelaySender.PortForward.MaxProtocolVersion, sender.DefaultSenderMaxProtocolVersion; got != want {
+		t.Errorf("kong-parsed sender --max-protocol-version default = %d, want %d (sender.DefaultSenderMaxProtocolVersion). Bumping the constant must propagate via kong.Vars; see cmd/aztunnel/main.go.",
+			got, want)
+	}
+
+	// Same drill for the listener subcommand. Build a fresh struct +
+	// parser; kong stores parsed values on the receiver.
+	c.RelayListener = RelayListenerCmd{}
+	parser, err = kong.New(&c, vars)
+	if err != nil {
+		t.Fatalf("kong.New (listener): %v", err)
+	}
+	if _, err := parser.Parse([]string{
+		"relay-listener",
+		"--relay", "test-namespace",
+		"--hyco", "test-hyco",
+	}); err != nil {
+		t.Fatalf("kong.Parse (listener): %v", err)
+	}
+	if got, want := c.RelayListener.MaxProtocolVersion, listener.DefaultListenerMaxProtocolVersion; got != want {
+		t.Errorf("kong-parsed listener --max-protocol-version default = %d, want %d (listener.DefaultListenerMaxProtocolVersion). Bumping the constant must propagate via kong.Vars; see cmd/aztunnel/main.go.",
+			got, want)
+	}
+}

--- a/cmd/aztunnel/relay_listener.go
+++ b/cmd/aztunnel/relay_listener.go
@@ -16,6 +16,22 @@ type RelayListenerCmd struct {
 	MaxConnections int           `name:"max-connections" help:"Max concurrent connections (0 = unlimited)." default:"0"`
 	ConnectTimeout time.Duration `name:"connect-timeout" help:"Timeout for dialing targets." default:"30s"`
 	TCPKeepAlive   time.Duration `name:"tcp-keepalive" help:"TCP keepalive interval." default:"30s"`
+
+	// MaxProtocolVersion is the highest aztunnel relay protocol
+	// version this listener will accept from a sender. The default,
+	// listener.DefaultListenerMaxProtocolVersion (2), accepts both
+	// legacy (v1) and stream-multiplexed (v2) senders. An operator
+	// who needs an emergency rollback to v1-only — for example to
+	// mitigate a v2-specific bug while a fix ships — sets this to 1.
+	//
+	// The flag is intentionally NOT bound to an environment variable
+	// (unlike its sender counterpart, AZTUNNEL_MAX_PROTOCOL_VERSION).
+	// A workstation that exports the env to pin its outbound sender
+	// to v1 should not accidentally disable v2 on a listener process
+	// it happens to launch as well (systemd units, containers with a
+	// shared env, etc.). Operators who genuinely want a fleet-wide
+	// listener pin pass --max-protocol-version=1 explicitly.
+	MaxProtocolVersion int `name:"max-protocol-version" help:"Highest aztunnel relay protocol version this listener will accept. 1 = legacy per-connection rendezvous only; senders requesting v2 (stream multiplexing) are rejected and fall back. 2 (default) = also accepts v2. Use 1 for an emergency rollback of a listener fleet." default:"${defaultListenerMaxProtocolVersion}"`
 }
 
 // Run executes the relay-listener command.
@@ -42,16 +58,17 @@ func (r *RelayListenerCmd) Run(globals *Globals) error {
 	}
 
 	cfg := listener.Config{
-		Endpoint:       endpoint,
-		EntityPath:     hyco,
-		TokenProvider:  observeTokenFetch(tp, m, providerName),
-		ClientOptions:  opts,
-		AllowList:      r.Allow,
-		MaxConnections: r.MaxConnections,
-		ConnectTimeout: r.ConnectTimeout,
-		TCPKeepAlive:   r.TCPKeepAlive,
-		Logger:         logger,
-		Metrics:        m,
+		Endpoint:           endpoint,
+		EntityPath:         hyco,
+		TokenProvider:      observeTokenFetch(tp, m, providerName),
+		ClientOptions:      opts,
+		AllowList:          r.Allow,
+		MaxConnections:     r.MaxConnections,
+		ConnectTimeout:     r.ConnectTimeout,
+		TCPKeepAlive:       r.TCPKeepAlive,
+		Logger:             logger,
+		Metrics:            m,
+		MaxProtocolVersion: r.MaxProtocolVersion,
 	}
 
 	return listener.ListenAndServe(ctx, cfg)

--- a/cmd/aztunnel/socks5_proxy.go
+++ b/cmd/aztunnel/socks5_proxy.go
@@ -14,6 +14,7 @@ import (
 type Socks5ProxyCmd struct {
 	AuthFlags
 	BindFlags
+	MuxFlags
 }
 
 // Run executes the socks5-proxy command.
@@ -46,13 +47,17 @@ func (s *Socks5ProxyCmd) Run(globals *Globals) error {
 	defer stop()
 
 	cfg := sender.SOCKS5Config{
-		Endpoint:      endpoint,
-		EntityPath:    hyco,
-		TokenProvider: tp,
-		ClientOptions: opts,
-		BindAddress:   bind,
-		TCPKeepAlive:  s.TCPKeepAlive,
-		Logger:        logger,
+		Endpoint:                  endpoint,
+		EntityPath:                hyco,
+		TokenProvider:             tp,
+		ClientOptions:             opts,
+		BindAddress:               bind,
+		TCPKeepAlive:              s.TCPKeepAlive,
+		Logger:                    logger,
+		MuxStreamHandshakeTimeout: s.MuxStreamHandshakeTimeout,
+		MaxProtocolVersion:        s.MaxProtocolVersion,
+		MuxSessions:               s.MuxSessions,
+		MaxStreamsPerSession:      s.MaxStreamsPerSession,
 	}
 	if cfg.Metrics, err = resolveMetrics(ctx, globals.MetricsAddr, globals.MetricsMaxTargets, logger); err != nil {
 		return err

--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -54,3 +54,10 @@ walks through the end-to-end setup.
 
 Common questions about aztunnel, including bgtask for background tasks,
 Entra ID vs SAS keys, hybrid connection design, and monitoring.
+
+## Reference
+
+| Page                                   | Description                                                                   |
+| -------------------------------------- | ----------------------------------------------------------------------------- |
+| [Stream multiplexing](../mux.md)       | How port-forward and SOCKS5 reuse one relay WebSocket for many TCP sessions   |
+| [Azure Relay Setup](../azure-setup.md) | Provisioning the relay namespace, hybrid connection, and SAS or Entra ID auth |

--- a/docs/guides/listener-systemd.md
+++ b/docs/guides/listener-systemd.md
@@ -118,6 +118,30 @@ For busier deployments, increase `MemoryMax`:
 MemoryMax=512M    # handles more concurrent connections
 ```
 
+### Sizing for mux fan-out
+
+Each accepted mux session reserves up to
+[`muxconfig.MaxReceiveBuffer`](../../internal/muxconfig/muxconfig.go) of
+inbound buffer space (16 MiB at the time of writing) as a back-pressure
+worst case, plus a small per-stream working set. The buffer only fills
+when the receiver stalls; typical steady-state usage is a small fraction
+of that ceiling. Even so, the listener's worst-case inbound buffering
+scales as `MaxReceiveBuffer × concurrent_mux_sessions`, where each
+sender process opens up to `--mux-sessions` of them (default `2`).
+
+Rough rule of thumb at the defaults:
+
+| Concurrent senders | Worst-case mux buffers | Suggested `MemoryMax` |
+| ------------------ | ---------------------- | --------------------- |
+| up to 4            | up to ~130 MiB         | `256M`                |
+| up to 16           | up to ~512 MiB         | `1G`                  |
+| 50+                | sized per fleet        | benchmark first       |
+
+Steady-state usage is usually much lower because smux only buffers when
+a stream's reader is slower than its sender. If your workload has many
+slow targets (e.g. legacy devices, throttled APIs) at high concurrency,
+prefer the higher end of these recommendations.
+
 To override the auto-tuning ratio:
 
 ```sh

--- a/docs/guides/sender-port-forward.md
+++ b/docs/guides/sender-port-forward.md
@@ -36,6 +36,17 @@ Then connect normally:
 psql -h 127.0.0.1 -p 5432 -U myuser mydb
 ```
 
+> **Fast connection setup**: new TCP connections to the forwarded port
+> share a persistent multiplexed relay session, established lazily on the
+> first connection. The first connection still pays the ~1–2 second
+> rendezvous; subsequent connections that reuse an already-established
+> mux session complete in milliseconds (just one smux stream open over
+> the persistent session). With `--mux-sessions > 1`, concurrent traffic
+> can lazily grow the pool, and the first connection on each new session
+> pays a rendezvous too. See
+> [stream multiplexing](../mux.md) for details and tuning knobs
+> (`--mux-sessions`, `--max-protocol-version`).
+
 ## Understanding `--bind`
 
 The `--bind` flag controls where the sender listens for local connections.

--- a/docs/guides/sender-socks5-proxy.md
+++ b/docs/guides/sender-socks5-proxy.md
@@ -33,6 +33,19 @@ aztunnel relay-sender socks5-proxy \
 The proxy listens on `127.0.0.1:1080` and forwards each connection through
 Azure Relay to the listener, which dials the requested target.
 
+> **Fast connection setup**: connections through the SOCKS5 proxy share a
+> persistent multiplexed relay session, established lazily on the first
+> connection. The first proxied connection still pays the ~1–2 second
+> rendezvous; subsequent connections that reuse an already-established
+> mux session complete in milliseconds (just one smux stream open over
+> the persistent session). With `--mux-sessions > 1`, concurrent SOCKS
+> traffic can lazily grow the pool, and the first connection on each new
+> session pays a rendezvous too. This makes
+> interactive workloads (browser tabs, `kubectl`, bulk `curl`) feel
+> responsive after the first request. See
+> [stream multiplexing](../mux.md) for details and tuning knobs
+> (`--mux-sessions`, `--max-protocol-version`).
+
 ## DNS resolution: `--socks5` vs `--socks5h`
 
 This matters. SOCKS5 clients can resolve DNS **locally** or pass the hostname

--- a/docs/mux.md
+++ b/docs/mux.md
@@ -1,0 +1,342 @@
+# Stream multiplexing
+
+Each new TCP session through aztunnel normally pays a full Azure Relay
+rendezvous: a TLS handshake, a WSS upgrade, a control-channel `accept` to
+the listener, the listener dialing its own rendezvous WebSocket, and the
+two sides being paired. End-to-end this typically costs **1–2 seconds per
+connection**, which is painful in SOCKS5 mode where a browser, `kubectl`,
+or `curl` workload opens many short-lived TCP sessions.
+
+To avoid paying that cost on every new connection, aztunnel supports
+**stream multiplexing** (relay protocol v2) — one or more persistent smux
+sessions over long-lived relay WebSockets. Each new TCP session becomes
+a cheap smux stream rather than a full rendezvous, dropping per-connection
+setup time from ~1–2 s to ~milliseconds.
+
+Sessions are **dialed lazily on the first request that needs one**, so the
+very first TCP connection through the sender still pays one full
+rendezvous (and is no faster than the v1 path). The speedup applies to
+every subsequent connection that reuses the established session.
+
+```
+Without mux (--max-protocol-version=1):    With mux (--max-protocol-version=2):
+┌──────┐                                   ┌──────┐
+│ ssn1 │──[full rendezvous 1-2s]           │ ssn1 │──┐
+└──────┘                                   └──────┘  │
+┌──────┐                                   ┌──────┐  │
+│ ssn2 │──[full rendezvous 1-2s]           │ ssn2 │──┼──[single persistent WS]
+└──────┘                                   └──────┘  │
+┌──────┐                                   ┌──────┐  │
+│ ssn3 │──[full rendezvous 1-2s]           │ ssn3 │──┘
+└──────┘                                   └──────┘
+```
+
+## Protocol versions
+
+Each aztunnel binary advertises a **highest protocol version** it
+supports, both on the sender side (`--max-protocol-version` /
+`AZTUNNEL_MAX_PROTOCOL_VERSION`) and on the listener side
+(`--max-protocol-version`, flag only).
+
+| version | sender behaviour                                                                                                                                    | listener behaviour                                                                                                                                                                               |
+| ------- | --------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `1`     | Legacy per-connection rendezvous on every TCP session. No mux pool is built; mux flags (`--mux-sessions`, `--max-streams-per-session`) are ignored. | Accepts only v1 senders. Incoming v2 mux handshakes are rejected with the same `unsupported protocol version` wire shape pre-mux listeners emitted, so v2 senders fall back to v1 automatically. |
+| `2`     | Stream multiplexing over a small pool of long-lived rendezvous WebSockets. Falls back to v1 if the listener rejects v2 (sticky for 60 s).           | Accepts both v1 and v2.                                                                                                                                                                          |
+
+### Defaults in this release (0.4.0)
+
+- **Sender default: `1`.** Stream multiplexing is **opt-in** in 0.4.0:
+  pass `--max-protocol-version=2` (or set `AZTUNNEL_MAX_PROTOCOL_VERSION=2`)
+  to enable it for the workloads that benefit most (SOCKS5 fan-out,
+  short-lived port-forward sessions).
+- **Listener default: `2`.** Every listener accepts both v1 and v2
+  unconditionally, so a sender opting into v2 works against any 0.4.0+
+  listener without operator coordination.
+
+This makes the 0.4.0 release safe to roll out: deploying it changes no
+observable behaviour for any operator who doesn't explicitly opt in to
+mux, but the capability is in place fleet-wide for the next release to
+flip on.
+
+### Defaults in a future release (0.5.0)
+
+- **Sender default: `2`.** Mux is on by default; pass
+  `--max-protocol-version=1` (or `AZTUNNEL_MAX_PROTOCOL_VERSION=1`) to
+  keep the legacy per-connection path.
+- **Listener default: `2`.** Unchanged.
+
+The listener-side `--max-protocol-version` flag also accepts `1` as an
+emergency rollback ("a v2-specific bug appeared in the wild and we need
+to take v2 off the wire fleet-wide while we ship a fix"). The flag is
+deliberately not bound to an environment variable so an operator
+exporting `AZTUNNEL_MAX_PROTOCOL_VERSION=1` for their sender doesn't
+silently disable v2 on every listener process that happens to inherit
+the same env.
+
+## When mux is used
+
+When `--max-protocol-version=2` is set, mux is used by:
+
+- `relay-sender port-forward`
+- `relay-sender socks5-proxy`
+
+These are the modes where many short-lived connections benefit most. The
+one-shot `relay-sender connect` (used for SSH `ProxyCommand` etc.) stays
+on the unmultiplexed v1 path regardless of `--max-protocol-version`
+because it only opens a single session per invocation.
+
+## Configuration
+
+| Flag                                      | Env                                     | Default | Notes                                                                                                                                    |
+| ----------------------------------------- | --------------------------------------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| `--max-protocol-version N`                | `AZTUNNEL_MAX_PROTOCOL_VERSION`         | `1`     | Highest relay protocol version the sender will attempt. Sender-side flag; safe to leave at `2` against any listener fleet.               |
+| `--mux-sessions N`                        | `AZTUNNEL_MUX_SESSIONS`                 | `2`     | Cap on persistent rendezvous WebSockets. Only effective with `--max-protocol-version=2`.                                                 |
+| `--max-streams-per-session N`             | `AZTUNNEL_MAX_STREAMS_PER_SESSION`      | `256`   | Per-session in-flight stream cap. Advanced; rarely needed. Only effective with `--max-protocol-version=2`.                               |
+| `--mux-stream-handshake-timeout DURATION` | `AZTUNNEL_MUX_STREAM_HANDSHAKE_TIMEOUT` | `60s`   | Sender-side cap on the per-stream envelope+response exchange. Hidden; see [Tuning the handshake timeout](#tuning-the-handshake-timeout). |
+
+The listener side has one knob:
+
+| Flag                       | Env  | Default | Notes                                                                                                                                                                                               |
+| -------------------------- | ---- | ------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--max-protocol-version N` | none | `2`     | Listener-side ceiling. Default accepts both v1 and v2. Set to `1` for an emergency v2 rollback. Intentionally not env-bound; see [Defaults in a future release](#defaults-in-a-future-release-050). |
+
+### `--mux-sessions` sizing
+
+Each "session" is one long-lived relay rendezvous WebSocket. The pool
+grows lazily to `--mux-sessions` whenever every existing session has at
+least one in-flight stream, so a serial workload stays on session 0 and a
+bursty workload spreads across new sessions.
+
+Guidance:
+
+- **Default (`2`)** covers typical workloads: single-stream callers
+  keep using session 0 (no extra rendezvous cost), and bursty
+  multi-stream callers get a second session lazily for parallel
+  fan-out and a chance at HA-listener spread.
+- **Strict single-rendezvous behavior**: set `--mux-sessions 1`. Use
+  this when you want a deterministic single WebSocket per sender and
+  are not concerned about head-of-line blocking under concurrent
+  load.
+- **High-availability listener fleet (many listeners)**: raise
+  `--mux-sessions` toward the number of listeners you run. Each new
+  session opens a fresh rendezvous, which **may** land on a different
+  listener — but Azure Relay's listener selection is opaque and we do
+  not promise true load balancing. Test empirically.
+- **Long-lived heavy traffic**: leave the default unless you observe
+  `aztunnel_mux_pool_saturated_total` incrementing in metrics, which
+  indicates callers blocking on `--max-streams-per-session`. The CLI
+  port-forward and SOCKS5 paths bound each per-connection mux open
+  wait at 60s (an internal `muxStreamAdmissionTimeout`); on saturation
+  the timeout fires and increments the counter, then the connection
+  is dropped (or falls back to v1 if mux is unsupported). Raise
+  `--mux-sessions` and/or `--max-streams-per-session` before the
+  counter becomes a sustained signal in your dashboards.
+
+### Tuning the handshake timeout
+
+The hidden `--mux-stream-handshake-timeout` flag (default `60s`) caps the
+per-stream envelope+response exchange between sender and listener. It
+needs to be greater than the listener's target-dial budget because the
+listener starts dialing the upstream target before writing the envelope
+response; if the sender timeout is too short, the sender gives up while
+the listener's target dial is still in progress, never seeing the
+response that was about to be written.
+
+Operators almost never need to touch this. Raise it only if you have
+also raised the listener's `--connect-timeout` above its `30s` default
+(e.g. for sluggish upstream targets like cold-start VMs) — in that case
+set the sender's `--mux-stream-handshake-timeout` to at least the
+listener's `--connect-timeout` plus a few seconds of headroom. Otherwise
+v2 mux streams will time out at the 60s default while v1 single-stream
+connections would have waited the full listener budget.
+
+The flag is intentionally hidden from `--help` because the default is
+correct for every standard configuration; it exists for the slow-dial
+edge case only.
+
+### Listener `--max-connections` and envelope-pending streams
+
+With mux enabled, a single accepted control-channel WebSocket can
+carry many concurrent smux streams. The listener guards three
+distinct resources independently:
+
+- The **per-rendezvous control-channel cap** (`--max-connections`,
+  applied at the relay control accept semaphore) bounds the number of
+  concurrent accepted relay WebSockets. In v1 this is equivalent to
+  the active-stream cap; in v2 it caps mux sessions, each of which
+  can multiplex up to `--max-streams-per-session` streams.
+- The **active-stream cap** (`--max-connections`, applied via
+  `streamSem` after envelope+allowlist validation) bounds in-flight
+  target connections across all paths (v1 and v2 mux). This restores
+  the v1 "MaxConnections == total target connections" semantics
+  under v2 multi-session deployments.
+- The **envelope-pending cap** (`pendingSem`, sized at 2× the active
+  cap) bounds smux streams that have been accepted but have not yet
+  completed envelope validation, so that slow or malicious peers
+  withholding envelopes can't pin unbounded goroutines and
+  read-deadline timers (up to `muxStreamReadTimeout`) inside the
+  listener.
+
+**Operator note (v2 vs v1):** Under v1 the per-rendezvous and
+active-stream caps fire simultaneously — one rendezvous carries
+exactly one target stream. Under v2 they decouple: with N senders
+each opening up to `--mux-sessions` rendezvous, an idle mux session
+holds a control slot for the session's lifetime (hours) while
+consuming zero stream slots. An operator running with a small
+explicit `--max-connections` (e.g. `--max-connections 1`) will find
+that one idle v2 mux session blocks all subsequent connections —
+including v1 senders — until that session closes. Size
+`--max-connections` with headroom for `N × MuxSessions` idle control
+slots when running a mixed v1/v2 fleet.
+
+When `--max-connections` is `0` (its default, meaning **unlimited**),
+all three caps are unlimited. Operators running mux-aware listeners
+in untrusted-sender environments should set an explicit
+`--max-connections` so that the envelope-pending cap takes effect —
+otherwise a single authenticated sender can open as many
+envelope-pending streams as its smux peer is willing to keep open.
+The v1 path is also unbounded at `--max-connections 0`, but in v2 the
+per-WebSocket multiplier makes the asymmetry worth calling out
+explicitly.
+
+## Session rotation
+
+aztunnel rotates each mux session every 6 hours by default:
+
+1. At `t + 6h` (`RotateAfter`), the session is marked **draining**.
+   The pool stops assigning new streams to it.
+2. In-flight streams are allowed to finish naturally for up to 5 minutes
+   (`RotateGrace`).
+3. If streams are still active at the end of the grace window, the
+   session is force-closed and a brief disruption follows.
+
+### Why rotation exists
+
+Empirical probing of Azure Relay shows that sender rendezvous
+WebSockets **survive past their SAS token's `se=` expiry indefinitely**
+as long as keepalives flow — token validation happens at handshake
+only. A 2-minute SAS token sustained traffic for at least 22 minutes
+past expiry in testing with no relay-side teardown.
+
+So rotation is **not** a correctness requirement to dodge token-expiry
+WS reaping. It is purely defensive:
+
+- **Fleet rebalancing**: each rotation re-dials, which is another
+  opportunity for Azure Relay to pick a different listener instance
+  in a multi-listener HA setup.
+- **Defence in depth**: against unknown long-term relay limits or
+  silent quotas not exposed in documentation.
+
+Draining sessions do **not** count toward `--mux-sessions`, so a
+rotation in progress never stalls new streams on the sender side: the
+pool can temporarily exceed the cap by the number of draining sessions.
+Note this is a sender-pool guarantee only — if the listener is running
+with `--max-connections` near `--mux-sessions`, the draining session
+still holds a listener control-channel slot until closed, so a
+replacement session can still be rejected or delayed by the listener's
+control cap. Size the listener's `--max-connections` with headroom for
+in-flight drains when running close to the cap.
+
+### Impact on long-lived streams
+
+Long-lived streams (interactive SSH sessions, `kubectl port-forward`,
+HTTP long-polling) reaching the 5-minute grace window during rotation
+will be force-closed. Plan around this: if you need a stream to live
+more than ~5 minutes uninterrupted across a 6h boundary, pin the
+sender to v1 with `--max-protocol-version=1` and accept the
+per-connection setup cost. For most workloads (browsers, short DB
+queries, repeated curl calls) rotation is invisible.
+
+## Backwards compatibility
+
+A mux-aware sender can talk to either:
+
+- a mux-aware listener (v2 — uses the persistent path), or
+- an older listener (v1 — falls back to per-connection rendezvous).
+
+When the sender first dials a v1 listener, the handshake is rejected
+with a v1-style error (`unsupported protocol version` on listeners
+that recognize the v2 version field, or `missing target` / `invalid
+envelope` on older listeners that parse the v2 handshake as a v1
+`ConnectEnvelope` and reject it). The sender treats any of these as a
+v1-fallback signal, remembers it for 60 seconds, and falls through to
+v1 for new connections during that window without re-dialing. After
+the window, it retries the mux path in case the listener pool was
+rolled.
+
+With `--mux-sessions > 1`, the first logical connection to an all-v1
+listener fleet can pay up to `MuxSessions` failed mux rendezvous
+before the 60-second sticky fallback is cached: the pool grows lazily
+and each new session has to learn the v1 verdict independently.
+Subsequent connections during the 60-second window short-circuit to
+v1 without paying that cost. Operators raising `--mux-sessions`
+during mixed-version rollouts should expect this one-time latency
+spike on the cold pool.
+
+If you operate a **mixed-version fleet** during a rolling upgrade, this
+fallback works automatically; preferably upgrade listeners first.
+
+## Metrics
+
+If `--metrics-addr` is set, mux-specific metrics are exposed. All mux
+metrics below are emitted by the sender path (`MuxDialer` / `MuxPool`)
+with `role="sender"`; listener-only mux session metrics are not
+currently implemented, so these series will not appear on a
+listener-only `/metrics` endpoint.
+
+| Metric                              | Type      | Labels           | Description                                                                                                                                             |
+| ----------------------------------- | --------- | ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `aztunnel_mux_sessions_active`      | gauge     | `role`           | Number of currently active mux sessions.                                                                                                                |
+| `aztunnel_mux_stream_open_seconds`  | histogram | `role`           | Time from `OpenStream` entry to smux stream open (pool admission + smux SYN; excludes the per-stream envelope handshake).                               |
+| `aztunnel_mux_session_age_seconds`  | histogram | `role`           | Distribution of session ages at rotation or eviction (includes `unsupported`, `pool_closed`, and `open_failed` shutdowns).                              |
+| `aztunnel_mux_rotations_total`      | counter   | `role`, `reason` | Mux session lifecycle exits by reason: `scheduled`, `force_after_grace` (rotations), `unsupported`, `pool_closed`, `open_failed` (evictions/shutdowns). |
+| `aztunnel_mux_pool_saturated_total` | counter   | `role`           | Callers that ctx-expired while waiting for a free slot.                                                                                                 |
+
+`aztunnel_connection_errors_total` also gains a `mux_open_failed` reason
+for connections that failed opening a mux stream (e.g. smux setup error,
+handshake parse failure, listener rejection that isn't the v1-fallback
+marker), and a `listener_at_capacity` reason emitted by the listener
+when it rejects an incoming connection because it has hit its own
+streamSem or pendingSem cap (operators can tell "we're at our
+configured `--max-connections`" apart from "Azure had a relay outage").
+Relay-dial failures inside the mux path are recorded under the
+`dial_timeout` and `relay_failed` reasons by `MuxDialer.connectLocked`,
+which calls `relay.DialWithRetry` directly and emits `ConnectionError`
+via `DialReason(err, ReasonRelayFailed)` itself (rather than going
+through `metrics.InstrumentedDial`, so it can suppress the dial-error
+metric when the cause is parentCtx cancellation during eviction). The
+`dial_failed` reason is reserved for the listener target-dial path and
+does not appear on sender mux dials. No double-counting, and context
+cancellation while waiting on a saturated pool is not recorded as a
+connection error.
+
+## Disabling mux
+
+If you hit a bug or want the legacy path for a specific session, pin the
+sender to v1:
+
+```sh
+aztunnel relay-sender socks5-proxy --max-protocol-version=1 --bind 127.0.0.1:1080
+# or
+AZTUNNEL_MAX_PROTOCOL_VERSION=1 aztunnel relay-sender port-forward 10.0.0.5:5432
+```
+
+In 0.4.0 v1 is also the default — these incantations are no-ops unless
+you've already opted in to v2 via env. They become meaningful in 0.5.0
+when the sender default flips to v2.
+
+For fleet-wide rollback at the listener side (e.g. responding to a
+v2-specific production bug), pass `--max-protocol-version=1` on the
+listener instead — a v1-only listener rejects v2 handshakes with the
+exact wire shape pre-mux listeners emitted, so every v2 sender falls
+back automatically without operator coordination on the sender side.
+
+Symptoms that might warrant pinning to v1:
+
+- An unusual protocol that depends on TCP framing characteristics not
+  preserved by smux (rare).
+- A stream that needs to survive a rotation boundary by more than the
+  5-minute grace window (rotation defaults to every 6h; see "Session
+  rotation" above for details and the "Impact on long-lived streams"
+  guidance).
+- Diagnosing whether a regression is mux-related.

--- a/e2e/backends/azure/backend_test.go
+++ b/e2e/backends/azure/backend_test.go
@@ -253,6 +253,7 @@ func (b *azureBackend) Setup(t testing.TB, opts scenarios.SetupOptions) *scenari
 		listenerArgs = append(listenerArgs, "--connect-timeout",
 			opts.ConnectTimeout.String())
 	}
+	listenerArgs = appendListenerProtocolArgs(listenerArgs, opts)
 
 	spawnListener := func(t testing.TB) *scenarios.Listener {
 		t.Helper()
@@ -270,6 +271,7 @@ func (b *azureBackend) Setup(t testing.TB, opts scenarios.SetupOptions) *scenari
 	}
 
 	senderArgs := []string{"--metrics-addr", "127.0.0.1:0", "--log-level", "debug"}
+	senderArgs = appendSenderProtocolArgs(senderArgs, opts)
 
 	listeners := make([]*scenarios.Listener, 0, opts.NumListeners)
 	for i := 0; i < opts.NumListeners; i++ {
@@ -295,11 +297,14 @@ func (b *azureBackend) Setup(t testing.TB, opts scenarios.SetupOptions) *scenari
 		senders = append(senders, &scenarios.Sender{
 			Addr:                bindAddr,
 			Completed:           scrapeCounter(metricsAddr, "aztunnel_connections_total"),
-			Active:              scrapeGauge(metricsAddr, "aztunnel_active_connections"),
-			DialDurationSamples: scrapeHistogramCount(metricsAddr, "aztunnel_dial_duration_seconds"),
-			TokenFetchOK:        scrapeTokenFetchOK(metricsAddr),
-			Stop:                func() { proc.Stop(t) },
-			Logs:                func() string { return proc.logs.String() },
+			Active:                scrapeGauge(metricsAddr, "aztunnel_active_connections"),
+			DialDurationSamples:   scrapeHistogramCount(metricsAddr, "aztunnel_dial_duration_seconds"),
+			TokenFetchOK:          scrapeTokenFetchOK(metricsAddr),
+			MuxSessionsActive:     scrapeGauge(metricsAddr, "aztunnel_mux_sessions_active"),
+			MuxStreamOpenSamples:  scrapeHistogramCount(metricsAddr, "aztunnel_mux_stream_open_seconds"),
+			MuxPoolSaturatedTotal: scrapeGauge(metricsAddr, "aztunnel_mux_pool_saturated_total"),
+			Stop:                  func() { proc.Stop(t) },
+			Logs:                  func() string { return proc.logs.String() },
 		})
 	}
 
@@ -546,6 +551,7 @@ func (b *azureBackend) SetupExpectingFailure(t testing.TB, opts scenarios.SetupO
 	for _, target := range opts.AllowedTargets {
 		listenerArgs = append(listenerArgs, "--allow", target)
 	}
+	listenerArgs = appendListenerProtocolArgs(listenerArgs, opts)
 
 	listenerLogs := func() string { return "" }
 	senderLogs := func() string { return "" }
@@ -562,7 +568,9 @@ func (b *azureBackend) SetupExpectingFailure(t testing.TB, opts scenarios.SetupO
 	// Sender-side failure: bring up a healthy listener (if asked)
 	// then start the sender with bad creds and observe.
 	if opts.NumListeners > 0 {
-		lp := startListener(t, env, auth, "--metrics-addr", "127.0.0.1:0", "--log-level", "debug")
+		healthyListenerArgs := []string{"--metrics-addr", "127.0.0.1:0", "--log-level", "debug"}
+		healthyListenerArgs = appendListenerProtocolArgs(healthyListenerArgs, opts)
+		lp := startListener(t, env, auth, healthyListenerArgs...)
 		listenerLogs = func() string { return lp.logs.String() }
 		waitForLog(t, lp, "control_started", 30*time.Second)
 	}
@@ -583,27 +591,30 @@ func (b *azureBackend) SetupExpectingFailure(t testing.TB, opts scenarios.SetupO
 	// Port-forward or SOCKS5: start sender with bad creds, dial
 	// locally to trigger the relay dial, wait for the failure log.
 	var proc *aztunnelProcess
+	senderExtra := appendSenderProtocolArgs(nil, opts)
 	switch opts.SenderMode {
 	case scenarios.ModePortForward:
 		target := opts.Target
 		if target == "" {
 			target = "127.0.0.1:9999"
 		}
-		proc = startAztunnelWithSAS(t, env, senderSAS,
+		args := append([]string{
 			"relay-sender", "port-forward", target,
 			"--relay", env.relayName,
 			"--hyco", hyco,
 			"--bind", "127.0.0.1:0",
 			"--log-level", "debug",
-		)
+		}, senderExtra...)
+		proc = startAztunnelWithSAS(t, env, senderSAS, args...)
 	case scenarios.ModeSOCKS5:
-		proc = startAztunnelWithSAS(t, env, senderSAS,
+		args := append([]string{
 			"relay-sender", "socks5-proxy",
 			"--relay", env.relayName,
 			"--hyco", hyco,
 			"--bind", "127.0.0.1:0",
 			"--log-level", "debug",
-		)
+		}, senderExtra...)
+		proc = startAztunnelWithSAS(t, env, senderSAS, args...)
 	}
 	senderLogs = func() string { return proc.logs.String() }
 
@@ -677,6 +688,40 @@ type azureFailureHandle struct {
 func (h *azureFailureHandle) ListenerLogs() string { return h.listenerLogs() }
 func (h *azureFailureHandle) SenderLogs() string   { return h.senderLogs() }
 func (h *azureFailureHandle) Close()               {}
+
+// appendListenerProtocolArgs threads the harness's listener protocol
+// knobs onto the listener subprocess command line. Centralised because
+// every code path that spawns a listener (Setup, SetupExpectingFailure
+// healthy-listener branch, SetupExpectingFailure listener-side failure
+// branch) must add the same flags in the same order — letting them
+// drift caused the original NoMux/ListenerRejectMux churn the
+// 0.4.0 redesign cleaned up.
+func appendListenerProtocolArgs(args []string, opts scenarios.SetupOptions) []string {
+	if opts.ListenerMaxProtocolVersion != 0 {
+		args = append(args, "--max-protocol-version",
+			strconv.Itoa(opts.ListenerMaxProtocolVersion))
+	}
+	return args
+}
+
+// appendSenderProtocolArgs threads the harness's sender protocol knobs
+// onto the sender subprocess command line. Mirrors
+// appendListenerProtocolArgs.
+func appendSenderProtocolArgs(args []string, opts scenarios.SetupOptions) []string {
+	if opts.SenderMaxProtocolVersion != 0 {
+		args = append(args, "--max-protocol-version",
+			strconv.Itoa(opts.SenderMaxProtocolVersion))
+	}
+	if opts.MuxSessions > 0 {
+		args = append(args, "--mux-sessions",
+			strconv.Itoa(opts.MuxSessions))
+	}
+	if opts.MaxStreamsPerSession > 0 {
+		args = append(args, "--max-streams-per-session",
+			strconv.Itoa(opts.MaxStreamsPerSession))
+	}
+	return args
+}
 
 // OpenConnect lets ModeConnect failure scenarios drive a connect
 // invocation against this handle's overridden auth credentials.

--- a/e2e/backends/mock/backend.go
+++ b/e2e/backends/mock/backend.go
@@ -417,15 +417,16 @@ func (b *MockBackend) Setup(t testing.TB, opts scenarios.SetupOptions) *scenario
 		done := make(chan struct{})
 
 		cfg := listener.Config{
-			Endpoint:       host,
-			EntityPath:     entity,
-			TokenProvider:  b.newTokenProvider(m),
-			ClientOptions:  clientOpts,
-			AllowList:      opts.AllowedTargets,
-			MaxConnections: opts.MaxConnections,
-			ConnectTimeout: opts.ConnectTimeout,
-			Logger:         slog.New(slog.NewTextHandler(logs, &slog.HandlerOptions{Level: slog.LevelDebug})),
-			Metrics:        m,
+			Endpoint:           host,
+			EntityPath:         entity,
+			TokenProvider:      b.newTokenProvider(m),
+			ClientOptions:      clientOpts,
+			AllowList:          opts.AllowedTargets,
+			MaxConnections:     opts.MaxConnections,
+			ConnectTimeout:     opts.ConnectTimeout,
+			Logger:             slog.New(slog.NewTextHandler(logs, &slog.HandlerOptions{Level: slog.LevelDebug})),
+			Metrics:            m,
+			MaxProtocolVersion: opts.ListenerMaxProtocolVersion,
 		}
 
 		wg.Add(1)
@@ -500,26 +501,32 @@ func (b *MockBackend) Setup(t testing.TB, opts scenarios.SetupOptions) *scenario
 			switch opts.SenderMode {
 			case scenarios.ModePortForward:
 				err = sender.PortForward(sctx, sender.PortForwardConfig{
-					Endpoint:      host,
-					EntityPath:    entity,
-					TokenProvider: senderTP,
-					ClientOptions: clientOpts,
-					Target:        opts.Target,
-					BindAddress:   "127.0.0.1:0",
-					Logger:        senderLogger,
-					Metrics:       m,
-					Ready:         ready,
+					Endpoint:             host,
+					EntityPath:           entity,
+					TokenProvider:        senderTP,
+					ClientOptions:        clientOpts,
+					Target:               opts.Target,
+					BindAddress:          "127.0.0.1:0",
+					Logger:               senderLogger,
+					Metrics:              m,
+					Ready:                ready,
+					MaxProtocolVersion:   opts.SenderMaxProtocolVersion,
+					MuxSessions:          opts.MuxSessions,
+					MaxStreamsPerSession: opts.MaxStreamsPerSession,
 				})
 			case scenarios.ModeSOCKS5:
 				err = sender.SOCKS5Proxy(sctx, sender.SOCKS5Config{
-					Endpoint:      host,
-					EntityPath:    entity,
-					TokenProvider: senderTP,
-					ClientOptions: clientOpts,
-					BindAddress:   "127.0.0.1:0",
-					Logger:        senderLogger,
-					Metrics:       m,
-					Ready:         ready,
+					Endpoint:             host,
+					EntityPath:           entity,
+					TokenProvider:        senderTP,
+					ClientOptions:        clientOpts,
+					BindAddress:          "127.0.0.1:0",
+					Logger:               senderLogger,
+					Metrics:              m,
+					Ready:                ready,
+					MaxProtocolVersion:   opts.SenderMaxProtocolVersion,
+					MuxSessions:          opts.MuxSessions,
+					MaxStreamsPerSession: opts.MaxStreamsPerSession,
 				})
 			}
 			if err != nil && sctx.Err() == nil && ctx.Err() == nil {
@@ -545,13 +552,16 @@ func (b *MockBackend) Setup(t testing.TB, opts scenarios.SetupOptions) *scenario
 		}
 
 		return &scenarios.Sender{
-			Addr:                addr.String(),
-			Completed:           counterReader(m, "aztunnel_connections_total"),
-			Active:              gaugeReader(m, "aztunnel_active_connections"),
-			DialDurationSamples: histogramSampleCount(m, "aztunnel_dial_duration_seconds"),
-			TokenFetchOK:        tokenFetchOKReader(m),
-			Stop:                stop,
-			Logs:                logs.String,
+			Addr:                  addr.String(),
+			Completed:             counterReader(m, "aztunnel_connections_total"),
+			Active:                gaugeReader(m, "aztunnel_active_connections"),
+			DialDurationSamples:   histogramSampleCount(m, "aztunnel_dial_duration_seconds"),
+			TokenFetchOK:          tokenFetchOKReader(m),
+			MuxSessionsActive:     gaugeReader(m, "aztunnel_mux_sessions_active"),
+			MuxStreamOpenSamples:  histogramSampleCount(m, "aztunnel_mux_stream_open_seconds"),
+			MuxPoolSaturatedTotal: counterReader(m, "aztunnel_mux_pool_saturated_total"),
+			Stop:                  stop,
+			Logs:                  logs.String,
 		}
 	}
 
@@ -765,13 +775,14 @@ func (b *MockBackend) SetupExpectingFailure(t testing.TB, opts scenarios.SetupOp
 		go func() {
 			defer wg.Done()
 			err := listener.ListenAndServe(lctx, listener.Config{
-				Endpoint:      host,
-				EntityPath:    entity,
-				TokenProvider: listenerProvider,
-				ClientOptions: clientOpts,
-				AllowList:     opts.AllowedTargets,
-				Logger:        listenerLogger,
-				Metrics:       metrics.New(),
+				Endpoint:           host,
+				EntityPath:         entity,
+				TokenProvider:      listenerProvider,
+				ClientOptions:      clientOpts,
+				AllowList:          opts.AllowedTargets,
+				Logger:             listenerLogger,
+				Metrics:            metrics.New(),
+				MaxProtocolVersion: opts.ListenerMaxProtocolVersion,
 			})
 			if err != nil && lctx.Err() == nil && ctx.Err() == nil {
 				listenerLogger.Debug("listener exited", "err", err)
@@ -803,15 +814,16 @@ func (b *MockBackend) SetupExpectingFailure(t testing.TB, opts scenarios.SetupOp
 		go func() {
 			defer wg.Done()
 			err := listener.ListenAndServe(lctx, listener.Config{
-				Endpoint:       host,
-				EntityPath:     entity,
-				TokenProvider:  listenerProvider,
-				ClientOptions:  clientOpts,
-				AllowList:      opts.AllowedTargets,
-				MaxConnections: opts.MaxConnections,
-				ConnectTimeout: opts.ConnectTimeout,
-				Logger:         listenerLogger,
-				Metrics:        m,
+				Endpoint:           host,
+				EntityPath:         entity,
+				TokenProvider:      listenerProvider,
+				ClientOptions:      clientOpts,
+				AllowList:          opts.AllowedTargets,
+				MaxConnections:     opts.MaxConnections,
+				ConnectTimeout:     opts.ConnectTimeout,
+				Logger:             listenerLogger,
+				Metrics:            m,
+				MaxProtocolVersion: opts.ListenerMaxProtocolVersion,
 			})
 			if err != nil && lctx.Err() == nil && ctx.Err() == nil {
 				listenerLogger.Debug("listener exited", "err", err)
@@ -854,26 +866,32 @@ func (b *MockBackend) SetupExpectingFailure(t testing.TB, opts scenarios.SetupOp
 		switch opts.SenderMode {
 		case scenarios.ModePortForward:
 			err = sender.PortForward(sctx, sender.PortForwardConfig{
-				Endpoint:      host,
-				EntityPath:    entity,
-				TokenProvider: senderProvider,
-				ClientOptions: clientOpts,
-				Target:        opts.Target,
-				BindAddress:   "127.0.0.1:0",
-				Logger:        senderLogger,
-				Metrics:       metrics.New(),
-				Ready:         ready,
+				Endpoint:             host,
+				EntityPath:           entity,
+				TokenProvider:        senderProvider,
+				ClientOptions:        clientOpts,
+				Target:               opts.Target,
+				BindAddress:          "127.0.0.1:0",
+				Logger:               senderLogger,
+				Metrics:              metrics.New(),
+				Ready:                ready,
+				MaxProtocolVersion:   opts.SenderMaxProtocolVersion,
+				MuxSessions:          opts.MuxSessions,
+				MaxStreamsPerSession: opts.MaxStreamsPerSession,
 			})
 		case scenarios.ModeSOCKS5:
 			err = sender.SOCKS5Proxy(sctx, sender.SOCKS5Config{
-				Endpoint:      host,
-				EntityPath:    entity,
-				TokenProvider: senderProvider,
-				ClientOptions: clientOpts,
-				BindAddress:   "127.0.0.1:0",
-				Logger:        senderLogger,
-				Metrics:       metrics.New(),
-				Ready:         ready,
+				Endpoint:             host,
+				EntityPath:           entity,
+				TokenProvider:        senderProvider,
+				ClientOptions:        clientOpts,
+				BindAddress:          "127.0.0.1:0",
+				Logger:               senderLogger,
+				Metrics:              metrics.New(),
+				Ready:                ready,
+				MaxProtocolVersion:   opts.SenderMaxProtocolVersion,
+				MuxSessions:          opts.MuxSessions,
+				MaxStreamsPerSession: opts.MaxStreamsPerSession,
 			})
 		}
 		if err != nil && sctx.Err() == nil && ctx.Err() == nil {

--- a/e2e/scenarios/backend.go
+++ b/e2e/scenarios/backend.go
@@ -326,6 +326,49 @@ type SetupOptions struct {
 	// valid; scenarios that need this override should scope-gate
 	// themselves on mock).
 	OverrideHycoName string
+
+	// SenderMaxProtocolVersion pins the sender's --max-protocol-version
+	// for the topology. Zero (the default) leaves the sender at its
+	// own default (DefaultSenderMaxProtocolVersion: 1 in 0.4.0, 2 in
+	// 0.5.0+). 1 forces the legacy per-connection rendezvous path; 2
+	// permits stream multiplexing (with automatic fallback when the
+	// listener rejects v2). Ignored for SenderMode==ModeConnect
+	// (one-shot stdio: no mux to opt into).
+	//
+	// Backends translate: --max-protocol-version on Azure (subprocess
+	// CLI), PortForwardConfig.MaxProtocolVersion / SOCKS5Config.MaxProtocolVersion
+	// on the mock. Set by WithMuxAxis for the mux=v1/v2 cells; scenarios
+	// may also set it directly to pin one version regardless of the
+	// surrounding cell (the explicit pin wins).
+	SenderMaxProtocolVersion int
+
+	// MuxSessions caps the sender's mux pool size. 0 means leave at
+	// the sender default. Threaded to --mux-sessions on Azure and to
+	// PortForwardConfig.MuxSessions / SOCKS5Config.MuxSessions on the
+	// mock backend. Only effective when the sender ends up running v2
+	// (SenderMaxProtocolVersion == 0 with the runtime default >= 2,
+	// or SenderMaxProtocolVersion == 2).
+	MuxSessions int
+
+	// MaxStreamsPerSession caps in-flight streams per mux session
+	// before back-pressure kicks in. 0 means leave at the sender
+	// default. Threaded to --max-streams-per-session on Azure and to
+	// the corresponding mock Config field. Only effective when the
+	// sender ends up running v2 (see MuxSessions).
+	MaxStreamsPerSession int
+
+	// ListenerMaxProtocolVersion pins every listener in the topology
+	// to a --max-protocol-version. Zero (the default) leaves listeners
+	// at their own default (DefaultListenerMaxProtocolVersion: 2,
+	// i.e. accept both v1 and v2). 1 forces v1-only acceptance: any
+	// incoming v2 MuxHandshake is rejected with the same wire shape a
+	// pre-mux listener emitted, so a v2 sender's mux-unavailable
+	// fallback (internal/sender/muxdialer.go:isMuxUnsupportedRejection)
+	// fires. This is the production-grade mechanism behind the
+	// rolling-deployment scenario (a v2 sender against a v1-only
+	// listener fleet) — same code path an operator would use for an
+	// emergency v2 rollback.
+	ListenerMaxProtocolVersion int
 }
 
 // AuthOverride substitutes auth credentials when SetupExpectingFailure
@@ -478,6 +521,32 @@ type Sender struct {
 	// backend and the in-process mock (via its {sas, entra} auth axis)
 	// populate it.
 	TokenFetchOK func() []TokenFetchObservation
+
+	// MuxSessionsActive returns the sum of the
+	// aztunnel_mux_sessions_active gauge across all labels on this
+	// sender's metrics surface. Used by
+	// ScenarioMetrics_MuxSessionsActive to assert that the sender
+	// actually built a mux pool when v2 was opted into. Optional:
+	// backends that do not wire mux metrics leave this nil and the
+	// scenario skips.
+	MuxSessionsActive func() int64
+
+	// MuxStreamOpenSamples returns the count of observations in the
+	// aztunnel_mux_stream_open_seconds histogram on this sender's
+	// metrics surface. Used by ScenarioMetrics_MuxSessionsActive to
+	// assert per-stream admission is going through the v2 pool.
+	// Optional: backends that do not wire mux metrics leave this nil
+	// and the scenario skips.
+	MuxStreamOpenSamples func() uint64
+
+	// MuxPoolSaturatedTotal returns the sum of the
+	// aztunnel_mux_pool_saturated_total counter on this sender's
+	// metrics surface. Used by ScenarioMetrics_MuxSessionsActive to
+	// assert the test workload did not pathologically saturate the
+	// pool (which would invalidate the scenario's assumptions about
+	// what the other two metrics mean). Optional: backends that do
+	// not wire mux metrics leave this nil and the scenario skips.
+	MuxPoolSaturatedTotal func() int64
 
 	// Stop drops this sender. Idempotent.
 	Stop func()

--- a/e2e/scenarios/matrix_mux_axis_test.go
+++ b/e2e/scenarios/matrix_mux_axis_test.go
@@ -1,0 +1,87 @@
+package scenarios
+
+import (
+	"reflect"
+	"testing"
+	"time"
+)
+
+// TestPerfMatrix_RecordsMuxAxisCellValue exercises the integration
+// between WithMuxAxis-tagged test paths and the perfMatrix recorder:
+// when a perf row's t.Name() contains a `/v2/` segment in the
+// canonical sub-test position, matrixIdentity should label it with
+// axes["mux"]="v2", and v1 vs v2 rows should be treated as distinct
+// cells by drain ordering and reporter pivoting.
+func TestPerfMatrix_RecordsMuxAxisCellValue(t *testing.T) {
+	perfMatrixSink.setAxisNames([]string{"auth", "delay", "mux"})
+	t.Cleanup(func() {
+		perfMatrixSink.drain()
+		perfMatrixSink.setAxisNames(nil)
+	})
+
+	// Record one row per (mux=v1, mux=v2) cell within the same outer
+	// auth/delay cell, simulating what RunPerformanceScenarios emits
+	// when wrapped by WithMuxAxis.
+	for _, mux := range []string{"v1", "v2"} {
+		recordPerfMatrixRow(
+			"TestE2E_Mock/sas/default/"+mux+"/Parallel_ConnReusedEcho_SOCKS5",
+			[]time.Duration{time.Second},
+			[]time.Duration{time.Millisecond},
+			3, 3, 2*time.Second,
+		)
+	}
+
+	rows := perfMatrixSink.drain()
+	if len(rows) != 2 {
+		t.Fatalf("got %d rows, want 2 (one per mux cell)", len(rows))
+	}
+
+	// Drain orders rows by (axis, scenario, mode). v1/v2 share scenario
+	// and mode but differ on axis, so v1 sorts before v2.
+	wantV1 := map[string]string{"auth": "sas", "delay": "default", "mux": "v1"}
+	wantV2 := map[string]string{"auth": "sas", "delay": "default", "mux": "v2"}
+	if !reflect.DeepEqual(rows[0].axes, wantV1) {
+		t.Errorf("rows[0].axes = %#v, want %#v", rows[0].axes, wantV1)
+	}
+	if !reflect.DeepEqual(rows[1].axes, wantV2) {
+		t.Errorf("rows[1].axes = %#v, want %#v", rows[1].axes, wantV2)
+	}
+	if rows[0].axis == rows[1].axis {
+		t.Errorf("v1 and v2 rows must NOT share the flat axis path (got %q for both); the reporter would treat them as duplicate cells",
+			rows[0].axis)
+	}
+}
+
+// TestPerfMatrix_NonPerfPathSkipsMuxAxis exercises the case where the
+// global axisNames includes "mux" (because the perf suite uses it) but
+// a non-perf path doesn't have a mux segment in t.Name(). The recorder
+// must not invent a mux axis value out of thin air — splitScenarioPath's
+// length cap is the line of defence.
+//
+// In practice non-perf scenarios don't call recordPerfMatrixRow today,
+// but this test pins the contract so a future scenario that does (e.g.
+// a streaming-family observability check) won't silently mislabel rows.
+func TestPerfMatrix_NonPerfPathSkipsMuxAxis(t *testing.T) {
+	perfMatrixSink.setAxisNames([]string{"auth", "delay", "mux"})
+	t.Cleanup(func() {
+		perfMatrixSink.drain()
+		perfMatrixSink.setAxisNames(nil)
+	})
+
+	// Path has only auth/delay segments, no mux segment — looks like a
+	// row a topology scenario would record if it ever did.
+	recordPerfMatrixRow(
+		"TestE2E_Mock/sas/default/Distribution_PerListener_PortForward",
+		[]time.Duration{time.Second},
+		[]time.Duration{time.Millisecond},
+		1, 1, time.Second,
+	)
+	rows := perfMatrixSink.drain()
+	if len(rows) != 1 {
+		t.Fatalf("got %d rows, want 1", len(rows))
+	}
+	want := map[string]string{"auth": "sas", "delay": "default"}
+	if !reflect.DeepEqual(rows[0].axes, want) {
+		t.Errorf("axes = %#v, want %#v (no synthesised mux key)", rows[0].axes, want)
+	}
+}

--- a/e2e/scenarios/muxaxis.go
+++ b/e2e/scenarios/muxaxis.go
@@ -1,0 +1,137 @@
+package scenarios
+
+import (
+	"fmt"
+	"testing"
+	"time"
+)
+
+// MuxAxisName is the Axis.Name() used by WithMuxAxis. Exported so
+// scenarios that need to inspect or skip cells by mux mode can do so
+// without string-duplicating the literal.
+const MuxAxisName = "mux"
+
+// MuxAxisValueV1 selects the v1 sender path (mux disabled — every
+// connection uses the legacy one-stream-per-rendezvous protocol).
+const MuxAxisValueV1 = "v1"
+
+// MuxAxisValueV2 selects the v2 sender path (mux pool enabled —
+// streams multiplexed over a small number of long-lived sessions).
+// This matches the sender's production default.
+const MuxAxisValueV2 = "v2"
+
+// WithMuxAxis returns a Backend wrapper that adds a "mux" axis with
+// values ["v1","v2"] as the INNERMOST axis (appended to inner.Axes()).
+// Sub-test paths read as `.../<auth>/<delay>/<mux>/<scenario>`, so the
+// PERF MATRIX history file groups v1/v2 rows together within each cell.
+//
+// On every Cell call the wrapper pins opts.SenderMaxProtocolVersion to
+// the cell's mux value (1 for v1, 2 for v2) before delegating Setup /
+// SetupExpectingFailure to the inner backend. A scenario that has
+// already populated opts.SenderMaxProtocolVersion before calling
+// b.Setup(t, opts) wins — the explicit pin overrides the cell. That
+// matters for scenarios whose contract depends on a specific protocol
+// version regardless of the surrounding cell (e.g. v1-only topology
+// distribution scenarios that exercise per-rendezvous semantics mux
+// dissolves).
+//
+// The wrapper delegates Name(), latency thresholds, and policy to the
+// inner Backend so the axis adds nothing to the backend's identity
+// beyond the extra sub-test layer.
+func WithMuxAxis(inner Backend) Backend {
+	if inner == nil {
+		panic("scenarios.WithMuxAxis: inner Backend must not be nil")
+	}
+	return &muxAxisBackend{inner: inner}
+}
+
+type muxAxisBackend struct {
+	inner Backend
+	// mode is empty until Cell() is called. The harness contract
+	// (Backend.Cell, backend.go) requires Cell() to return a fresh
+	// backend pinned to the cell; we honour that by returning a new
+	// *muxAxisBackend with mode set, never mutating the receiver.
+	mode string
+}
+
+func (b *muxAxisBackend) Name() string { return b.inner.Name() }
+
+func (b *muxAxisBackend) ConnectLatencyThreshold() time.Duration {
+	return b.inner.ConnectLatencyThreshold()
+}
+
+func (b *muxAxisBackend) ColdStartLatencyThreshold() time.Duration {
+	return b.inner.ColdStartLatencyThreshold()
+}
+
+func (b *muxAxisBackend) WarmRequestBudget() time.Duration {
+	return b.inner.WarmRequestBudget()
+}
+
+func (b *muxAxisBackend) ConnectLatencyPolicy() ConnectLatencyPolicy {
+	return b.inner.ConnectLatencyPolicy()
+}
+
+func (b *muxAxisBackend) Axes() []Axis {
+	inner := b.inner.Axes()
+	axes := make([]Axis, 0, len(inner)+1)
+	axes = append(axes, inner...)
+	axes = append(axes, muxAxis{})
+	return axes
+}
+
+func (b *muxAxisBackend) Cell(values map[string]string) Backend {
+	mode, ok := values[MuxAxisName]
+	if !ok {
+		panic(fmt.Sprintf("scenarios.muxAxisBackend.Cell: missing %q in cell values %v", MuxAxisName, values))
+	}
+	switch mode {
+	case MuxAxisValueV1, MuxAxisValueV2:
+	default:
+		panic(fmt.Sprintf("scenarios.muxAxisBackend.Cell: unknown %q value %q", MuxAxisName, mode))
+	}
+	// Strip our axis before delegating; the inner backend's Cell
+	// expects only its own axes' keys.
+	rest := make(map[string]string, len(values)-1)
+	for k, v := range values {
+		if k == MuxAxisName {
+			continue
+		}
+		rest[k] = v
+	}
+	return &muxAxisBackend{inner: b.inner.Cell(rest), mode: mode}
+}
+
+func (b *muxAxisBackend) Setup(t testing.TB, opts SetupOptions) *Tunnel {
+	t.Helper()
+	return b.inner.Setup(t, b.applyMux(opts))
+}
+
+func (b *muxAxisBackend) SetupExpectingFailure(t testing.TB, opts SetupOptions) FailureHandle {
+	t.Helper()
+	return b.inner.SetupExpectingFailure(t, b.applyMux(opts))
+}
+
+func (b *muxAxisBackend) applyMux(opts SetupOptions) SetupOptions {
+	// A scenario that pre-populates SenderMaxProtocolVersion wins.
+	// This protects v1-only and v2-only scenarios from being silently
+	// flipped by the surrounding mux-axis cell.
+	if opts.SenderMaxProtocolVersion != 0 {
+		return opts
+	}
+	switch b.mode {
+	case MuxAxisValueV1:
+		opts.SenderMaxProtocolVersion = 1
+	case MuxAxisValueV2:
+		opts.SenderMaxProtocolVersion = 2
+	}
+	return opts
+}
+
+// muxAxis is the Axis implementation for the mux-mode dimension.
+// Kept unexported because callers construct the axis via the
+// WithMuxAxis decorator rather than instantiating the axis directly.
+type muxAxis struct{}
+
+func (muxAxis) Name() string     { return MuxAxisName }
+func (muxAxis) Values() []string { return []string{MuxAxisValueV1, MuxAxisValueV2} }

--- a/e2e/scenarios/observability.go
+++ b/e2e/scenarios/observability.go
@@ -47,6 +47,7 @@ func observabilityCases() []scenarioCase {
 		{name: "ListenerID_PropagatesAndChangesOnRestart", scope: AnyBackend, run: ScenarioListenerID_PropagatesAndChangesOnRestart},
 		{name: "AcceptID_Saturation", scope: AnyBackend, run: ScenarioAcceptID_Saturation},
 		{name: "TokenFetchMetric", scope: AnyBackend, run: ScenarioTokenFetchMetric},
+		{name: "Metrics_MuxSessionsActive", scope: AnyBackend, run: ScenarioMetrics_MuxSessionsActive},
 	}
 }
 
@@ -86,6 +87,17 @@ func ScenarioBridgeID_Correlation(t *testing.T, b Backend) {
 		SenderMode:     ModeSOCKS5,
 		AllowedTargets: []string{echo.Addr(), refused},
 		ConnectTimeout: 5 * time.Second,
+		// Pin v1: the per-bridge retry filter (bridgeIDForTarget
+		// requires a per-bridge "relay connected" log to anchor
+		// the canonical bridge_id, see senderLogsWithRetry in
+		// observability_test.go) is a v1-path log shape. On v2
+		// the relay dial fires once per mux session — not per
+		// stream — so "relay connected" never carries the
+		// stream's bridge_id, and bridgeIDForTarget returns ""
+		// for every bridge. The cross-side bridge_id correlation
+		// guarantee itself is identical on v1 and v2; only the
+		// retry-disambiguation mechanism is v1-coupled.
+		SenderMaxProtocolVersion: 1,
 	})
 	requireLogs(t, tun)
 
@@ -716,6 +728,91 @@ func ScenarioMetrics_DialDuration(t *testing.T, b Backend) {
 	t.Errorf("aztunnel_dial_duration_seconds histogram has %d samples after round-trip, want >= 1", got)
 }
 
+// ScenarioMetrics_MuxSessionsActive asserts the v2-only mux metrics
+// surface lights up when the sender is opted into protocol v2:
+//
+//   - aztunnel_mux_sessions_active flips from 0 to >= 1 once the pool
+//     dials its first session, and stays >= 1 while the workload is
+//     live (the pool holds the session open).
+//   - aztunnel_mux_stream_open_seconds_count grows by at least N after
+//     N concurrent round-trips, proving the per-stream path went through
+//     pool.OpenStream rather than the v1 single-rendezvous path.
+//   - aztunnel_mux_pool_saturated_total stays at 0 under a workload
+//     well below MaxStreamsPerSession × MuxSessions (the default 2 ×
+//     256 = 512 caps, vs N=8 here). A non-zero saturation count would
+//     mean callers were giving up on the pool, which would invalidate
+//     what the other two metrics are telling us.
+//
+// Pinned to ModeSOCKS5 because it's the canonical many-distinct-target
+// workload the mux pool was sized for, and to SenderMaxProtocolVersion=2
+// because the metrics only exist when the pool is built — under the
+// 0.4.0 default (v1) the metrics surface returns 0 for everything and
+// the scenario would falsely fail. Skips when the backend handle
+// doesn't expose the mux accessors (no implementation gates the
+// scenario via Skip rather than Fail).
+//
+// Verifies the metrics actually fire end-to-end against a real mux
+// session, complementing the unit-level coverage in
+// internal/metrics/metrics_test.go.
+func ScenarioMetrics_MuxSessionsActive(t *testing.T, b Backend) {
+	t.Helper()
+	AssertNoLeaks(t)
+	echo := StartPlainEcho(t)
+	tun := b.Setup(t, SetupOptions{
+		NumListeners:             1,
+		SenderMode:               ModeSOCKS5,
+		AllowedTargets:           []string{echo.Addr()},
+		SenderMaxProtocolVersion: 2,
+	})
+
+	sender := tun.Senders[0]
+	if sender.MuxSessionsActive == nil ||
+		sender.MuxStreamOpenSamples == nil ||
+		sender.MuxPoolSaturatedTotal == nil {
+		t.Skipf("Metrics_MuxSessionsActive: %s backend does not expose mux metric accessors", b.Name())
+	}
+
+	// Drive 8 sequential SOCKS5 round-trips against the echo target.
+	// Serial (rather than concurrent) so the assertion is purely
+	// about "did the per-stream path increment the histogram N times"
+	// without depending on goroutine-safe Fatalf semantics. The first
+	// round-trip lazily dials the mux session; the remaining 7 reuse
+	// it as smux streams.
+	const flows = 8
+	for i := 0; i < flows; i++ {
+		doSOCKS5Echo(t, tun.SenderAddr, echo.Addr(), []byte("mux-metrics\n"))
+	}
+	if t.Failed() {
+		return
+	}
+
+	// Poll: subprocess backends scrape /metrics, in-process backends
+	// read the registry directly. Both reach steady state quickly,
+	// but allow up to 15s to absorb a slow Azure scrape.
+	deadline := time.Now().Add(15 * time.Second)
+	var (
+		sessions int64
+		opens    uint64
+	)
+	for time.Now().Before(deadline) {
+		sessions = sender.MuxSessionsActive()
+		opens = sender.MuxStreamOpenSamples()
+		if sessions >= 1 && opens >= flows {
+			break
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	if sessions < 1 {
+		t.Errorf("aztunnel_mux_sessions_active = %d after %d round-trips, want >= 1 (pool never dialed a session — is the sender on v1?)", sessions, flows)
+	}
+	if opens < flows {
+		t.Errorf("aztunnel_mux_stream_open_seconds_count = %d after %d round-trips, want >= %d (per-stream path didn't go through pool.OpenStream)", opens, flows, flows)
+	}
+	if got := sender.MuxPoolSaturatedTotal(); got != 0 {
+		t.Errorf("aztunnel_mux_pool_saturated_total = %d, want 0 (test workload below pool capacity should never saturate; non-zero invalidates the other assertions)", got)
+	}
+}
+
 // ScenarioListenerID_PropagatesAndChangesOnRestart: assert the
 // listener_id slog attribute appears on sender-side accept logs
 // and changes after a listener restart. Subsumes the legacy
@@ -803,9 +900,19 @@ func ScenarioAcceptID_Saturation(t *testing.T, b Backend) {
 	tun := b.Setup(t, SetupOptions{
 		NumListeners:   1,
 		MaxConnections: maxConns,
-		SenderMode:     ModePortForward,
-		Target:         echo.Addr(),
-		AllowedTargets: []string{echo.Addr()},
+		// Pin v1: the test contract is the control-loop's
+		// per-rendezvous accept semaphore ("MaxConnections
+		// drops past N concurrent accepts"). Under mux all N
+		// client TCP connections multiplex over a single mux
+		// session bound to one rendezvous; the listener's
+		// accept semaphore sees one accept regardless of N
+		// and never saturates. v1's per-connection rendezvous
+		// surfaces the accept-saturation events the test
+		// inspects (accept_dropped + reason=semaphore_full).
+		SenderMaxProtocolVersion: 1,
+		SenderMode:               ModePortForward,
+		Target:                   echo.Addr(),
+		AllowedTargets:           []string{echo.Addr()},
 	})
 	requireLogs(t, tun)
 

--- a/e2e/scenarios/performance.go
+++ b/e2e/scenarios/performance.go
@@ -43,6 +43,10 @@ import (
 // Scenarios run sequentially. Each builds its own topology via
 // b.Setup so the timing measurement is dominated by the per-
 // connection cost, not by amortised setup.
+//
+// Scenarios run sequentially. b is the fully-cell-pinned backend the
+// caller (typically RunAllScenarios) hands in; b.Axes() is expected
+// to be nil/empty.
 func RunPerformanceScenarios(t *testing.T, b Backend) {
 	t.Helper()
 	runScenarioCases(t, b, performanceCases())

--- a/e2e/scenarios/reliability.go
+++ b/e2e/scenarios/reliability.go
@@ -78,6 +78,8 @@ func reliabilityCases() []scenarioCase {
 			reason: "validates Azure Relay's ~120s idle-connection timeout via keepalive pings; mock relay has no idle timeout",
 			run:    ScenarioLongLivedConnection,
 		},
+		{name: "MuxFallback_V1Listener_PortForward", scope: AnyBackend, run: ScenarioMuxFallback_V1Listener_PortForward},
+		{name: "MuxFallback_V1Listener_SOCKS5", scope: AnyBackend, run: ScenarioMuxFallback_V1Listener_SOCKS5},
 	}
 }
 
@@ -1161,6 +1163,147 @@ func waitForLogSubstrAny(logs func() string, substrs []string, timeout time.Dura
 		time.Sleep(50 * time.Millisecond)
 	}
 	return false
+}
+
+// muxUnsupportedFallbackLog is the warn-level message the sender's
+// muxdialer emits when it observes a v1-style rejection of the v2
+// handshake and arms its sticky v1-fallback marker. Pinned here so
+// the rolling-deployment scenarios can assert against the exact log
+// shape the production sender emits.
+const muxUnsupportedFallbackLog = "listener does not support mux protocol; falling back to v1"
+
+// ScenarioMuxFallback_V1Listener_PortForward asserts the rolling-
+// deployment story end-to-end: a sender that speaks v2 (mux)
+// against a listener fleet that only speaks v1 must
+//
+//  1. detect the rejection on its first v2 probe and fall back to
+//     v1 transparently so the application-visible round-trip
+//     succeeds, AND
+//  2. cache the rejection for muxUnavailableTTL (60 s) so
+//     subsequent connections skip the probe and dial straight
+//     into v1 — proven here by observing exactly one fallback log
+//     line across two back-to-back round-trips.
+//
+// The v1-only listener is driven by ListenerMaxProtocolVersion=1,
+// which makes the listener respond to v2 mux handshakes with the same
+// "unsupported protocol version" rejection a pre-mux listener would
+// emit (internal/listener/listener.go honours Config.MaxProtocolVersion;
+// the Azure backend sets it via the --max-protocol-version CLI flag
+// and the mock backend via the equivalent Config field). The sender is
+// pinned with SenderMaxProtocolVersion=2 so the v2 probe always fires
+// regardless of the runtime default (which differs between 0.4.0 and
+// 0.5.0). Same production-grade flag an operator would use for an
+// emergency v2 rollback; no test-only seam involved.
+//
+// Scope: this scenario is NOT wrapped by WithMuxAxis in
+// RunReliabilityScenarios — running it under a v1 cell would still
+// run the same code (the sender starts in v2 mode then falls back),
+// but the test name would falsely suggest the v1 cell is exercising
+// something different. Pinning to one configuration keeps the
+// scenario's intent unambiguous in -v output.
+func ScenarioMuxFallback_V1Listener_PortForward(t *testing.T, b Backend) {
+	t.Helper()
+	AssertNoLeaks(t)
+	echo := StartPlainEcho(t)
+	tun := b.Setup(t, SetupOptions{
+		NumListeners:               1,
+		SenderMode:                 ModePortForward,
+		Target:                     echo.Addr(),
+		AllowedTargets:             []string{echo.Addr()},
+		ListenerMaxProtocolVersion: 1,
+		SenderMaxProtocolVersion:   2,
+	})
+
+	// First round-trip: triggers the v2 probe, observes the
+	// rejection, falls back to v1, succeeds. Assert at least one
+	// fallback log line was emitted.
+	doPortForwardEcho(t, tun.SenderAddr, []byte("mux-fallback round 1\n"))
+	if !waitForLogSubstring(tun.Senders[0].Logs, muxUnsupportedFallbackLog, 10*time.Second) {
+		t.Fatalf("sender never logged mux-unsupported fallback within 10s\n--- sender logs ---\n%s",
+			tun.Senders[0].Logs())
+	}
+	count1 := strings.Count(tun.Senders[0].Logs(), muxUnsupportedFallbackLog)
+
+	// Second round-trip: sticky cache should hold (muxUnavailableTTL
+	// is 60 s, well beyond the few-ms gap here), so the sender must
+	// NOT emit another fallback log line — that would mean it
+	// re-probed mux and burned the listener's reject again.
+	doPortForwardEcho(t, tun.SenderAddr, []byte("mux-fallback round 2\n"))
+	// Give any in-flight log writes a brief moment to flush before
+	// we count, otherwise a second fallback could race past us.
+	time.Sleep(250 * time.Millisecond)
+	count2 := strings.Count(tun.Senders[0].Logs(), muxUnsupportedFallbackLog)
+	if count2 != count1 {
+		t.Errorf("sticky v1-fallback cache did not hold: fallback log count went from %d to %d after second round-trip (expected unchanged)\n--- sender logs ---\n%s",
+			count1, count2, tun.Senders[0].Logs())
+	}
+}
+
+// ScenarioMuxFallback_V1Listener_SOCKS5 is the SOCKS5 counterpart of
+// ScenarioMuxFallback_V1Listener_PortForward. The SOCKS5 sender's
+// CONNECT handshake completes only after the underlying tunnel
+// stream is established, so this also pins that the SOCKS5 reply
+// REP=0x00 (succeeded) is delivered even when the first attempt's
+// v2 probe is rejected and the sender silently falls back. Round-
+// trip semantics are identical: two back-to-back CONNECTs, with the
+// sticky cache asserted to suppress a second fallback log on call 2.
+func ScenarioMuxFallback_V1Listener_SOCKS5(t *testing.T, b Backend) {
+	t.Helper()
+	AssertNoLeaks(t)
+	echo := StartPlainEcho(t)
+	tun := b.Setup(t, SetupOptions{
+		NumListeners:               1,
+		SenderMode:                 ModeSOCKS5,
+		AllowedTargets:             []string{echo.Addr()},
+		ListenerMaxProtocolVersion: 1,
+		SenderMaxProtocolVersion:   2,
+	})
+
+	doSOCKS5Echo(t, tun.SenderAddr, echo.Addr(), []byte("mux-fallback socks5 round 1\n"))
+	if !waitForLogSubstring(tun.Senders[0].Logs, muxUnsupportedFallbackLog, 10*time.Second) {
+		t.Fatalf("sender never logged mux-unsupported fallback within 10s\n--- sender logs ---\n%s",
+			tun.Senders[0].Logs())
+	}
+	count1 := strings.Count(tun.Senders[0].Logs(), muxUnsupportedFallbackLog)
+
+	doSOCKS5Echo(t, tun.SenderAddr, echo.Addr(), []byte("mux-fallback socks5 round 2\n"))
+	time.Sleep(250 * time.Millisecond)
+	count2 := strings.Count(tun.Senders[0].Logs(), muxUnsupportedFallbackLog)
+	if count2 != count1 {
+		t.Errorf("sticky v1-fallback cache did not hold: fallback log count went from %d to %d after second round-trip (expected unchanged)\n--- sender logs ---\n%s",
+			count1, count2, tun.Senders[0].Logs())
+	}
+}
+
+// doPortForwardEcho runs one port-forward dial → write → readN →
+// close round-trip and Fatals the test on any error. Used by the
+// mux-fallback scenarios to keep their bodies focused on the
+// fallback-log assertions.
+func doPortForwardEcho(t *testing.T, senderAddr string, payload []byte) {
+	t.Helper()
+	conn := dialWithRetry(t, senderAddr, 10*time.Second)
+	defer conn.Close() //nolint:errcheck // best-effort cleanup
+	writeAll(t, conn, payload)
+	got := readN(t, conn, len(payload), 15*time.Second)
+	if string(got) != string(payload) {
+		t.Fatalf("port-forward echo mismatch\n got=%q\nwant=%q", got, payload)
+	}
+}
+
+// doSOCKS5Echo runs one SOCKS5 CONNECT → write → readN → close
+// round-trip and Fatals the test on any error.
+func doSOCKS5Echo(t *testing.T, proxyAddr, target string, payload []byte) {
+	t.Helper()
+	conn, err := dialSOCKS5WithRetry(proxyAddr, target, 10*time.Second)
+	if err != nil {
+		t.Fatalf("socks5 dial: %v", err)
+	}
+	defer conn.Close() //nolint:errcheck // best-effort cleanup
+	writeAll(t, conn, payload)
+	got := readN(t, conn, len(payload), 15*time.Second)
+	if string(got) != string(payload) {
+		t.Fatalf("socks5 echo mismatch\n got=%q\nwant=%q", got, payload)
+	}
 }
 
 // assertNoTokenLeak fails the test if output contains a raw

--- a/e2e/scenarios/scenarios.go
+++ b/e2e/scenarios/scenarios.go
@@ -20,33 +20,56 @@ import (
 
 // RunAllScenarios runs every scenario suite (Core, Topology,
 // Reliability, Observability, Performance) against b. It enumerates
-// b.Axes() exactly once and runs all suites inside each cell, so the
-// auth dimension (or any future axis) appears once in the rendered
-// sub-test path even though every suite runs inside it.
+// the full axis stack (b.Axes() outer + the mux v1/v2 axis innermost)
+// exactly once, so each suite sees a fully-cell-pinned backend and
+// the rendered sub-test path reads as
+// `<entry>/<outer-cell-values>/<mux>/<scenario>` without Go's #01/#02
+// disambiguation suffixes.
+//
+// EVERY suite runs under both v1 (legacy) and v2 (mux) sender code
+// paths. This is the only place the project asserts v2 actually works
+// end-to-end for non-perf functionality — half-close, SOCKS5
+// distinct-targets, error propagation, bridge cause logs, listener-id
+// and bridge-id correlation, the metrics surface (other than the
+// explicitly-mux scenarios). Wrapping only the perf suite (as an
+// earlier iteration did) leaves the bulk of v2 behavior unverified.
+//
+// Scenarios that pin SenderMaxProtocolVersion explicitly (e.g. the
+// topology / observability scenarios whose contracts depend on
+// per-rendezvous semantics, or the mux-fallback scenarios that need
+// v2 specifically) keep their pin in BOTH the v1 and v2 cells —
+// WithMuxAxis only fills SenderMaxProtocolVersion when the caller
+// hasn't already set it. Those scenarios run twice with the same
+// effective configuration; the duplication is harmless and avoids the
+// alternative (a per-scenario skip mechanism) until it's actually felt.
 //
 // Call this from test entry points (TestE2E_Azure, TestE2E_Mock)
 // rather than calling the individual Run*Scenarios in sequence —
-// independent forEachCell calls would render the axis layer once per
-// suite and Go would disambiguate the second-and-later instances with
-// #01/#02/... suffixes.
+// each Run*Scenarios expects a fully-pinned backend (no axes left to
+// enumerate); driving them directly would skip the mux fan-out.
 func RunAllScenarios(t *testing.T, b Backend) {
 	t.Helper()
 	axes := b.Axes()
-	names := make([]string, len(axes))
-	for i, a := range axes {
-		names[i] = a.Name()
+	names := make([]string, 0, len(axes)+1)
+	for _, a := range axes {
+		names = append(names, a.Name())
 	}
+	// The mux axis is innermost (added inside each outer cell).
+	names = append(names, MuxAxisName)
 	perfMatrixSink.setAxisNames(names)
 	t.Cleanup(func() {
 		finishPerfMatrix(t)
 	})
-	forEachCell(t, axes, func(t *testing.T, cell map[string]string) {
-		cellBackend := b.Cell(cell)
-		RunCoreScenarios(t, cellBackend)
-		RunTopologyScenarios(t, cellBackend)
-		RunReliabilityScenarios(t, cellBackend)
-		RunObservabilityScenarios(t, cellBackend)
-		RunPerformanceScenarios(t, cellBackend)
+	forEachCell(t, axes, func(t *testing.T, outerCell map[string]string) {
+		muxBackend := WithMuxAxis(b.Cell(outerCell))
+		forEachCell(t, muxBackend.Axes(), func(t *testing.T, muxCell map[string]string) {
+			pinned := muxBackend.Cell(muxCell)
+			RunCoreScenarios(t, pinned)
+			RunTopologyScenarios(t, pinned)
+			RunReliabilityScenarios(t, pinned)
+			RunObservabilityScenarios(t, pinned)
+			RunPerformanceScenarios(t, pinned)
+		})
 	})
 }
 

--- a/e2e/scenarios/topology.go
+++ b/e2e/scenarios/topology.go
@@ -129,11 +129,21 @@ func scenarioDistributionPerListener(t *testing.T, b Backend, n, m int) {
 	AssertNoLeaks(t)
 	echo := StartPlainEcho(t)
 	tun := b.Setup(t, SetupOptions{
-		NumListeners:   m,
-		NumSenders:     n,
-		SenderMode:     ModePortForward,
-		Target:         echo.Addr(),
-		AllowedTargets: []string{echo.Addr()},
+		NumListeners: m,
+		NumSenders:   n,
+		// Pin v1: the test contract is rendezvous-level
+		// distribution ("every listener gets traffic"). Under
+		// mux a single sender opens one mux session bound to a
+		// single rendezvous, so other listeners never see
+		// traffic regardless of how many connections the test
+		// drives through that one sender. v1 mints one
+		// rendezvous per accepted TCP connection, restoring
+		// the per-listener-distribution invariant the test
+		// asserts.
+		SenderMaxProtocolVersion: 1,
+		SenderMode:               ModePortForward,
+		Target:                   echo.Addr(),
+		AllowedTargets:           []string{echo.Addr()},
 	})
 
 	const (
@@ -272,11 +282,22 @@ func scenarioHotDropListener(t *testing.T, b Backend, n, m int) {
 	AssertNoLeaks(t)
 	echo := StartPlainEcho(t)
 	tun := b.Setup(t, SetupOptions{
-		NumListeners:   m,
-		NumSenders:     n,
-		SenderMode:     ModePortForward,
-		Target:         echo.Addr(),
-		AllowedTargets: []string{echo.Addr()},
+		NumListeners: m,
+		NumSenders:   n,
+		// Pin v1: the test contract is "drop one listener,
+		// observe exactly A0 flows broken on the survivors".
+		// Under mux each sender opens one mux session bound to
+		// a single rendezvous, so all K long flows from a
+		// sender land on the same listener; with N=1 or N=2
+		// vs M=2 the bound listener can easily be the one we
+		// then drop (or the wrong one), and Active() on the
+		// drop target reads 0 even after kMax flows. v1's per-
+		// connection rendezvous gives the natural distribution
+		// the snapshot/drop assertion depends on.
+		SenderMaxProtocolVersion: 1,
+		SenderMode:               ModePortForward,
+		Target:                   echo.Addr(),
+		AllowedTargets:           []string{echo.Addr()},
 	})
 
 	const (
@@ -406,11 +427,19 @@ func scenarioHotAddListener(t *testing.T, b Backend, n, m int) {
 	AssertNoLeaks(t)
 	echo := StartPlainEcho(t)
 	tun := b.Setup(t, SetupOptions{
-		NumListeners:   m,
-		NumSenders:     n,
-		SenderMode:     ModePortForward,
-		Target:         echo.Addr(),
-		AllowedTargets: []string{echo.Addr()},
+		NumListeners: m,
+		NumSenders:   n,
+		// Pin v1: the test contract is "a newly added listener
+		// picks up traffic". Under mux the sender's existing
+		// session(s) are bound to the original listeners; new
+		// connections multiplex onto those, so the freshly-
+		// added listener never receives a rendezvous. v1's
+		// per-connection rendezvous restores the convergence
+		// the test waits for.
+		SenderMaxProtocolVersion: 1,
+		SenderMode:               ModePortForward,
+		Target:                   echo.Addr(),
+		AllowedTargets:           []string{echo.Addr()},
 	})
 	if tun.AddListener == nil {
 		t.Skip("backend does not implement hot-add (Tunnel.AddListener is nil)")

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/prometheus/client_golang v1.23.2
 	github.com/prometheus/client_model v0.6.2
 	github.com/willabides/kongplete v0.4.0
+	github.com/xtaci/smux v1.5.57
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -79,6 +79,8 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/willabides/kongplete v0.4.0 h1:eivXxkp5ud5+4+NVN9e4goxC5mSh3n1RHov+gsblM2g=
 github.com/willabides/kongplete v0.4.0/go.mod h1:0P0jtWD9aTsqPSUAl4de35DLghrr57XcayPyvqSi2X8=
+github.com/xtaci/smux v1.5.57 h1:N72VbGoSYxgcm6mPOYX0QzEZNVD3UI/JlVvAtXF+WrY=
+github.com/xtaci/smux v1.5.57/go.mod h1:IGQ9QYrBphmb/4aTnLEcJby0TNr3NV+OslIOMrX825Q=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
 go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
 go.yaml.in/yaml/v2 v2.4.2 h1:DzmwEr2rDGHl7lsFgAHxmNz/1NlQ7xLIrlN2h5d1eGI=

--- a/internal/listener/listener.go
+++ b/internal/listener/listener.go
@@ -2,6 +2,10 @@
 // from the Azure Relay control channel, reads the connect envelope,
 // optionally checks the target against an allowlist, dials the target,
 // sends the response, and bridges data bidirectionally.
+//
+// The listener accepts both v1 (single connection per relay rendezvous)
+// and v2 (multiplexed) senders. It inspects the first WebSocket message
+// to decide which path to run; this allows mixed-version rolling upgrades.
 package listener
 
 import (
@@ -11,15 +15,75 @@ import (
 	"fmt"
 	"log/slog"
 	"net"
+	"sync"
 	"syscall"
 	"time"
 
 	"github.com/coder/websocket"
 	"github.com/philsphicas/aztunnel/internal/idgen"
 	"github.com/philsphicas/aztunnel/internal/metrics"
+	"github.com/philsphicas/aztunnel/internal/muxconfig"
 	"github.com/philsphicas/aztunnel/internal/protocol"
 	"github.com/philsphicas/aztunnel/internal/relay"
+	"github.com/xtaci/smux"
 )
+
+// muxStreamReadTimeout bounds reading a per-stream ConnectEnvelope. We
+// intentionally allow more time here than the WebSocket-level envelope
+// read because each smux stream is opened on demand and may be slow to
+// transmit its first frame under load.
+const muxStreamReadTimeout = 30 * time.Second
+
+// muxStreamWriteTimeout bounds every WriteStreamResponse on a smux
+// stream. Without this, a misbehaving peer that stops reading (or
+// fills smux's per-stream send window and never drains it) could
+// block the listener indefinitely on its rejection / handshake write —
+// either pinning a per-stream goroutine + its pendingSem slot, or
+// (on the accept-loop fast-reject path) stalling the accept loop
+// itself. 5s is generous for an authenticated peer over Azure Relay
+// and far below muxStreamReadTimeout, so a stuck write surfaces as
+// an error long before the read-side timeout would.
+const muxStreamWriteTimeout = 5 * time.Second
+
+// muxRejectInflightCap bounds the number of concurrent in-flight
+// rejection goroutines (rejection write + close) spawned by the
+// accept-loop fast-reject path (pendingSem-overflow). Each rejection
+// goroutine is bounded individually by muxStreamWriteTimeout, but
+// without this cap a peer that keeps opening streams while
+// back-pressuring smux's transport (so writes block on the 5s
+// deadline) could accumulate one goroutine per opened stream,
+// defeating the envelope-pending cap that's meant to control exactly
+// this abuse. When the cap is full, the accept loop tears down the
+// entire mux session — the only bounded response: we cannot close
+// the overflow stream inline (smux's internal 30s openCloseTimeout
+// is not bounded by SetWriteDeadline, so close-on-back-pressured-
+// transport stalls the accept loop) and we cannot dispatch unbounded
+// close goroutines either (each lives up to ~30s; sustained attack
+// accumulates them faster than they drain). Session teardown
+// triggers defer sess.Close() → wg.Wait(): sess.Close unblocks all
+// in-flight stream ops (smux Read/Write/Close observe session-die
+// and return immediately), so wg drains promptly. Legitimate bursts
+// complete in microseconds (peers that read responses don't block
+// on the write deadline) and never fill the cap.
+// 32 is large enough for legitimate bursts above pendingSem and
+// small enough to bound the rejection goroutine/timer footprint to
+// ~256 KiB per session worst-case.
+const muxRejectInflightCap = 32
+
+// listenerControlWriteTimeout bounds the time spent writing
+// ConnectResponse envelopes on the per-connection rendezvous
+// WebSocket (handled by sendResponse). The handler ctx is tied to the
+// rendezvous WS lifetime, so without a bounded write deadline a peer
+// that stops reading can stall every sendResponse call — including
+// capacity-rejection paths that need to release their listener slot
+// quickly. 5s is generous over Azure Relay's typical <100 ms write
+// latency, far below the ConnectTimeout envelope-read deadline
+// (default 30s) so the read-side budget dominates legitimate traffic,
+// and consistent with muxStreamWriteTimeout. The timeout applies to
+// every sendResponse caller: rejection paths discard the error
+// (intent), OK paths observe it and return immediately, releasing
+// slots.
+const listenerControlWriteTimeout = 5 * time.Second
 
 // Config holds relay-listener configuration.
 type Config struct {
@@ -40,6 +104,30 @@ type Config struct {
 	// startup. Tests that drive handleConnection directly may set it
 	// to a known string for deterministic assertions.
 	ListenerID string
+
+	// MaxProtocolVersion is the highest relay protocol version this
+	// listener will accept from a sender.
+	//
+	//   1 = legacy per-connection rendezvous only. Incoming v2
+	//       MuxHandshake messages are rejected with the same
+	//       "unsupported protocol version" string a pre-mux listener
+	//       would emit, so a v2 sender's mux-unavailable fallback path
+	//       (internal/sender/muxdialer.go:isMuxUnsupportedRejection)
+	//       triggers cleanly and the connection drops back to v1.
+	//   2 = also accepts v2 (stream multiplexing) sessions.
+	//
+	// Zero is normalized to DefaultListenerMaxProtocolVersion in
+	// applyDefaults. The flag has no environment-variable binding (see
+	// cmd/aztunnel/relay_listener.go) to prevent a stray
+	// AZTUNNEL_MAX_PROTOCOL_VERSION env intended for senders from
+	// accidentally pinning a listener fleet to v1.
+	//
+	// Production callers normally leave this at the default. The
+	// 0.4.0 default is protocol.MuxVersion (2) so every listener is
+	// mux-capable from day one; an operator who needs to roll a
+	// listener fleet back to v1 (e.g. emergency mitigation for a
+	// v2-only bug) sets MaxProtocolVersion = 1.
+	MaxProtocolVersion int
 
 	// dialContext optionally overrides target dialing. When nil,
 	// handleConnection uses a net.Dialer honouring ConnectTimeout.
@@ -76,6 +164,9 @@ func applyDefaults(cfg *Config) {
 	if cfg.ListenerID == "" {
 		cfg.ListenerID = idgen.NewListenerID()
 	}
+	if cfg.MaxProtocolVersion == 0 {
+		cfg.MaxProtocolVersion = DefaultListenerMaxProtocolVersion
+	}
 	cfg.Logger = cfg.Logger.With("listener_id", cfg.ListenerID)
 }
 
@@ -87,6 +178,39 @@ func ListenAndServe(ctx context.Context, cfg Config) error {
 		cfg.Logger.Warn("no allowlist configured, all targets will be permitted")
 	}
 
+	// Global stream semaphore: caps total in-flight target connections
+	// across all paths (v1 and v2 mux) at MaxConnections. Without a
+	// global cap, a v2 mux session could grow up to MaxConnections
+	// streams per session and multiple sessions would multiply the
+	// budget; this restores v1's "MaxConnections == total target
+	// connections" semantics under v2 multi-session deployments.
+	//
+	// Note: there is also a separate per-rendezvous control-channel cap
+	// (ctrlCfg.MaxConnections below) that limits the number of
+	// concurrent accepted relay WebSockets. In v1 the two caps fire
+	// simultaneously (1 rendezvous = 1 target stream). In v2 mux they
+	// are decoupled: with N senders each opening MuxSessions
+	// rendezvous, the control cap may bind first (rejecting new
+	// rendezvous) even when streamSem has idle slots. Both caps are
+	// kept at MaxConnections as a conservative default — operators
+	// running large mux-aware deployments may want to size them
+	// independently in future.
+	streamSem := newConnSemaphore(cfg.MaxConnections)
+
+	// pendingSem bounds the concurrent mux streams that have been
+	// accepted but have not yet completed envelope validation. Without
+	// this, a malicious peer could open many smux streams that
+	// withhold the per-stream envelope, each pinning a goroutine + a
+	// read-deadline timer for up to muxStreamReadTimeout. Sized at 2x
+	// MaxConnections to give envelope-pending streams headroom over the
+	// active-stream cap (so legitimate slow envelopes can't starve the
+	// active path). Bypassed when MaxConnections is 0 (unlimited).
+	pendingMax := 0
+	if cfg.MaxConnections > 0 {
+		pendingMax = cfg.MaxConnections * 2
+	}
+	pendingSem := newConnSemaphore(pendingMax)
+
 	ctrlCfg := relay.ControlConfig{
 		Endpoint:       cfg.Endpoint,
 		EntityPath:     cfg.EntityPath,
@@ -96,7 +220,7 @@ func ListenAndServe(ctx context.Context, cfg Config) error {
 		Logger:         cfg.Logger,
 		RenewInterval:  cfg.RenewInterval,
 		Handler: func(ctx context.Context, ws *websocket.Conn) {
-			handleConnection(ctx, ws, cfg)
+			handleConnection(ctx, ws, cfg, streamSem, pendingSem)
 		},
 	}
 	ctrlCfg.OnConnect = func() { cfg.Metrics.SetControlChannelConnected(true) }
@@ -105,10 +229,18 @@ func ListenAndServe(ctx context.Context, cfg Config) error {
 	return relay.ListenAndServe(ctx, ctrlCfg)
 }
 
-func handleConnection(ctx context.Context, ws *websocket.Conn, cfg Config) {
+func handleConnection(ctx context.Context, ws *websocket.Conn, cfg Config, streamSem, pendingSem *connSemaphore) {
 	logger := cfg.Logger
+	// Defensive default: tests call handleConnection directly,
+	// bypassing applyDefaults. Zero is normalized to the production
+	// default so an uninitialised Config still dispatches v2 the way
+	// ListenAndServe would.
+	if cfg.MaxProtocolVersion == 0 {
+		cfg.MaxProtocolVersion = DefaultListenerMaxProtocolVersion
+	}
 
-	// Read the connect envelope with a timeout.
+	// Read the first message with a timeout. Both v1 and v2 senders open
+	// with a single text JSON message; only the contents differ.
 	readCtx, readCancel := context.WithTimeout(ctx, cfg.ConnectTimeout)
 	defer readCancel()
 	_, data, err := ws.Read(readCtx)
@@ -122,6 +254,31 @@ func handleConnection(ctx context.Context, ws *websocket.Conn, cfg Config) {
 		return
 	}
 
+	// Forward-compatible dispatch: parse as FirstMessage first to learn the
+	// version/mode, then re-parse as the appropriate concrete type. JSON's
+	// extra-field tolerance means a v1 ConnectEnvelope and a v2 MuxHandshake
+	// both decode into FirstMessage cleanly.
+	var first protocol.FirstMessage
+	if err := json.Unmarshal(data, &first); err != nil {
+		logger.Warn("invalid envelope", "error", err)
+		_ = sendResponse(ctx, ws, cfg, false, "invalid envelope")
+		cfg.Metrics.ConnectionError("listener", metrics.ReasonEnvelopeError)
+		return
+	}
+
+	if first.IsMux() {
+		if cfg.MaxProtocolVersion < protocol.MuxVersion {
+			logger.Info("rejecting v2 mux handshake (listener max protocol version)",
+				"max", cfg.MaxProtocolVersion)
+			_ = sendResponse(ctx, ws, cfg, false, "unsupported protocol version")
+			cfg.Metrics.ConnectionError("listener", metrics.ReasonEnvelopeError)
+			return
+		}
+		handleMuxSession(ctx, ws, cfg, streamSem, pendingSem)
+		return
+	}
+
+	// v1 path.
 	var env protocol.ConnectEnvelope
 	if err := json.Unmarshal(data, &env); err != nil {
 		logger.Warn("invalid envelope", "error", err)
@@ -135,6 +292,14 @@ func handleConnection(ctx context.Context, ws *websocket.Conn, cfg Config) {
 		cfg.Metrics.ConnectionError("listener", metrics.ReasonEnvelopeError)
 		return
 	}
+	handleSingleConnection(ctx, ws, env, cfg, streamSem)
+}
+
+// handleSingleConnection runs the v1 path: one rendezvous WebSocket, one
+// target connection, one bidirectional bridge.
+func handleSingleConnection(ctx context.Context, ws *websocket.Conn, env protocol.ConnectEnvelope, cfg Config, streamSem *connSemaphore) {
+	logger := cfg.Logger
+
 	if env.Target == "" {
 		_ = sendResponse(ctx, ws, cfg, false, "missing target")
 		cfg.Metrics.ConnectionError("listener", metrics.ReasonEnvelopeError)
@@ -151,13 +316,23 @@ func handleConnection(ctx context.Context, ws *websocket.Conn, cfg Config) {
 
 	logger.Info("connection requested", "target", env.Target)
 
-	// Check allowlist.
 	if len(cfg.AllowList) > 0 && !isAllowed(env.Target, cfg.AllowList) {
 		logger.Warn("target not allowed", "target", env.Target)
 		_ = sendResponse(ctx, ws, cfg, false, "target not allowed")
 		cfg.Metrics.ConnectionError("listener", metrics.ReasonAllowlistRejected)
 		return
 	}
+
+	// Reserve a slot in the listener-wide stream cap before dialing.
+	// This holds the slot for the entire bridge lifetime, mirroring the
+	// per-stream accounting on the v2 path.
+	if !streamSem.tryAcquire() {
+		logger.Warn("listener at max concurrent streams, rejecting connection")
+		_ = sendResponse(ctx, ws, cfg, false, "listener at max concurrent streams")
+		cfg.Metrics.ConnectionError("listener", metrics.ReasonListenerAtCapacity)
+		return
+	}
+	defer streamSem.release()
 
 	// Dial the target.
 	dial := cfg.dialContext
@@ -180,7 +355,6 @@ func handleConnection(ctx context.Context, ws *websocket.Conn, cfg Config) {
 	}
 	defer conn.Close() //nolint:errcheck // best-effort cleanup
 
-	// Set TCP keepalive.
 	relay.SetTCPKeepAlive(conn, cfg.TCPKeepAlive)
 
 	// Send success response.
@@ -212,23 +386,332 @@ func handleConnection(ctx context.Context, ws *websocket.Conn, cfg Config) {
 	logger.Debug("bridge ended", attrs...)
 }
 
-func sendResponse(ctx context.Context, ws *websocket.Conn, cfg Config, ok bool, errMsg string) error {
-	return sendResponseWithCode(ctx, ws, cfg, ok, errMsg, "")
-}
-
-// sendResponseWithCode is the variant of sendResponse that includes a
-// machine-readable code so the sender can map listener-side dial
-// failures onto client-visible status (e.g. SOCKS5 REP bytes).
-func sendResponseWithCode(ctx context.Context, ws *websocket.Conn, cfg Config, ok bool, errMsg, code string) error {
-	resp := protocol.ConnectResponse{
+// newConnectResponse builds a protocol.ConnectResponse stamped with the
+// listener's ListenerID. Both transport paths (WebSocket-framed v1 via
+// sendResponse* and stream-framed v2 via WriteStreamResponse) go through
+// this helper so every response, including capacity-reject and dial-fail
+// rejections, carries the listener correlation ID.
+func newConnectResponse(cfg Config, ok bool, errMsg, code string) protocol.ConnectResponse {
+	return protocol.ConnectResponse{
 		Version:    protocol.CurrentVersion,
 		OK:         ok,
 		Error:      errMsg,
 		Code:       code,
 		ListenerID: cfg.ListenerID,
 	}
-	data, _ := json.Marshal(resp) // simple struct, cannot fail
-	return ws.Write(ctx, websocket.MessageText, data)
+}
+
+func sendResponse(ctx context.Context, ws *websocket.Conn, cfg Config, ok bool, errMsg string) error {
+	return sendResponseWithCode(ctx, ws, cfg, ok, errMsg, "")
+}
+
+// handleMuxSession runs the v2 path: one rendezvous WebSocket carries an
+// smux session; each accepted stream is an independent target connection.
+//
+// Streams are gated on two semaphores:
+//   - pendingSem (envelope-read DoS bound) is acquired in the accept loop
+//     before dispatching to handleMuxStream; rejected if at cap.
+//   - streamSem (MaxConnections cap on in-flight target connections) is
+//     acquired inside handleMuxStream AFTER envelope validation + allowlist
+//     so that slow/withheld envelopes cannot starve legitimate connections
+//     of the active-stream budget.
+func handleMuxSession(ctx context.Context, ws *websocket.Conn, cfg Config, streamSem, pendingSem *connSemaphore) {
+	logger := cfg.Logger
+	logger.Info("mux session started")
+
+	// Acknowledge mux support. From this point the WS is owned by smux —
+	// nothing else may read/write/ping it directly.
+	if err := sendResponse(ctx, ws, cfg, true, ""); err != nil {
+		logger.Warn("failed to confirm mux", "error", err)
+		return
+	}
+
+	netConn := websocket.NetConn(ctx, ws, websocket.MessageBinary)
+	sess, err := smux.Server(netConn, muxconfig.SmuxConfig())
+	if err != nil {
+		logger.Warn("smux server creation failed", "error", err)
+		return
+	}
+
+	// Defer ordering: registered as (wg.Wait, sess.Close); LIFO means
+	// sess.Close runs FIRST on return and wg.Wait runs second. Closing
+	// the smux session unblocks any in-flight Read/Write/Close on its
+	// streams (they observe sess.die and return io.ErrClosedPipe
+	// immediately), so wg drains promptly. This matters for the
+	// rejectSem-exhaustion teardown branch in the accept loop below,
+	// where we deliberately return to tear the session down; for
+	// natural exits (peer-initiated session close) the session is
+	// already closed when the accept loop returns, so order is a
+	// no-op.
+	var wg sync.WaitGroup
+	defer wg.Wait()
+	defer sess.Close() //nolint:errcheck // best-effort cleanup
+
+	// rejectSem caps concurrent in-flight rejection writers so a peer
+	// that back-pressures smux's transport can't accumulate one
+	// goroutine per overflow stream. See muxRejectInflightCap for the
+	// rationale.
+	rejectSem := make(chan struct{}, muxRejectInflightCap)
+
+	for {
+		stream, err := sess.AcceptStream()
+		if err != nil {
+			if ctx.Err() != nil || sess.IsClosed() {
+				logger.Debug("mux session ended")
+			} else {
+				logger.Warn("mux accept failed", "error", err)
+			}
+			return
+		}
+
+		if !pendingSem.tryAcquire() {
+			logger.Warn("listener at envelope-pending cap, rejecting mux stream")
+			cfg.Metrics.ConnectionError("listener", metrics.ReasonListenerAtCapacity)
+			// Dispatch the rejection write + close to a goroutine so a
+			// misbehaving peer that fills smux's per-stream send window
+			// (or stops reading) cannot stall the accept loop. Bounded
+			// by muxStreamWriteTimeout per write and rejectSem
+			// (muxRejectInflightCap) across concurrent writers; tracked
+			// via wg so session shutdown drains in-flight rejections.
+			// If rejectSem is full, tear down the entire mux session —
+			// see muxRejectInflightCap for the rationale.
+			select {
+			case rejectSem <- struct{}{}:
+				wg.Add(1)
+				go func() {
+					defer wg.Done()
+					defer func() { <-rejectSem }()
+					defer stream.Close() //nolint:errcheck // best-effort cleanup
+					writeMuxRejection(stream, cfg, "listener busy")
+				}()
+			default:
+				logger.Warn("listener rejection cap exhausted, tearing down mux session")
+				return
+			}
+			continue
+		}
+
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			defer stream.Close() //nolint:errcheck // best-effort cleanup
+			handleMuxStream(ctx, stream, cfg, streamSem, pendingSem)
+		}()
+	}
+}
+
+// newConnSemaphore is the listener-local copy of relay.newConnSemaphore;
+// it accepts max==0 as "unlimited" to preserve MaxConnections semantics.
+// We don't reach into relay.connSemaphore because it's unexported.
+type connSemaphore struct {
+	ch chan struct{}
+}
+
+func newConnSemaphore(max int) *connSemaphore {
+	if max <= 0 {
+		return &connSemaphore{}
+	}
+	return &connSemaphore{ch: make(chan struct{}, max)}
+}
+
+// tryAcquire is non-blocking: it returns true if a slot was reserved,
+// false if the semaphore is at capacity. Callers that want to reject
+// fast at capacity (the only use today) should call this directly.
+func (s *connSemaphore) tryAcquire() bool {
+	if s.ch == nil {
+		return true
+	}
+	select {
+	case s.ch <- struct{}{}:
+		return true
+	default:
+		return false
+	}
+}
+
+func (s *connSemaphore) release() {
+	if s.ch == nil {
+		return
+	}
+	<-s.ch
+}
+
+// held returns the number of slots currently acquired. It exists for
+// tests that need to synchronize on semaphore state instead of
+// fixed-duration sleeps (a sleep can falsely pass on a slow listener
+// without exercising the intended pending state).
+func (s *connSemaphore) held() int {
+	if s.ch == nil {
+		return 0
+	}
+	return len(s.ch)
+}
+
+// handleMuxStream handles one stream of an established mux session. It uses
+// length-prefixed framing for the per-stream envelope exchange to avoid
+// json.Decoder over-read into immediately-following bytes (e.g. server
+// banners like SSH or SMTP, or client-first startup payloads).
+//
+// The caller (handleMuxSession) acquires pendingSem before dispatching.
+// This function is responsible for releasing it — either on early return
+// (envelope/version/target/allowlist failure) or as soon as the active-
+// stream slot (streamSem, the MaxConnections cap) is acquired. The
+// streamSem reservation is held for the entire bridge lifetime so that
+// MaxConnections genuinely bounds in-flight target connections; envelope-
+// pending streams do not consume from it.
+func handleMuxStream(ctx context.Context, stream *smux.Stream, cfg Config, streamSem, pendingSem *connSemaphore) {
+	logger := cfg.Logger
+
+	pendingHeld := true
+	defer func() {
+		if pendingHeld {
+			pendingSem.release()
+		}
+	}()
+
+	_ = stream.SetReadDeadline(time.Now().Add(muxStreamReadTimeout))
+	env, err := protocol.ReadStreamEnvelope(stream)
+	_ = stream.SetReadDeadline(time.Time{})
+	if err != nil {
+		logger.Warn("mux stream: failed to read envelope", "error", err)
+		cfg.Metrics.ConnectionError("listener", metrics.ReasonEnvelopeError)
+		return
+	}
+	if env.Version != protocol.CurrentVersion {
+		logger.Warn("mux stream: unsupported version", "version", env.Version)
+		writeMuxRejection(stream, cfg, "unsupported protocol version")
+		cfg.Metrics.ConnectionError("listener", metrics.ReasonEnvelopeError)
+		return
+	}
+
+	// Bind the sender-minted bridge correlation ID onto the per-stream
+	// logger so every log line on this listener for this bridge carries
+	// the same value the sender logs against. An empty value indicates
+	// a pre-P5 sender on the mux path; we bind it anyway so operators
+	// see explicit evidence of mixed-version traffic rather than a
+	// silently absent attribute.
+	logger = logger.With("bridge_id", env.BridgeID)
+
+	if env.Target == "" {
+		writeMuxRejection(stream, cfg, "missing target")
+		cfg.Metrics.ConnectionError("listener", metrics.ReasonEnvelopeError)
+		return
+	}
+
+	if len(cfg.AllowList) > 0 && !isAllowed(env.Target, cfg.AllowList) {
+		logger.Warn("mux stream: target not allowed", "target", env.Target)
+		writeMuxRejection(stream, cfg, "target not allowed")
+		cfg.Metrics.ConnectionError("listener", metrics.ReasonAllowlistRejected)
+		return
+	}
+
+	// Acquire the active-stream slot AFTER envelope validation and
+	// allowlist enforcement. This way slow/withheld envelopes (gated
+	// by pendingSem) cannot consume MaxConnections budget; only
+	// connections that are actually about to dial a target do.
+	if !streamSem.tryAcquire() {
+		logger.Warn("mux stream: listener at max concurrent streams, rejecting", "target", env.Target)
+		writeMuxRejection(stream, cfg, "listener at max concurrent streams")
+		cfg.Metrics.ConnectionError("listener", metrics.ReasonListenerAtCapacity)
+		return
+	}
+	defer streamSem.release()
+
+	// We're past the envelope-pending phase — free the pendingSem slot
+	// so another stream can start its envelope read while this one
+	// occupies an active-stream slot for the bridge lifetime.
+	pendingSem.release()
+	pendingHeld = false
+
+	logger.Info("connection requested", "target", env.Target)
+
+	// Dial the target via the same seam used by the v1 path so tests
+	// can stub one entry point for both transports.
+	dial := cfg.dialContext
+	if dial == nil {
+		dialer := &net.Dialer{Timeout: cfg.ConnectTimeout}
+		dial = dialer.DialContext
+	}
+	dialCtx, cancel := context.WithTimeout(ctx, cfg.ConnectTimeout)
+	defer cancel()
+
+	dialStart := time.Now()
+	conn, err := dial(dialCtx, "tcp", env.Target)
+	cfg.Metrics.ObserveDialDuration("listener", time.Since(dialStart).Seconds())
+	if err != nil {
+		code := classifyDialError(err)
+		logger.Warn("dial target failed", "target", env.Target, "error", err, "code", code)
+		writeMuxRejectionWithCode(stream, cfg, "connection failed", code)
+		cfg.Metrics.ConnectionError("listener", metrics.DialReason(err, metrics.ReasonDialFailed))
+		return
+	}
+	defer conn.Close() //nolint:errcheck // best-effort cleanup
+
+	relay.SetTCPKeepAlive(conn, cfg.TCPKeepAlive)
+
+	// Bound the success-response write so a peer that fills smux's
+	// send window cannot pin this goroutine + its streamSem slot
+	// before the bridge takes over. Clear the deadline once the OK
+	// is on the wire so the bridge's own deadline logic owns the
+	// stream from here on.
+	_ = stream.SetWriteDeadline(time.Now().Add(muxStreamWriteTimeout))
+	if err := protocol.WriteStreamResponse(stream, newConnectResponse(cfg, true, "", "")); err != nil {
+		logger.Warn("mux stream: failed to send response", "error", err)
+		return
+	}
+	_ = stream.SetWriteDeadline(time.Time{})
+
+	result, bridgeErr := cfg.Metrics.TrackedStreamBridge(ctx, stream, conn, "listener", env.Target)
+	attrs := []any{
+		"target", env.Target,
+		"cause", result.EndCause,
+		"tcp_to_ws", result.Stats.TCPToWS,
+		"ws_to_tcp", result.Stats.WSToTCP,
+	}
+	if bridgeErr != nil {
+		attrs = append(attrs, "error", bridgeErr)
+	}
+	if result.TCPToWS != nil {
+		attrs = append(attrs, "tcp_to_ws_err", result.TCPToWS)
+	}
+	if result.WSToTCP != nil {
+		attrs = append(attrs, "ws_to_tcp_err", result.WSToTCP)
+	}
+	logger.Debug("bridge ended", attrs...)
+}
+
+// writeMuxRejection writes a non-OK ConnectResponse on a per-stream
+// rejection path, capped by muxStreamWriteTimeout. Without the
+// deadline, a peer that stops reading (or fills smux's per-stream
+// send window) can pin the calling goroutine — and, on the accept
+// loop's fast-reject path, the accept loop itself — until the smux
+// session closes. Errors are intentionally ignored: the caller is
+// already on a rejection path and the stream will be closed
+// immediately after this returns.
+func writeMuxRejection(stream *smux.Stream, cfg Config, errMsg string) {
+	writeMuxRejectionWithCode(stream, cfg, errMsg, "")
+}
+
+// writeMuxRejectionWithCode is the variant of writeMuxRejection that
+// includes a machine-readable code so the sender can map listener-side
+// dial failures onto client-visible status (e.g. SOCKS5 REP bytes).
+// Used on the v2 dial-failure path so that error-code propagation
+// reaches mux-mode senders just like v1 senders. The response carries
+// cfg.ListenerID via newConnectResponse so rejection bookkeeping on
+// the sender side can correlate which listener answered.
+func writeMuxRejectionWithCode(stream *smux.Stream, cfg Config, errMsg, code string) {
+	_ = stream.SetWriteDeadline(time.Now().Add(muxStreamWriteTimeout))
+	_ = protocol.WriteStreamResponse(stream, newConnectResponse(cfg, false, errMsg, code))
+}
+
+// sendResponseWithCode is the variant of sendResponse that includes a
+// machine-readable code so the sender can map listener-side dial
+// failures onto client-visible status (e.g. SOCKS5 REP bytes).
+func sendResponseWithCode(ctx context.Context, ws *websocket.Conn, cfg Config, ok bool, errMsg, code string) error {
+	data, _ := json.Marshal(newConnectResponse(cfg, ok, errMsg, code)) // simple struct, cannot fail
+	writeCtx, cancel := context.WithTimeout(ctx, listenerControlWriteTimeout)
+	defer cancel()
+	return ws.Write(writeCtx, websocket.MessageText, data)
 }
 
 // classifyDialError maps a net.Dial error to one of the protocol Code

--- a/internal/listener/listener_test.go
+++ b/internal/listener/listener_test.go
@@ -18,7 +18,9 @@ import (
 
 	"github.com/coder/websocket"
 	"github.com/philsphicas/aztunnel/internal/metrics"
+	"github.com/philsphicas/aztunnel/internal/muxconfig"
 	"github.com/philsphicas/aztunnel/internal/protocol"
+	"github.com/xtaci/smux"
 )
 
 func TestIsAllowed(t *testing.T) {
@@ -400,6 +402,33 @@ func TestHandleConnection_FailurePathsCarryListenerID(t *testing.T) {
 			wantOK:  false,
 			wantErr: "connection failed",
 		},
+		{
+			// MaxProtocolVersion=1 makes the listener reject v2
+			// MuxHandshakes with the same wire shape a v1-only
+			// listener would emit. The sender's
+			// isMuxUnsupportedRejection recognises this exact string
+			// and falls back to the v1 path. Locking the response
+			// shape here protects the rolling-deployment scenario
+			// from a silent rename of the rejection string.
+			name: "reject-mux-when-listener-pinned-to-v1",
+			cfg: Config{
+				ConnectTimeout:     5 * time.Second,
+				TCPKeepAlive:       5 * time.Second,
+				Logger:             slog.New(slog.NewTextHandler(io.Discard, nil)),
+				Metrics:            metrics.New(),
+				ListenerID:         listenerID,
+				MaxProtocolVersion: 1,
+			},
+			send: func(ctx context.Context, ws *websocket.Conn) error {
+				data, _ := json.Marshal(protocol.MuxHandshake{
+					Version: protocol.MuxVersion,
+					Mode:    protocol.MuxMode,
+				})
+				return ws.Write(ctx, websocket.MessageText, data)
+			},
+			wantOK:  false,
+			wantErr: "unsupported protocol version",
+		},
 	}
 
 	for _, tt := range tests {
@@ -452,7 +481,13 @@ func driveCustomHandshake(t *testing.T, cfg Config, send func(ctx context.Contex
 		}
 		// handleConnection takes ownership of the ws and closes
 		// internal state on return.
-		handleConnection(r.Context(), ws, cfg)
+		streamSem := newConnSemaphore(cfg.MaxConnections)
+		pendingMax := 0
+		if cfg.MaxConnections > 0 {
+			pendingMax = cfg.MaxConnections * 2
+		}
+		pendingSem := newConnSemaphore(pendingMax)
+		handleConnection(r.Context(), ws, cfg, streamSem, pendingSem)
 	}))
 	defer srv.Close()
 
@@ -510,7 +545,13 @@ func runDialFailureHandler(t *testing.T, target string,
 			return
 		}
 		defer ws.CloseNow() //nolint:errcheck // best-effort cleanup
-		handleConnection(r.Context(), ws, cfg)
+		streamSem := newConnSemaphore(cfg.MaxConnections)
+		pendingMax := 0
+		if cfg.MaxConnections > 0 {
+			pendingMax = cfg.MaxConnections * 2
+		}
+		pendingSem := newConnSemaphore(pendingMax)
+		handleConnection(r.Context(), ws, cfg, streamSem, pendingSem)
 	}))
 	t.Cleanup(srv.Close)
 
@@ -611,5 +652,819 @@ func assertDialFailureLog(t *testing.T, logs, target, code string) {
 	}
 	if !strings.Contains(hit, want) {
 		t.Fatalf("dial-failure log missing %q:\n%s", want, hit)
+	}
+}
+
+// --- v2 mux path tests ---
+
+// muxTestRig wires a smux client/server pair over a TCP socket pair,
+// runs handleMuxSession on the server side, and returns the client
+// session so tests can OpenStream + drive the envelope exchange
+// directly. The returned cancel tears the rig down.
+//
+// TCP socket pair (not net.Pipe): smux relies on the transport
+// buffering small frames (SYN/FIN/keepalive) so multiple streams can
+// be opened without head-of-line blocking. net.Pipe is strictly
+// synchronous and stalls smux in subtle ways.
+type muxTestRig struct {
+	clientSess *smux.Session
+	cancel     context.CancelFunc
+	wg         *sync.WaitGroup
+	cfg        Config
+	streamSem  *connSemaphore
+	pendingSem *connSemaphore
+}
+
+func newMuxTestRig(t *testing.T, cfg Config) *muxTestRig {
+	t.Helper()
+
+	if cfg.ConnectTimeout == 0 {
+		cfg.ConnectTimeout = 5 * time.Second
+	}
+	if cfg.TCPKeepAlive == 0 {
+		cfg.TCPKeepAlive = 30 * time.Second
+	}
+	if cfg.Logger == nil {
+		cfg.Logger = slog.New(slog.NewTextHandler(io.Discard, nil))
+	}
+
+	// Use a TCP socket pair rather than net.Pipe: smux relies on the
+	// transport buffering small frames (SYN/FIN/keepalive) so multiple
+	// streams can be opened without head-of-line blocking. net.Pipe is
+	// strictly synchronous and stalls smux in subtle ways.
+	clientPipe, serverPipe := tcpSocketPair(t)
+	clientSess, err := smux.Client(clientPipe, muxTestSmuxCfg())
+	if err != nil {
+		t.Fatalf("smux.Client: %v", err)
+	}
+	serverSess, err := smux.Server(serverPipe, muxTestSmuxCfg())
+	if err != nil {
+		t.Fatalf("smux.Server: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	streamSem := newConnSemaphore(cfg.MaxConnections)
+	pendingMax := 0
+	if cfg.MaxConnections > 0 {
+		pendingMax = cfg.MaxConnections * 2
+	}
+	pendingSem := newConnSemaphore(pendingMax)
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		runMuxAcceptLoop(ctx, serverSess, cfg, streamSem, pendingSem)
+	}()
+
+	t.Cleanup(func() {
+		cancel()
+		_ = clientSess.Close()
+		_ = serverSess.Close()
+		_ = clientPipe.Close()
+		_ = serverPipe.Close()
+		wg.Wait()
+	})
+
+	return &muxTestRig{
+		clientSess: clientSess,
+		cancel:     cancel,
+		wg:         &wg,
+		cfg:        cfg,
+		streamSem:  streamSem,
+		pendingSem: pendingSem,
+	}
+}
+
+// waitForPendingSem blocks until the rig's pendingSem reaches the
+// requested holder count, or fails the test if the state isn't
+// observed within timeout. This replaces fixed-duration sleeps that
+// could falsely pass on a slow listener without exercising the
+// intended envelope-pending state.
+func (r *muxTestRig) waitForPendingSem(t *testing.T, want int, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if r.pendingSem.held() == want {
+			return
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+	t.Fatalf("pendingSem.held() = %d, want %d after %s", r.pendingSem.held(), want, timeout)
+}
+
+// runMuxAcceptLoop is the body of handleMuxSession minus the outer ws
+// handshake — letting tests exercise the AcceptStream → handleMuxStream
+// path without faking a websocket. Keep the rejection branch
+// behaviourally identical to handleMuxSession (listener.go's accept
+// loop), including the metric call AND the goroutine dispatch + write
+// deadline on the rejection write, so tests of that branch actually
+// cover the production path.
+func runMuxAcceptLoop(ctx context.Context, sess *smux.Session, cfg Config, streamSem, pendingSem *connSemaphore) {
+	var wg sync.WaitGroup
+	defer wg.Wait()
+	rejectSem := make(chan struct{}, muxRejectInflightCap)
+	for {
+		stream, err := sess.AcceptStream()
+		if err != nil {
+			return
+		}
+		if !pendingSem.tryAcquire() {
+			cfg.Metrics.ConnectionError("listener", metrics.ReasonListenerAtCapacity)
+			select {
+			case rejectSem <- struct{}{}:
+				wg.Add(1)
+				go func() {
+					defer wg.Done()
+					defer func() { <-rejectSem }()
+					defer stream.Close() //nolint:errcheck // test cleanup
+					writeMuxRejection(stream, cfg, "listener busy")
+				}()
+			default:
+				return
+			}
+			continue
+		}
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			defer stream.Close() //nolint:errcheck // test cleanup
+			handleMuxStream(ctx, stream, cfg, streamSem, pendingSem)
+		}()
+	}
+}
+
+func muxTestSmuxCfg() *smux.Config {
+	return muxconfig.SmuxConfig()
+}
+
+// tcpSocketPair returns two connected TCP sockets via a loopback
+// listener — a more faithful substitute for the smux-over-WebSocket
+// transport used in production than net.Pipe (which is fully synchronous
+// and stalls smux's SYN/FIN/keepalive flow).
+func tcpSocketPair(t *testing.T) (net.Conn, net.Conn) {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer ln.Close() //nolint:errcheck // best-effort cleanup
+
+	type result struct {
+		c   net.Conn
+		err error
+	}
+	acceptCh := make(chan result, 1)
+	go func() {
+		c, err := ln.Accept()
+		acceptCh <- result{c, err}
+	}()
+
+	client, err := net.Dial("tcp", ln.Addr().String())
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	res := <-acceptCh
+	if res.err != nil {
+		_ = client.Close()
+		t.Fatalf("accept: %v", res.err)
+	}
+	return client, res.c
+}
+
+func startEchoTarget(t *testing.T) string {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	t.Cleanup(func() { _ = ln.Close() })
+	go func() {
+		for {
+			c, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			go func(c net.Conn) {
+				defer c.Close() //nolint:errcheck // test cleanup
+				_, _ = io.Copy(c, c)
+			}(c)
+		}
+	}()
+	return ln.Addr().String()
+}
+
+// TestMuxStream_HappyPath_EchoesData verifies the full v2 stream path
+// against a real local target: open a stream, send envelope, expect OK,
+// then bridge bytes through.
+func TestMuxStream_HappyPath_EchoesData(t *testing.T) {
+	target := startEchoTarget(t)
+	rig := newMuxTestRig(t, Config{
+		MaxConnections: 10,
+		// nil allowlist → all targets allowed (test-only mode)
+	})
+
+	stream, err := rig.clientSess.OpenStream()
+	if err != nil {
+		t.Fatalf("OpenStream: %v", err)
+	}
+	defer stream.Close() //nolint:errcheck // test cleanup
+
+	if err := protocol.WriteStreamEnvelope(stream, protocol.ConnectEnvelope{
+		Version: protocol.CurrentVersion,
+		Target:  target,
+	}); err != nil {
+		t.Fatalf("WriteStreamEnvelope: %v", err)
+	}
+	resp, err := protocol.ReadStreamResponse(stream)
+	if err != nil {
+		t.Fatalf("ReadStreamResponse: %v", err)
+	}
+	if !resp.OK {
+		t.Fatalf("response not OK: %q", resp.Error)
+	}
+
+	const payload = "hello mux\n"
+	if _, err := stream.Write([]byte(payload)); err != nil {
+		t.Fatalf("stream.Write: %v", err)
+	}
+	_ = stream.SetReadDeadline(time.Now().Add(3 * time.Second))
+	got := make([]byte, len(payload))
+	if _, err := io.ReadFull(stream, got); err != nil {
+		t.Fatalf("stream.Read: %v", err)
+	}
+	if string(got) != payload {
+		t.Errorf("echo = %q, want %q", got, payload)
+	}
+}
+
+// TestMuxStream_RejectsMissingTarget covers the case where a sender opens
+// a stream but sends an envelope with no target. The listener must reply
+// with an error (length-prefixed) and not deadlock.
+func TestMuxStream_RejectsMissingTarget(t *testing.T) {
+	rig := newMuxTestRig(t, Config{MaxConnections: 10})
+
+	stream, err := rig.clientSess.OpenStream()
+	if err != nil {
+		t.Fatalf("OpenStream: %v", err)
+	}
+	defer stream.Close() //nolint:errcheck // test cleanup
+
+	if err := protocol.WriteStreamEnvelope(stream, protocol.ConnectEnvelope{
+		Version: protocol.CurrentVersion,
+		Target:  "",
+	}); err != nil {
+		t.Fatalf("WriteStreamEnvelope: %v", err)
+	}
+	_ = stream.SetReadDeadline(time.Now().Add(3 * time.Second))
+	resp, err := protocol.ReadStreamResponse(stream)
+	if err != nil {
+		t.Fatalf("ReadStreamResponse: %v", err)
+	}
+	if resp.OK {
+		t.Fatal("expected rejection")
+	}
+	if !strings.Contains(resp.Error, "missing target") {
+		t.Errorf("error = %q, want it to contain 'missing target'", resp.Error)
+	}
+}
+
+// TestMuxStream_AllowlistEnforced verifies the allowlist applies to every
+// stream individually, not just the outer handshake.
+func TestMuxStream_AllowlistEnforced(t *testing.T) {
+	rig := newMuxTestRig(t, Config{
+		MaxConnections: 10,
+		AllowList:      []string{"10.0.0.1:22"},
+	})
+
+	stream, err := rig.clientSess.OpenStream()
+	if err != nil {
+		t.Fatalf("OpenStream: %v", err)
+	}
+	defer stream.Close() //nolint:errcheck // test cleanup
+
+	if err := protocol.WriteStreamEnvelope(stream, protocol.ConnectEnvelope{
+		Version: protocol.CurrentVersion,
+		Target:  "10.0.0.99:22",
+	}); err != nil {
+		t.Fatalf("WriteStreamEnvelope: %v", err)
+	}
+	_ = stream.SetReadDeadline(time.Now().Add(3 * time.Second))
+	resp, err := protocol.ReadStreamResponse(stream)
+	if err != nil {
+		t.Fatalf("ReadStreamResponse: %v", err)
+	}
+	if resp.OK {
+		t.Fatal("expected rejection by allowlist")
+	}
+	if !strings.Contains(resp.Error, "not allowed") {
+		t.Errorf("error = %q, want 'not allowed'", resp.Error)
+	}
+}
+
+// TestMuxStream_StreamCapRejectsOverflow is the critical regression test
+// for the resource-control gap originally flagged by the rubber-duck and
+// re-flagged by the GPT-5.5/Sonnet reviewers under v2: a single accepted
+// relay WebSocket could spawn unbounded target dials, and multiple mux
+// sessions multiplied the effective budget. The listener-wide stream
+// semaphore (capped at MaxConnections) must reject streams beyond the
+// cap regardless of how many mux sessions are sharing it.
+//
+// We hold one stream open (bridging to a live target), then open a second
+// stream which should be rejected with "at max concurrent streams" after
+// completing envelope/allowlist validation (the cap is now acquired
+// post-envelope, so the second stream must send a valid envelope before
+// it reaches the streamSem gate).
+func TestMuxStream_StreamCapRejectsOverflow(t *testing.T) {
+	target := startEchoTarget(t)
+	rig := newMuxTestRig(t, Config{
+		MaxConnections: 1, // strict cap
+	})
+
+	// First stream — should succeed and hold its slot open.
+	hold, err := rig.clientSess.OpenStream()
+	if err != nil {
+		t.Fatalf("OpenStream #1: %v", err)
+	}
+	defer hold.Close() //nolint:errcheck // test cleanup
+	if err := protocol.WriteStreamEnvelope(hold, protocol.ConnectEnvelope{
+		Version: protocol.CurrentVersion,
+		Target:  target,
+	}); err != nil {
+		t.Fatalf("WriteStreamEnvelope #1: %v", err)
+	}
+	resp1, err := protocol.ReadStreamResponse(hold)
+	if err != nil {
+		t.Fatalf("ReadStreamResponse #1: %v", err)
+	}
+	if !resp1.OK {
+		t.Fatalf("first stream not OK: %q", resp1.Error)
+	}
+
+	// Second stream — should be rejected. The streamSem gate runs AFTER
+	// envelope/allowlist validation in handleMuxStream, so the client
+	// must send a valid envelope before the rejection is produced.
+	overflow, err := rig.clientSess.OpenStream()
+	if err != nil {
+		t.Fatalf("OpenStream #2: %v", err)
+	}
+	defer overflow.Close() //nolint:errcheck // test cleanup
+	if err := protocol.WriteStreamEnvelope(overflow, protocol.ConnectEnvelope{
+		Version: protocol.CurrentVersion,
+		Target:  target,
+	}); err != nil {
+		t.Fatalf("WriteStreamEnvelope #2: %v", err)
+	}
+	_ = overflow.SetReadDeadline(time.Now().Add(3 * time.Second))
+	resp2, err := protocol.ReadStreamResponse(overflow)
+	if err != nil {
+		t.Fatalf("ReadStreamResponse #2: %v", err)
+	}
+	if resp2.OK {
+		t.Fatal("second stream should have been rejected at the cap")
+	}
+	if !strings.Contains(resp2.Error, "max concurrent streams") {
+		t.Errorf("error = %q, want 'max concurrent streams'", resp2.Error)
+	}
+}
+
+// TestMuxStream_EnvelopePendingDoesNotConsumeStreamCap is the regression
+// test for the TOCTOU fix where pre-fix, MaxConnections slots were
+// reserved BEFORE the per-stream envelope was read or validated, letting
+// a malicious or slow peer hold slots for up to muxStreamReadTimeout
+// without dialing any target. After the fix, streamSem is acquired only
+// after a successful envelope+allowlist check, so envelope-pending
+// streams cannot starve legitimate connections of the active-stream cap.
+func TestMuxStream_EnvelopePendingDoesNotConsumeStreamCap(t *testing.T) {
+	target := startEchoTarget(t)
+	rig := newMuxTestRig(t, Config{
+		MaxConnections: 1, // strict cap
+	})
+
+	// Open a stream but DELAY sending the envelope. Under the old code
+	// this would have already consumed the streamSem slot the moment
+	// the accept loop dispatched the stream. Under the new code, the
+	// slot is only acquired after envelope+allowlist validation.
+	stalled, err := rig.clientSess.OpenStream()
+	if err != nil {
+		t.Fatalf("OpenStream #1 (stalled): %v", err)
+	}
+	defer stalled.Close() //nolint:errcheck // test cleanup
+
+	// Wait for the listener to AcceptStream + dispatch the handler;
+	// the handler is now blocked in ReadStreamEnvelope, holding
+	// pendingSem (streamSem is NOT held yet — that's acquired only
+	// after envelope+allowlist validation).
+	rig.waitForPendingSem(t, 1, 2*time.Second)
+
+	// Open a SECOND stream and send a valid envelope. With
+	// MaxConnections=1, this only works if envelope-pending stream #1
+	// has not consumed the cap.
+	active, err := rig.clientSess.OpenStream()
+	if err != nil {
+		t.Fatalf("OpenStream #2 (active): %v", err)
+	}
+	defer active.Close() //nolint:errcheck // test cleanup
+	if err := protocol.WriteStreamEnvelope(active, protocol.ConnectEnvelope{
+		Version: protocol.CurrentVersion,
+		Target:  target,
+	}); err != nil {
+		t.Fatalf("WriteStreamEnvelope #2: %v", err)
+	}
+	_ = active.SetReadDeadline(time.Now().Add(3 * time.Second))
+	resp, err := protocol.ReadStreamResponse(active)
+	if err != nil {
+		t.Fatalf("ReadStreamResponse #2: %v", err)
+	}
+	if !resp.OK {
+		t.Fatalf("envelope-pending stream consumed the cap; active stream rejected: %q", resp.Error)
+	}
+
+	// Sanity: bridge is live — echo a byte through.
+	if _, err := active.Write([]byte("p")); err != nil {
+		t.Fatalf("write payload: %v", err)
+	}
+	buf := make([]byte, 1)
+	_ = active.SetReadDeadline(time.Now().Add(3 * time.Second))
+	if _, err := active.Read(buf); err != nil {
+		t.Fatalf("read echo: %v", err)
+	}
+	if string(buf) != "p" {
+		t.Errorf("echo = %q, want %q", buf, "p")
+	}
+}
+
+// TestMuxStream_PendingCapRejectsOverflow is the regression test for
+// the envelope-pending DoS protection. With `MaxConnections=1` (so
+// pendingMax=2), opening 2 streams that withhold their envelopes
+// fills `pendingSem`. A 3rd OpenStream must receive a "listener busy"
+// response before being closed by the accept loop, and the cap must
+// not leak — closing the held streams must let a fresh stream proceed.
+func TestMuxStream_PendingCapRejectsOverflow(t *testing.T) {
+	target := startEchoTarget(t)
+	rig := newMuxTestRig(t, Config{
+		MaxConnections: 1, // pendingMax = MaxConnections * 2 = 2
+	})
+
+	// Open 2 streams that withhold their envelopes — they sit in
+	// handleMuxStream blocked on ReadStreamEnvelope, each holding a
+	// pendingSem slot.
+	pending := make([]*smux.Stream, 0, 2)
+	for i := range 2 {
+		s, err := rig.clientSess.OpenStream()
+		if err != nil {
+			t.Fatalf("OpenStream #%d (pending): %v", i, err)
+		}
+		pending = append(pending, s)
+	}
+
+	// Wait until both handlers have dispatched and are blocked in
+	// ReadStreamEnvelope holding their pendingSem slots.
+	rig.waitForPendingSem(t, 2, 2*time.Second)
+
+	// A 3rd OpenStream must be rejected by the accept loop with
+	// "listener busy" before any handler runs (no envelope read).
+	rejected, err := rig.clientSess.OpenStream()
+	if err != nil {
+		t.Fatalf("OpenStream #3 (rejected): %v", err)
+	}
+	defer rejected.Close() //nolint:errcheck // test cleanup
+
+	_ = rejected.SetReadDeadline(time.Now().Add(3 * time.Second))
+	resp, err := protocol.ReadStreamResponse(rejected)
+	if err != nil {
+		t.Fatalf("ReadStreamResponse #3: %v", err)
+	}
+	if resp.OK {
+		t.Fatalf("3rd stream was accepted; expected pendingSem rejection")
+	}
+	if !strings.Contains(resp.Error, "listener busy") {
+		t.Errorf("rejection error = %q, want substring %q", resp.Error, "listener busy")
+	}
+
+	// Close the held streams to free pendingSem — their handlers
+	// should exit (envelope read fails on closed stream) and release
+	// their pendingSem slots.
+	for _, s := range pending {
+		_ = s.Close()
+	}
+	// Wait for the handlers to observe the close and release their
+	// pendingSem slots.
+	rig.waitForPendingSem(t, 0, 2*time.Second)
+
+	// A subsequent stream must now succeed — proving pendingSem is not
+	// leaked by either the rejection path or the closed-pending-stream
+	// path.
+	fresh, err := rig.clientSess.OpenStream()
+	if err != nil {
+		t.Fatalf("OpenStream #4 (after recovery): %v", err)
+	}
+	defer fresh.Close() //nolint:errcheck // test cleanup
+	if err := protocol.WriteStreamEnvelope(fresh, protocol.ConnectEnvelope{
+		Version: protocol.CurrentVersion,
+		Target:  target,
+	}); err != nil {
+		t.Fatalf("WriteStreamEnvelope #4: %v", err)
+	}
+	_ = fresh.SetReadDeadline(time.Now().Add(3 * time.Second))
+	freshResp, err := protocol.ReadStreamResponse(fresh)
+	if err != nil {
+		t.Fatalf("ReadStreamResponse #4: %v", err)
+	}
+	if !freshResp.OK {
+		t.Fatalf("post-recovery stream rejected: %q (pendingSem leaked)", freshResp.Error)
+	}
+}
+
+// TestMuxStream_ListenerHalfCloseToTarget is the regression test for
+// half-close propagation on the listener-side mux path: when the
+// sender CloseWrites the smux stream (e.g. HTTP/1.0, SSH ProxyCommand
+// stdin closure, "send EOF then read response"), the bridge must
+// propagate that to the target conn via CloseWrite so the target
+// observes EOF on its read.
+func TestMuxStream_ListenerHalfCloseToTarget(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	t.Cleanup(func() { _ = ln.Close() })
+
+	// Target accepts, then blocks reading until EOF. If the listener
+	// bridge fails to propagate the smux CloseWrite as a TCP FIN, the
+	// target's io.Copy stays blocked forever and the test times out
+	// on the eofObserved select below.
+	eofObserved := make(chan struct{})
+	go func() {
+		c, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		defer c.Close()               //nolint:errcheck // test cleanup
+		_, _ = io.Copy(io.Discard, c) // returns when listener-side half-closes
+		close(eofObserved)
+	}()
+
+	rig := newMuxTestRig(t, Config{MaxConnections: 10})
+
+	stream, err := rig.clientSess.OpenStream()
+	if err != nil {
+		t.Fatalf("OpenStream: %v", err)
+	}
+	defer stream.Close() //nolint:errcheck // test cleanup
+
+	if err := protocol.WriteStreamEnvelope(stream, protocol.ConnectEnvelope{
+		Version: protocol.CurrentVersion,
+		Target:  ln.Addr().String(),
+	}); err != nil {
+		t.Fatalf("WriteStreamEnvelope: %v", err)
+	}
+	resp, err := protocol.ReadStreamResponse(stream)
+	if err != nil {
+		t.Fatalf("ReadStreamResponse: %v", err)
+	}
+	if !resp.OK {
+		t.Fatalf("envelope rejected: %q", resp.Error)
+	}
+
+	// Send a request body, then half-close the sender → bridge must
+	// CloseWrite the target conn so the target's io.Copy sees EOF.
+	if _, err := stream.Write([]byte("REQUEST")); err != nil {
+		t.Fatalf("write request: %v", err)
+	}
+	if err := stream.CloseWrite(); err != nil {
+		t.Fatalf("CloseWrite stream: %v", err)
+	}
+
+	// The only thing we assert is that the target observed EOF — i.e.
+	// the listener bridge translated stream.CloseWrite() into a
+	// conn.CloseWrite() on the target side. The reverse direction
+	// (response flowing back through the smux stream) is already
+	// exercised by TestMuxStream_HappyPath_EchoesData and friends;
+	// reading here would re-introduce a known smux v1.5.57
+	// tryReadV2/die race on fully-half-closed streams.
+	select {
+	case <-eofObserved:
+	case <-time.After(3 * time.Second):
+		t.Fatal("target did not observe EOF: listener bridge did not propagate half-close from smux stream to target conn")
+	}
+}
+
+// TestConnSemaphore exercises the listener-local connSemaphore in
+// isolation.
+func TestConnSemaphore(t *testing.T) {
+	t.Run("unlimited when max<=0", func(t *testing.T) {
+		s := newConnSemaphore(0)
+		for range 100 {
+			if !s.tryAcquire() {
+				t.Fatal("unlimited semaphore should always acquire")
+			}
+		}
+		// release is a no-op but must not panic.
+		s.release()
+	})
+
+	t.Run("bounded acquire/release", func(t *testing.T) {
+		s := newConnSemaphore(2)
+		if !s.tryAcquire() {
+			t.Fatal("first acquire should succeed")
+		}
+		if !s.tryAcquire() {
+			t.Fatal("second acquire should succeed")
+		}
+		if s.tryAcquire() {
+			t.Fatal("third acquire should fail")
+		}
+		s.release()
+		if !s.tryAcquire() {
+			t.Fatal("acquire after release should succeed")
+		}
+	})
+}
+
+// --- handleConnection dispatch tests ---
+
+// newDispatchTestServer stands up an httptest server that runs the real
+// handleConnection on each incoming WebSocket. It returns the ws:// URL
+// the test client should dial, plus the shared streamSem (so tests can
+// pre-fill it if they want to exercise rejection).
+func newDispatchTestServer(t *testing.T, cfg Config) (string, *connSemaphore) {
+	t.Helper()
+	if cfg.MaxConnections == 0 {
+		cfg.MaxConnections = 10
+	}
+	if cfg.ConnectTimeout == 0 {
+		cfg.ConnectTimeout = 5 * time.Second
+	}
+	if cfg.TCPKeepAlive == 0 {
+		cfg.TCPKeepAlive = 30 * time.Second
+	}
+	if cfg.Logger == nil {
+		cfg.Logger = slog.New(slog.NewTextHandler(io.Discard, nil))
+	}
+	streamSem := newConnSemaphore(cfg.MaxConnections)
+	pendingMax := 0
+	if cfg.MaxConnections > 0 {
+		pendingMax = cfg.MaxConnections * 2
+	}
+	pendingSem := newConnSemaphore(pendingMax)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ws, err := websocket.Accept(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer ws.CloseNow() //nolint:errcheck // test cleanup
+		handleConnection(r.Context(), ws, cfg, streamSem, pendingSem)
+	}))
+	t.Cleanup(srv.Close)
+	return "ws" + strings.TrimPrefix(srv.URL, "http"), streamSem
+}
+
+// TestHandleConnection_RejectsUnsupportedVersion verifies the exact
+// "unsupported protocol version" rejection string that the sender's
+// sticky v1-fallback detector (isMuxUnsupportedRejection) depends on.
+// A regression here silently breaks rolling upgrades from v2 senders to
+// older v1-only listeners.
+func TestHandleConnection_RejectsUnsupportedVersion(t *testing.T) {
+	wsURL, _ := newDispatchTestServer(t, Config{})
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	ws, _, err := websocket.Dial(ctx, wsURL, nil)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer ws.CloseNow() //nolint:errcheck // test cleanup
+
+	env := protocol.ConnectEnvelope{Version: 99, Target: "127.0.0.1:1"}
+	data, err := json.Marshal(env)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if err := ws.Write(ctx, websocket.MessageText, data); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	_, resp, err := ws.Read(ctx)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	var got protocol.ConnectResponse
+	if err := json.Unmarshal(resp, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got.OK {
+		t.Fatal("expected !OK")
+	}
+	if !strings.Contains(got.Error, "unsupported protocol version") {
+		t.Errorf("error = %q, want substring %q", got.Error, "unsupported protocol version")
+	}
+}
+
+// TestHandleConnection_DispatchesV1 verifies that a v1 ConnectEnvelope
+// reaches handleSingleConnection: an OK response is sent and the bridge
+// to a local echo target is established (an end-to-end echo proves
+// dispatch).
+func TestHandleConnection_DispatchesV1(t *testing.T) {
+	target := startEchoTarget(t)
+	wsURL, _ := newDispatchTestServer(t, Config{})
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	ws, _, err := websocket.Dial(ctx, wsURL, nil)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer ws.CloseNow() //nolint:errcheck // test cleanup
+
+	env := protocol.ConnectEnvelope{Version: protocol.CurrentVersion, Target: target}
+	data, err := json.Marshal(env)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if err := ws.Write(ctx, websocket.MessageText, data); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	_, resp, err := ws.Read(ctx)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	var got protocol.ConnectResponse
+	if err := json.Unmarshal(resp, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if !got.OK {
+		t.Fatalf("v1 dispatch failed: %q", got.Error)
+	}
+	// Bridge is now active; echo a payload through.
+	const payload = "hello v1\n"
+	if err := ws.Write(ctx, websocket.MessageBinary, []byte(payload)); err != nil {
+		t.Fatalf("write payload: %v", err)
+	}
+	_, echoed, err := ws.Read(ctx)
+	if err != nil {
+		t.Fatalf("read echo: %v", err)
+	}
+	if string(echoed) != payload {
+		t.Errorf("echo = %q, want %q", echoed, payload)
+	}
+}
+
+// TestHandleConnection_DispatchesV2Mux verifies that a v2 MuxHandshake
+// reaches handleMuxSession: an OK response is sent, the server hands the
+// underlying WebSocket to smux, and a logical stream can be opened. The
+// stream is exercised by sending a malformed envelope and observing the
+// per-stream "unsupported protocol version" reply — that proves we
+// actually reached handleMuxStream, not just sent OK and returned.
+func TestHandleConnection_DispatchesV2Mux(t *testing.T) {
+	wsURL, _ := newDispatchTestServer(t, Config{})
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	ws, _, err := websocket.Dial(ctx, wsURL, nil)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer ws.CloseNow() //nolint:errcheck // test cleanup
+
+	hs := protocol.MuxHandshake{Version: protocol.MuxVersion, Mode: protocol.MuxMode}
+	data, err := json.Marshal(hs)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if err := ws.Write(ctx, websocket.MessageText, data); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	_, resp, err := ws.Read(ctx)
+	if err != nil {
+		t.Fatalf("read handshake response: %v", err)
+	}
+	var got protocol.ConnectResponse
+	if err := json.Unmarshal(resp, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if !got.OK {
+		t.Fatalf("v2 mux dispatch failed: %q", got.Error)
+	}
+	// Server has handed the ws to smux.Server. Complete the smux
+	// handshake on the client side and open a stream.
+	netConn := websocket.NetConn(ctx, ws, websocket.MessageBinary)
+	sess, err := smux.Client(netConn, muxTestSmuxCfg())
+	if err != nil {
+		t.Fatalf("smux.Client: %v", err)
+	}
+	defer sess.Close() //nolint:errcheck // test cleanup
+	stream, err := sess.OpenStream()
+	if err != nil {
+		t.Fatalf("OpenStream: %v", err)
+	}
+	defer stream.Close() //nolint:errcheck // test cleanup
+	_ = stream.SetReadDeadline(time.Now().Add(3 * time.Second))
+	if err := protocol.WriteStreamEnvelope(stream, protocol.ConnectEnvelope{
+		Version: 99,
+		Target:  "127.0.0.1:1",
+	}); err != nil {
+		t.Fatalf("WriteStreamEnvelope: %v", err)
+	}
+	sresp, err := protocol.ReadStreamResponse(stream)
+	if err != nil {
+		t.Fatalf("ReadStreamResponse: %v", err)
+	}
+	if sresp.OK || !strings.Contains(sresp.Error, "unsupported protocol version") {
+		t.Errorf("mux stream response: OK=%v err=%q", sresp.OK, sresp.Error)
 	}
 }

--- a/internal/listener/protocol_version.go
+++ b/internal/listener/protocol_version.go
@@ -1,0 +1,17 @@
+package listener
+
+import "github.com/philsphicas/aztunnel/internal/protocol"
+
+// DefaultListenerMaxProtocolVersion is the default upper bound on the
+// relay protocol version this listener will accept.
+//
+// Stays at protocol.MuxVersion (2) across both 0.4.0 (mux opt-in on
+// the sender side) and 0.5.0 (mux on by default): a listener should
+// always speak the highest version it implements, so a rolling
+// upgrade can land sender-side mux without redeploying listeners.
+//
+// Operators who need to pin a listener fleet back to v1 (e.g. for a
+// v2 emergency rollback) set Config.MaxProtocolVersion = 1, which
+// CLI surface --max-protocol-version=1 binds to. No environment
+// variable binding — see Config.MaxProtocolVersion.
+const DefaultListenerMaxProtocolVersion = protocol.MuxVersion

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -4,6 +4,7 @@ package metrics
 import (
 	"context"
 	"errors"
+	"io"
 	"log/slog"
 	"net"
 	"sync"
@@ -11,6 +12,7 @@ import (
 	"time"
 
 	"github.com/coder/websocket"
+	"github.com/philsphicas/aztunnel/internal/bridgecause"
 	"github.com/philsphicas/aztunnel/internal/relay"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/collectors"
@@ -39,6 +41,39 @@ const (
 	// ReasonDialTimeout because the failure happened before any SYN was
 	// sent; the underlying network may be fine.
 	ReasonDNSTimeout = "dns_timeout"
+	// ReasonListenerAtCapacity is recorded by the listener when an
+	// incoming connection is rejected because the listener has hit
+	// its own capacity cap (streamSem for active target streams, or
+	// pendingSem for envelope-pending mux streams). Distinct from
+	// ReasonRelayFailed (Azure Relay outage) so operators can tell
+	// "we're at our configured limit" apart from "Azure had a
+	// problem" in `aztunnel_connection_errors_total`.
+	ReasonListenerAtCapacity = "listener_at_capacity"
+	// ReasonMuxOpenFailed is the catch-all for non-dial, non-ctx
+	// failures bubbling out of MuxPool.OpenStream (smux setup
+	// failure, mux handshake parse error, listener rejection that
+	// isn't the v1-fallback marker). Dial failures are already
+	// recorded by MuxDialer.connectLocked (which calls DialWithRetry
+	// directly and emits ConnectionError via DialReason itself), and
+	// context cancellation is not a connection error, so neither
+	// path records this reason — callers must filter those out
+	// before recording.
+	ReasonMuxOpenFailed = "mux_open_failed"
+)
+
+// Mux session lifecycle-exit reasons reported via RecordMuxRotation.
+// Despite the "MuxRotation" prefix (kept for label backward
+// compatibility), this group covers all paths that retire a pool
+// session: scheduled / forced rotations, sticky v1-fallback evictions
+// (`unsupported`), open-failure evictions (`open_failed`), and pool
+// shutdown (`pool_closed`). Use these constants to keep label
+// cardinality bounded.
+const (
+	MuxRotationScheduled   = "scheduled"
+	MuxRotationForced      = "force_after_grace"
+	MuxRotationUnsupported = "unsupported"
+	MuxRotationPoolClosed  = "pool_closed"
+	MuxRotationOpenFailed  = "open_failed"
 )
 
 // Metrics holds all Prometheus metrics for aztunnel.
@@ -59,6 +94,12 @@ type Metrics struct {
 	dialDuration       *prometheus.HistogramVec
 	tokenFetchSeconds  *prometheus.HistogramVec
 	tokenFetchTotal    *prometheus.CounterVec
+
+	muxSessionsActive     *prometheus.GaugeVec
+	muxStreamOpenDuration *prometheus.HistogramVec
+	muxSessionAge         *prometheus.HistogramVec
+	muxRotationsTotal     *prometheus.CounterVec
+	muxPoolSaturatedTotal *prometheus.CounterVec
 
 	targetCount atomic.Int64
 	targets     sync.Map // map[string]struct{}
@@ -137,6 +178,41 @@ func New() *Metrics {
 			Name:      "token_fetch_total",
 			Help:      "Count of TokenProvider.GetToken calls by outcome.",
 		}, []string{"provider", "result"}),
+
+		muxSessionsActive: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Namespace: namespace,
+			Name:      "mux_sessions_active",
+			Help:      "Number of currently active persistent mux sessions.",
+		}, []string{"role"}),
+
+		muxStreamOpenDuration: prometheus.NewHistogramVec(prometheus.HistogramOpts{
+			Namespace: namespace,
+			Name:      "mux_stream_open_seconds",
+			Help:      "Time from OpenStream call to smux stream open (pool admission + smux SYN; excludes the per-stream envelope handshake).",
+			Buckets:   []float64{0.0005, 0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5},
+		}, []string{"role"}),
+
+		muxSessionAge: prometheus.NewHistogramVec(prometheus.HistogramOpts{
+			Namespace: namespace,
+			Name:      "mux_session_age_seconds",
+			Help:      "Age of mux pool sessions at lifecycle exit (rotation or eviction). Measured from the pool slot's creation; the underlying relay WebSocket may have been transparently reconnected during the slot's lifetime, so this is slot age, not necessarily WS age.",
+			// Buckets span up to 12h so the default 6h scheduled
+			// rotation falls into a finite bucket (rather than +Inf)
+			// and is observable in the distribution.
+			Buckets: []float64{1, 30, 60, 300, 600, 1800, 3000, 3600, 7200, 10800, 21600, 32400, 43200},
+		}, []string{"role"}),
+
+		muxRotationsTotal: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace: namespace,
+			Name:      "mux_rotations_total",
+			Help:      "Total mux session lifecycle exits (rotations and evictions), by reason: scheduled, force_after_grace, unsupported, pool_closed, open_failed.",
+		}, []string{"role", "reason"}),
+
+		muxPoolSaturatedTotal: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace: namespace,
+			Name:      "mux_pool_saturated_total",
+			Help:      "Total times a caller blocked on a saturated mux pool and gave up.",
+		}, []string{"role"}),
 	}
 
 	reg.MustRegister(
@@ -149,6 +225,11 @@ func New() *Metrics {
 		m.dialDuration,
 		m.tokenFetchSeconds,
 		m.tokenFetchTotal,
+		m.muxSessionsActive,
+		m.muxStreamOpenDuration,
+		m.muxSessionAge,
+		m.muxRotationsTotal,
+		m.muxPoolSaturatedTotal,
 	)
 
 	return m
@@ -285,6 +366,64 @@ func (m *Metrics) SetControlChannelConnected(up bool) {
 	}
 }
 
+// MuxSessionOpened increments the active mux sessions gauge. Safe to
+// call on a nil receiver.
+func (m *Metrics) MuxSessionOpened(role string) {
+	if m == nil {
+		return
+	}
+	m.muxSessionsActive.WithLabelValues(role).Inc()
+}
+
+// MuxSessionClosed decrements the active mux sessions gauge. Safe to
+// call on a nil receiver. Use RecordMuxRotation in addition when the
+// close is a pool-driven rotation (so the age histogram and rotation
+// reason counter are updated).
+func (m *Metrics) MuxSessionClosed(role string) {
+	if m == nil {
+		return
+	}
+	m.muxSessionsActive.WithLabelValues(role).Dec()
+}
+
+// RecordMuxRotation observes the age at which a mux pool session was
+// retired and increments the per-reason lifecycle-exit counter. The
+// "Rotation" in the name is historical; this covers all exit paths
+// (scheduled / forced rotations, sticky v1-fallback evictions,
+// open-failure evictions, and pool shutdown). Age measured from the
+// pool slot's birth — note that MuxDialer can transparently reconnect
+// the underlying WebSocket during a slot's lifetime, so the observed
+// age describes the pool slot, not necessarily the currently active
+// relay WS. Safe to call on a nil receiver.
+func (m *Metrics) RecordMuxRotation(role string, age time.Duration, reason string) {
+	if m == nil {
+		return
+	}
+	m.muxSessionAge.WithLabelValues(role).Observe(age.Seconds())
+	m.muxRotationsTotal.WithLabelValues(role, reason).Inc()
+}
+
+// ObserveMuxStreamOpen records the time from pool.OpenStream entry to
+// smux stream open (pool admission + smux SYN). The per-stream envelope
+// handshake runs after this point and is NOT included in this histogram.
+// Safe to call on a nil receiver.
+func (m *Metrics) ObserveMuxStreamOpen(role string, seconds float64) {
+	if m == nil {
+		return
+	}
+	m.muxStreamOpenDuration.WithLabelValues(role).Observe(seconds)
+}
+
+// MuxPoolSaturated increments the pool-saturation counter, indicating a
+// caller blocked on a full pool and ultimately gave up (ctx expired).
+// Safe to call on a nil receiver.
+func (m *Metrics) MuxPoolSaturated(role string) {
+	if m == nil {
+		return
+	}
+	m.muxPoolSaturatedTotal.WithLabelValues(role).Inc()
+}
+
 // ConnectionTracker records the outcome of a single bridged connection.
 type ConnectionTracker struct {
 	m      *Metrics
@@ -335,4 +474,330 @@ func (m *Metrics) InstrumentedDial(ctx context.Context, endpoint, entityPath str
 		return nil, err
 	}
 	return ws, nil
+}
+
+// closeWriter is implemented by net.TCPConn and smux.Stream. It allows a
+// bridge to signal end-of-stream in one direction without tearing down the
+// other (half-close), which is required by protocols like HTTP/1.0
+// Connection: close, SSH channel close, and SMTP QUIT.
+type closeWriter interface {
+	CloseWrite() error
+}
+
+// closeWriteOrClose calls CloseWrite if available and falls back to Close
+// otherwise. Errors are intentionally swallowed: best-effort signalling
+// after the source has already ended, and the deferred Close in the caller
+// will surface anything that matters.
+func closeWriteOrClose(c io.Closer) {
+	if cw, ok := c.(closeWriter); ok {
+		_ = cw.CloseWrite()
+		return
+	}
+	_ = c.Close()
+}
+
+// streamBridgeBufSize is the per-direction io.Copy buffer used to shuttle
+// bytes between an smux stream and the local target. 64 KiB is large
+// enough that a single read can absorb a meaningful slice of the
+// per-stream smux window (muxconfig.MaxStreamBuffer, currently 1 MiB)
+// while keeping the per-bridge memory footprint tiny — each bridged
+// connection allocates two of these. Don't grow this beyond
+// MaxStreamBuffer; doing so wastes memory without reducing syscalls.
+const streamBridgeBufSize = 64 * 1024
+
+// TrackedStreamBridge bidirectionally copies data between an smux stream
+// (or any net.Conn) and a local target net.Conn while recording connection
+// lifecycle metrics.
+//
+// Unlike TrackedBridge (which is built for a websocket+TCP pair and forces
+// teardown when either side ends), TrackedStreamBridge supports half-close:
+// when one direction sees EOF, it calls CloseWrite() on the destination
+// rather than closing both sides. This preserves protocols that depend on
+// signalling end-of-input while still reading a response (HTTP/1.0, SSH,
+// SMTP, etc.).
+//
+// The returned BridgeResult mirrors TrackedBridge: Stats.TCPToWS /
+// Stats.WSToTCP carry per-direction byte counts (conn→stream / stream→conn
+// respectively), TCPToWS / WSToTCP carry the terminating error of each
+// direction's pump (nil on clean EOF), and the second-return error is the
+// first non-nil pump error preserved for callers that just check err != nil.
+//
+// EndCause carries the bridgecause classification of why the bridge ended,
+// matching v1's relay.Bridge: the first pump exit stamps a cause sentinel
+// (CauseLocalClose for the conn→stream direction, CausePeerClose for the
+// stream→conn direction, CauseTimeout for net.Error.Timeout()) on the
+// bridge ctx via WithCancelCause, and EndCause is resolved from
+// context.Cause(ctx) so a parent cancel-cause (e.g. CauseRenewFailure
+// stamped by the listener's renewLoop) wins over a pump-driven exit.
+//
+// Safe to call on a nil receiver.
+func (m *Metrics) TrackedStreamBridge(ctx context.Context, stream, conn net.Conn, role, target string) (relay.BridgeResult, error) {
+	tracker := m.ConnectionOpened(role, target)
+	start := time.Now()
+	var toRelay, fromRelay atomic.Int64
+	var bridgeErr error
+	defer func() {
+		tracker.Done(time.Since(start).Seconds(), toRelay.Load(), fromRelay.Load(), bridgeErr)
+	}()
+
+	// Capture the caller-supplied ctx so we can distinguish external
+	// cancellation (caller shutting us down) from internal cancellation
+	// (a real per-direction copy error triggering hard teardown). Both
+	// look identical to the inner derived ctx, but only the former
+	// should surface as bridgeErr — the latter is already represented
+	// by the propagated direction error.
+	outerCtx := ctx
+	ctx, cancel := context.WithCancelCause(ctx)
+	// Cancellation cause is first-writer-wins (context.WithCancelCause
+	// semantics). Pumps stamp pump-driven causes via cancel(...) on
+	// hard teardown; this deferred cancel(nil) is a no-op cause-wise
+	// (cancel-with-nil maps to context.Canceled in stdlib but only
+	// takes effect if no prior cancel ran) and exists to release the
+	// cancelCtx resources. EndCause is resolved before this defer
+	// runs and goroutines are joined.
+	defer cancel(nil)
+
+	// Hard teardown if ctx is cancelled externally (e.g. process shutdown).
+	// Half-close cannot rescue a cancelled context; close both ends.
+	//
+	// teardownFired records whether the teardown goroutine actually
+	// closed the endpoints because of ctx cancellation. The post-wait
+	// outerCtx.Err() attribution check below consults it so we don't
+	// flag a clean half-close on both sides as forcibly-cancelled
+	// just because the caller's ctx happened to expire after the
+	// copies completed cleanly.
+	//
+	// Race-resolution: teardownDecision is committed-to from TWO
+	// places — the teardown goroutine on ctx.Done(), and main right
+	// after wg.Wait() returns. First caller wins. If main wins, both
+	// copies have already exited (wg.Wait has returned), so the
+	// teardown's close cannot have caused the exit — teardownFired
+	// stays false, bridge attributes nil. If teardown wins, at least
+	// one copy was still in-flight (main hadn't yet reached the Do),
+	// so the teardown's close DID affect the in-flight data — flag
+	// fires, bridge attributes outerCtx.Err(). The residual race —
+	// teardown winning the Do race in the microsecond window after
+	// copies exhausted their data but before wg.Wait returned — is a
+	// metrics-attribution near-miss only, not a correctness issue.
+	var teardownDecision sync.Once
+	var teardownFired bool // guarded by teardownDecision
+	done := make(chan struct{})
+	teardownDone := make(chan struct{})
+	go func() {
+		defer close(teardownDone)
+		select {
+		case <-ctx.Done():
+			teardownDecision.Do(func() {
+				teardownFired = true
+				_ = stream.Close()
+				_ = conn.Close()
+			})
+		case <-done:
+		}
+	}()
+
+	errc := make(chan error, 2)
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	var toRelayErr, fromRelayErr error
+
+	// firstCause records the bridgecause sentinel for the first pump
+	// to exit. Used on the happy half-close path where neither pump
+	// triggers a hard teardown (so no cancel-with-cause runs and
+	// context.Cause(ctx) returns nil): the recorded sentinel is then
+	// surfaced via EndCause below.
+	//
+	// We cannot stamp via cancel-with-cause on clean EOF — the
+	// teardown goroutine watches ctx.Done() and would fire
+	// immediately, closing the destination and defeating the
+	// CloseWrite-and-drain half-close semantics.
+	var firstCausePtr atomic.Pointer[error]
+	recordCause := func(c error) {
+		if c == nil {
+			return
+		}
+		firstCausePtr.CompareAndSwap(nil, &c)
+	}
+
+	// causeFromPumpExit picks the bridgecause sentinel a pump's exit
+	// stamps. Mirrors relay.causeFromPumpExit's policy adapted to
+	// the mux bridge's symmetric direction names: conn→stream is
+	// local-side (CauseLocalClose), stream→conn is peer-side
+	// (CausePeerClose), net.Error.Timeout() wins as CauseTimeout
+	// regardless of side, context.Canceled / DeadlineExceeded pass
+	// through so bridgecause.Name's stdlib aliasing classifies them.
+	causeFromPumpExit := func(toRelaySide bool, err error) error {
+		if err == nil {
+			if toRelaySide {
+				return bridgecause.CauseLocalClose
+			}
+			return bridgecause.CausePeerClose
+		}
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			return err
+		}
+		var netErr net.Error
+		if errors.As(err, &netErr) && netErr.Timeout() {
+			return bridgecause.CauseTimeout
+		}
+		if toRelaySide {
+			return bridgecause.CauseLocalClose
+		}
+		return bridgecause.CausePeerClose
+	}
+
+	// conn → stream (to_relay)
+	go func() {
+		defer wg.Done()
+		buf := make([]byte, streamBridgeBufSize)
+		n, err := io.CopyBuffer(countingWriter{w: stream, c: &toRelay}, conn, buf)
+		_ = n
+		nerr := normalizeBridgeErr(err)
+		recordCause(causeFromPumpExit(true, nerr))
+		if nerr != nil {
+			// Hard teardown on a real (non-EOF) copy error: cancel
+			// the bridge ctx so the shutdown goroutine closes BOTH
+			// ends. Half-closing only one side can hang the bridge
+			// indefinitely if the opposite direction is idle (e.g.
+			// an interactive protocol with no reverse traffic) —
+			// the mux stream and pool slot would be held until the
+			// pool's ctx eventually expires. Stamp the bridgecause
+			// sentinel via cancel-with-cause so EndCause surfaces
+			// the right label.
+			cancel(causeFromPumpExit(true, nerr))
+		} else {
+			// Source exhausted (clean EOF). Signal end-of-input to
+			// the destination via CloseWrite so half-close-aware
+			// protocols (HTTP/1.0, SSH, SMTP) can drain pending
+			// responses on the reverse direction before tearing
+			// down. Do NOT cancel the bridge ctx: the teardown
+			// goroutine watches ctx.Done() and would close the
+			// destination side, defeating the half-close. The
+			// recordCause above captures the sentinel for EndCause.
+			closeWriteOrClose(stream)
+		}
+		toRelayErr = nerr
+		errc <- nerr
+	}()
+
+	// stream → conn (from_relay)
+	go func() {
+		defer wg.Done()
+		buf := make([]byte, streamBridgeBufSize)
+		n, err := io.CopyBuffer(countingWriter{w: conn, c: &fromRelay}, stream, buf)
+		_ = n
+		nerr := normalizeBridgeErr(err)
+		recordCause(causeFromPumpExit(false, nerr))
+		if nerr != nil {
+			cancel(causeFromPumpExit(false, nerr))
+		} else {
+			closeWriteOrClose(conn)
+		}
+		fromRelayErr = nerr
+		errc <- nerr
+	}()
+
+	wg.Wait()
+
+	// Commit the teardown decision from main BEFORE close(done) so
+	// that a ctx cancellation racing the post-completion path
+	// resolves to "no teardown fired" — main's Do here, runs first,
+	// no-ops the teardown goroutine's eventual Do. This is the half
+	// of the race-resolution comment on teardownDecision.
+	teardownDecision.Do(func() {
+		// teardownFired stays false: both copies have exited
+		// (wg.Wait returned), so any subsequent close from the
+		// teardown goroutine cannot have caused the exit.
+	})
+	close(done)
+	<-teardownDone
+
+	// First non-nil error wins. EOF/closed are normalized to nil.
+	for range 2 {
+		if err := <-errc; err != nil && bridgeErr == nil {
+			bridgeErr = err
+		}
+	}
+	// Attribute external cancellation to bridgeErr ONLY when the
+	// teardown goroutine actually closed the endpoints
+	// (teardownFired is true) AND the outer ctx is what was
+	// cancelled. Without the teardownFired gate, an outerCtx that's
+	// cancelled AFTER both copy goroutines have completed cleanly
+	// (clean half-close on both sides) but BEFORE this check runs
+	// would falsely flag a successful bridge as forcibly-cancelled.
+	if bridgeErr == nil && teardownFired && outerCtx.Err() != nil {
+		bridgeErr = outerCtx.Err()
+	}
+	// Resolve EndCause with v1-parity "first pump exit wins" semantics:
+	//   1. Parent cancel-cause wins when the parent actually cancelled
+	//      (mirrors the bridgeErr attribution above).
+	//   2. Otherwise the first pump's recorded cause wins (matches v1's
+	//      relay.Bridge: the side that ends the bridge owns the cause).
+	//   3. Fall back to context.Cause(ctx) — non-nil only when a pump
+	//      hard-tearndown ran but firstCausePtr was somehow unset (a
+	//      defensive belt-and-braces; firstCausePtr is recorded before
+	//      cancel-with-cause so this branch should be unreachable).
+	//   4. Else unknown.
+	var endCause string
+	switch {
+	case teardownFired && outerCtx.Err() != nil:
+		endCause = bridgecause.Name(context.Cause(outerCtx))
+	default:
+		if ptr := firstCausePtr.Load(); ptr != nil {
+			endCause = bridgecause.Name(*ptr)
+		} else if c := context.Cause(ctx); c != nil {
+			endCause = bridgecause.Name(c)
+		} else {
+			endCause = bridgecause.Name(nil)
+		}
+	}
+	result := relay.BridgeResult{
+		Stats:    relay.BridgeStats{TCPToWS: toRelay.Load(), WSToTCP: fromRelay.Load()},
+		TCPToWS:  toRelayErr,
+		WSToTCP:  fromRelayErr,
+		EndCause: endCause,
+	}
+	return result, bridgeErr
+}
+
+// normalizeBridgeErr maps the "clean EOF / closed network connection"
+// cases to nil so the metrics tracker records success on a clean half-close
+// shutdown. Real I/O errors propagate unchanged.
+//
+// io.ErrUnexpectedEOF is deliberately NOT normalized: it represents a
+// truncated read, not an orderly half-close. Treating it as clean EOF
+// would push the bridge onto the half-close path (CloseWrite on the
+// opposite direction) when it should be on the hard-teardown path, and
+// could hang the bridge if the opposite direction is idle.
+func normalizeBridgeErr(err error) error {
+	if err == nil {
+		return nil
+	}
+	if errors.Is(err, io.EOF) {
+		return nil
+	}
+	if errors.Is(err, io.ErrClosedPipe) {
+		return nil
+	}
+	if errors.Is(err, net.ErrClosed) {
+		return nil
+	}
+	return err
+}
+
+// countingWriter wraps an io.Writer and increments an atomic counter for
+// every byte successfully written. Used by TrackedStreamBridge to record
+// per-direction byte totals without an additional copy.
+type countingWriter struct {
+	w io.Writer
+	c *atomic.Int64
+}
+
+func (cw countingWriter) Write(p []byte) (int, error) {
+	n, err := cw.w.Write(p)
+	if n > 0 {
+		cw.c.Add(int64(n))
+	}
+	return n, err
 }

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -494,6 +495,11 @@ func TestNilMetrics(t *testing.T) {
 	m.ObserveDialDuration("sender", 0.1)
 	m.ObserveTokenFetch("entra", "ok", 0.1)
 	m.SetControlChannelConnected(true)
+	m.MuxSessionOpened("sender")
+	m.MuxSessionClosed("sender")
+	m.RecordMuxRotation("sender", time.Second, MuxRotationScheduled)
+	m.ObserveMuxStreamOpen("sender", 0.01)
+	m.MuxPoolSaturated("sender")
 
 	// Calling Done on a nil *ConnectionTracker must not panic.
 	var nilTracker *ConnectionTracker
@@ -567,4 +573,418 @@ func labelKey(sample *dto.Metric, names ...string) string {
 		parts[i] = values[n]
 	}
 	return strings.Join(parts, "/")
+}
+
+// TestMuxMetrics_Lifecycle verifies the gauge / counter / histogram
+// flow for mux session lifecycle and rotation accounting.
+func TestMuxMetrics_Lifecycle(t *testing.T) {
+	m := New()
+
+	// Two sessions open; one closed normally; one rotated by force.
+	m.MuxSessionOpened("sender")
+	m.MuxSessionOpened("sender")
+	if got := getGauge(t, m.muxSessionsActive, "sender"); got != 2 {
+		t.Errorf("mux_sessions_active{sender} = %v, want 2", got)
+	}
+
+	m.MuxSessionClosed("sender")
+	m.RecordMuxRotation("sender", 50*time.Minute, MuxRotationScheduled)
+	if got := getCounter(t, m.muxRotationsTotal, "sender", MuxRotationScheduled); got != 1 {
+		t.Errorf("mux_rotations_total{sender,scheduled} = %v, want 1", got)
+	}
+
+	m.MuxSessionClosed("sender")
+	m.RecordMuxRotation("sender", 55*time.Minute, MuxRotationForced)
+	if got := getCounter(t, m.muxRotationsTotal, "sender", MuxRotationForced); got != 1 {
+		t.Errorf("mux_rotations_total{sender,forced} = %v, want 1", got)
+	}
+
+	if got := getGauge(t, m.muxSessionsActive, "sender"); got != 0 {
+		t.Errorf("mux_sessions_active{sender} = %v, want 0 after both closed", got)
+	}
+
+	// Histogram observations are written without panicking; verify
+	// total count via Write.
+	dtoH := &dto.Metric{}
+	if err := m.muxSessionAge.WithLabelValues("sender").(prometheus.Histogram).Write(dtoH); err != nil {
+		t.Fatalf("write mux_session_age: %v", err)
+	}
+	if got := dtoH.GetHistogram().GetSampleCount(); got != 2 {
+		t.Errorf("mux_session_age sample count = %d, want 2", got)
+	}
+}
+
+// TestMuxMetrics_StreamOpenAndSaturation verifies the stream-open
+// histogram and pool-saturation counter.
+func TestMuxMetrics_StreamOpenAndSaturation(t *testing.T) {
+	m := New()
+
+	m.ObserveMuxStreamOpen("sender", 0.005)
+	m.ObserveMuxStreamOpen("sender", 0.1)
+	m.MuxPoolSaturated("sender")
+	m.MuxPoolSaturated("sender")
+	m.MuxPoolSaturated("sender")
+
+	dtoH := &dto.Metric{}
+	if err := m.muxStreamOpenDuration.WithLabelValues("sender").(prometheus.Histogram).Write(dtoH); err != nil {
+		t.Fatalf("write mux_stream_open: %v", err)
+	}
+	if got := dtoH.GetHistogram().GetSampleCount(); got != 2 {
+		t.Errorf("mux_stream_open_seconds sample count = %d, want 2", got)
+	}
+
+	if got := getCounter(t, m.muxPoolSaturatedTotal, "sender"); got != 3 {
+		t.Errorf("mux_pool_saturated_total{sender} = %v, want 3", got)
+	}
+}
+
+// halfCloseConn is a net.Pipe-backed conn that records whether CloseWrite
+// was called, so tests can verify half-close semantics without needing a
+// real *net.TCPConn. CloseWrite only records — it does not tear down the
+// underlying pipe, mirroring TCPConn semantics (FIN sent, but local reads
+// remain open).
+type halfCloseConn struct {
+	net.Conn
+	closeWriteCalled int32 // accessed via atomic
+}
+
+func (h *halfCloseConn) CloseWrite() error {
+	atomic.StoreInt32(&h.closeWriteCalled, 1)
+	return nil
+}
+
+func (h *halfCloseConn) sawCloseWrite() bool {
+	return atomic.LoadInt32(&h.closeWriteCalled) == 1
+}
+
+// TestTrackedStreamBridge_HalfCloseOnEOF verifies that when one side of the
+// bridge sees EOF, CloseWrite is called on the OPPOSITE side rather than
+// fully closing the bridge. This is the SSH/HTTP-1.0 use case.
+func TestTrackedStreamBridge_HalfCloseOnEOF(t *testing.T) {
+	t.Parallel()
+
+	// We need 4 endpoints: stream-local / stream-remote, conn-local / conn-remote.
+	// The bridge runs between stream-local and conn-local.
+	streamLocal, streamRemote := net.Pipe()
+	connLocal, connRemote := net.Pipe()
+
+	// Wrap conn-local so we can observe CloseWrite calls.
+	hcConn := &halfCloseConn{Conn: connLocal}
+
+	bridgeDone := make(chan error, 1)
+	go func() {
+		var m *Metrics // nil-safe
+		_, err := m.TrackedStreamBridge(context.Background(),
+			streamLocal, hcConn, "test", "target:80")
+		bridgeDone <- err
+	}()
+
+	// Send a request from the stream side, expect it to arrive on the conn side.
+	want := []byte("REQUEST")
+	if _, err := streamRemote.Write(want); err != nil {
+		t.Fatalf("write request: %v", err)
+	}
+	buf := make([]byte, len(want))
+	if _, err := io.ReadFull(connRemote, buf); err != nil {
+		t.Fatalf("read request: %v", err)
+	}
+	if string(buf) != string(want) {
+		t.Errorf("got %q, want %q", buf, want)
+	}
+
+	// Half-close stream → bridge sees EOF on its read-from-stream side and
+	// should propagate that to conn via CloseWrite.
+	if err := streamRemote.Close(); err != nil {
+		t.Fatalf("close stream-remote: %v", err)
+	}
+
+	// Wait for the bridge to detect EOF and call CloseWrite on conn-local.
+	deadline := time.Now().Add(2 * time.Second)
+	for !hcConn.sawCloseWrite() && time.Now().Before(deadline) {
+		time.Sleep(10 * time.Millisecond)
+	}
+	if !hcConn.sawCloseWrite() {
+		t.Fatal("expected CloseWrite to be called on conn after stream EOF")
+	}
+
+	// Clean up so the bridge can exit.
+	_ = connRemote.Close()
+
+	select {
+	case err := <-bridgeDone:
+		if err != nil {
+			t.Errorf("bridge returned unexpected error: %v", err)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("bridge did not exit")
+	}
+}
+
+// TestTrackedStreamBridge_NoCloseWriter exercises the fallback path: a conn
+// that doesn't implement CloseWriter must still cleanly terminate.
+func TestTrackedStreamBridge_NoCloseWriter(t *testing.T) {
+	t.Parallel()
+
+	streamLocal, streamRemote := net.Pipe()
+	connLocal, connRemote := net.Pipe()
+
+	bridgeDone := make(chan error, 1)
+	go func() {
+		var m *Metrics
+		_, err := m.TrackedStreamBridge(context.Background(),
+			streamLocal, connLocal, "test", "target:80")
+		bridgeDone <- err
+	}()
+
+	// One side EOFs.
+	_ = streamRemote.Close()
+
+	// Bridge falls back to Close on conn-local.
+	deadline := time.Now().Add(2 * time.Second)
+	exited := false
+	for time.Now().Before(deadline) {
+		// connRemote.Read should error once connLocal is closed.
+		_ = connRemote.SetReadDeadline(time.Now().Add(50 * time.Millisecond))
+		buf := make([]byte, 1)
+		if _, err := connRemote.Read(buf); err != nil {
+			if errors.Is(err, io.EOF) || errors.Is(err, net.ErrClosed) || errors.Is(err, io.ErrClosedPipe) {
+				exited = true
+				break
+			}
+			// timeout — keep polling
+		}
+	}
+	_ = connRemote.Close()
+	if !exited {
+		t.Error("conn-local was not closed after stream EOF")
+	}
+
+	select {
+	case <-bridgeDone:
+	case <-time.After(3 * time.Second):
+		t.Fatal("bridge did not exit")
+	}
+}
+
+// TestTrackedStreamBridge_RecordsBytes verifies the metric counters are
+// updated for both directions and a clean close registers as success.
+func TestTrackedStreamBridge_RecordsBytes(t *testing.T) {
+	t.Parallel()
+
+	m := New()
+	streamLocal, streamRemote := net.Pipe()
+	connLocal, connRemote := net.Pipe()
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := m.TrackedStreamBridge(context.Background(),
+			streamLocal, connLocal, "sender", "target:1234")
+		done <- err
+	}()
+
+	want := []byte("PING")
+	go func() {
+		_, _ = streamRemote.Write(want)
+		_ = streamRemote.Close()
+	}()
+	buf := make([]byte, len(want))
+	if _, err := io.ReadFull(connRemote, buf); err != nil {
+		t.Fatalf("read echo: %v", err)
+	}
+	_ = connRemote.Close()
+
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("bridge did not exit")
+	}
+
+	// from_relay = stream → conn = 4 bytes ("PING")
+	from := getCounter(t, m.bytesTotal, "sender", "target:1234", "from_relay")
+	if from < float64(len(want)) {
+		t.Errorf("from_relay bytes = %v, want >=%d", from, len(want))
+	}
+	// One completed connection, success status.
+	total := getCounter(t, m.connectionsTotal, "sender", "target:1234", "success")
+	if total != 1 {
+		t.Errorf("connectionsTotal{success} = %v, want 1", total)
+	}
+}
+
+// TestTrackedStreamBridge_NilReceiver verifies the nil-receiver fast path.
+func TestTrackedStreamBridge_NilReceiver(t *testing.T) {
+	t.Parallel()
+	streamLocal, streamRemote := net.Pipe()
+	connLocal, connRemote := net.Pipe()
+	done := make(chan error, 1)
+	go func() {
+		var m *Metrics
+		_, err := m.TrackedStreamBridge(context.Background(),
+			streamLocal, connLocal, "x", "y")
+		done <- err
+	}()
+	_ = streamRemote.Close()
+	_ = connRemote.Close()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("nil-receiver bridge did not exit")
+	}
+}
+
+// erroringConn wraps a net.Conn but forces Read to return a non-EOF
+// error immediately, simulating a connection reset / TLS error /
+// network glitch on the stream side.
+type erroringConn struct {
+	net.Conn
+}
+
+func (e *erroringConn) Read(p []byte) (int, error) {
+	return 0, fmt.Errorf("simulated connection reset")
+}
+
+// TestTrackedStreamBridge_RealErrorTriggersFullTeardown is the regression
+// test for the hang-on-real-error bug: when one direction's io.CopyBuffer
+// returns a non-EOF error and the opposite direction is parked on Read
+// with no incoming data, the bridge previously called CloseWriteOrClose
+// on only one side and blocked indefinitely in wg.Wait — holding the
+// mux stream and pool slot. CloseWrite on a real TCP / smux conn does
+// NOT tear down the read direction (mirrors FIN, not RST), so direction
+// A's blocked Read was never unblocked.
+//
+// The fix cancels the bridge ctx on any non-EOF error so the shutdown
+// goroutine closes BOTH ends. This test asserts the bridge returns
+// within a bounded time after a stream-side read error.
+func TestTrackedStreamBridge_RealErrorTriggersFullTeardown(t *testing.T) {
+	t.Parallel()
+
+	streamLocal, _ := net.Pipe()
+	connLocal, _ := net.Pipe()
+
+	// halfCloseConn mirrors TCPConn / smux semantics: CloseWrite() is a
+	// no-op signal, the underlying pipe stays open. Without the fix,
+	// direction B's closeWriteOrClose(conn) call resolves to a no-op
+	// here, and direction A's Read on conn never unblocks.
+	hcConn := &halfCloseConn{Conn: connLocal}
+	errStream := &erroringConn{Conn: streamLocal}
+
+	bridgeDone := make(chan error, 1)
+	go func() {
+		var m *Metrics // nil-safe; we don't need recording for this test
+		_, err := m.TrackedStreamBridge(context.Background(),
+			errStream, hcConn, "test", "target:80")
+		bridgeDone <- err
+	}()
+
+	select {
+	case err := <-bridgeDone:
+		if err == nil {
+			t.Error("bridge returned nil error; expected the simulated reset to propagate")
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("bridge did not exit within 3s after a real read error (hang on idle opposite direction)")
+	}
+}
+
+// TestTrackedStreamBridge_OuterCtxCancelRecordsError is the regression
+// test for the outer-context cancellation reporting path: when the
+// caller cancels the bridge ctx (e.g. on listener shutdown), the
+// internal close-on-cancel goroutine tears down both endpoints. Both
+// copy goroutines therefore observe only closed-pipe errors, which
+// normalize to nil. Without explicit propagation, the bridge would
+// then report status="success" for a forcibly-aborted bridge. The fix
+// sets bridgeErr = outerCtx.Err() when bridgeErr would otherwise be
+// nil.
+func TestTrackedStreamBridge_OuterCtxCancelRecordsError(t *testing.T) {
+	t.Parallel()
+
+	streamLocal, streamRemote := net.Pipe()
+	connLocal, connRemote := net.Pipe()
+	t.Cleanup(func() {
+		_ = streamRemote.Close()
+		_ = connRemote.Close()
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	bridgeDone := make(chan error, 1)
+	go func() {
+		var m *Metrics // nil-safe; we only need the error contract
+		_, err := m.TrackedStreamBridge(ctx, streamLocal, connLocal, "test", "target:80")
+		bridgeDone <- err
+	}()
+
+	// Bridge is now parked on Read on both directions. Cancel the
+	// outer ctx → close-on-cancel goroutine closes both endpoints,
+	// io.Copy returns net.ErrClosed which normalizes to nil, then the
+	// outerCtx.Err() check must rescue the cancellation as bridgeErr.
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+
+	select {
+	case err := <-bridgeDone:
+		if err == nil {
+			t.Fatal("bridge returned nil error after outer-ctx cancel; expected ctx.Canceled")
+		}
+		if !errors.Is(err, context.Canceled) {
+			t.Errorf("bridge err = %v, want context.Canceled", err)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("bridge did not exit within 3s after outer-ctx cancel")
+	}
+}
+
+// unexpectedEOFConn returns io.ErrUnexpectedEOF from Read, simulating a
+// truncated read on the stream side (e.g. an smux session that died
+// mid-stream).
+type unexpectedEOFConn struct {
+	net.Conn
+}
+
+func (u *unexpectedEOFConn) Read(p []byte) (int, error) {
+	return 0, io.ErrUnexpectedEOF
+}
+
+// TestTrackedStreamBridge_UnexpectedEOFTriggersFullTeardown is the
+// regression guard for the iter-9 Copilot finding: io.ErrUnexpectedEOF
+// is a truncated read, not an orderly half-close. It MUST trigger the
+// hard-teardown (cancel ctx) path so both endpoints are closed. The
+// half-close path (CloseWrite on the opposite direction only) leaves
+// the opposite direction parked on Read if it's idle — the bridge
+// would then hang holding the mux stream and pool slot.
+func TestTrackedStreamBridge_UnexpectedEOFTriggersFullTeardown(t *testing.T) {
+	t.Parallel()
+
+	streamLocal, _ := net.Pipe()
+	connLocal, _ := net.Pipe()
+
+	// halfCloseConn mirrors TCPConn / smux semantics: CloseWrite() is a
+	// no-op signal that does NOT unblock a parked Read. If the bridge
+	// took the half-close path on ErrUnexpectedEOF, direction A's Read
+	// on this conn would never unblock.
+	hcConn := &halfCloseConn{Conn: connLocal}
+	errStream := &unexpectedEOFConn{Conn: streamLocal}
+
+	bridgeDone := make(chan error, 1)
+	go func() {
+		var m *Metrics // nil-safe
+		_, err := m.TrackedStreamBridge(context.Background(),
+			errStream, hcConn, "test", "target:80")
+		bridgeDone <- err
+	}()
+
+	select {
+	case err := <-bridgeDone:
+		if err == nil {
+			t.Error("bridge returned nil error; ErrUnexpectedEOF must propagate as a real failure")
+		}
+		if !errors.Is(err, io.ErrUnexpectedEOF) {
+			t.Errorf("bridge error = %v, want errors.Is(..., io.ErrUnexpectedEOF) = true", err)
+		}
+		if hcConn.sawCloseWrite() {
+			t.Error("CloseWrite called on opposite side after ErrUnexpectedEOF; hard-teardown path expected (cancel ctx + Close), not half-close")
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("bridge did not exit within 3s after ErrUnexpectedEOF on the stream side (hang on idle opposite direction)")
+	}
 }

--- a/internal/muxconfig/muxconfig.go
+++ b/internal/muxconfig/muxconfig.go
@@ -1,0 +1,55 @@
+// Package muxconfig holds shared smux configuration applied at both ends
+// of an aztunnel mux session. Keeping these settings in one place ensures
+// the sender and listener agree on buffer sizing and keepalive cadence;
+// asymmetric settings can cause subtle window-update stalls.
+package muxconfig
+
+import (
+	"time"
+
+	"github.com/xtaci/smux"
+)
+
+const (
+	// MaxStreamBuffer caps the per-stream receive window. Sized so a
+	// typical Azure Relay path's bandwidth-delay product (RTT in the
+	// tens of ms, single-stream throughput in the low MiB/s) fits
+	// inside one window cycle; smux's 64 KiB default is far below this
+	// BDP and produces SteadyThroughput regressions for any transfer
+	// larger than one window. See docs/mux.md for the math.
+	MaxStreamBuffer = 1 << 20 // 1 MiB
+
+	// MaxReceiveBuffer caps total in-flight bytes per session across
+	// all streams. Sized to absorb a modest fan-out burst (e.g. several
+	// large responses landing simultaneously) without unbounded memory
+	// growth on the receiver. Worst-case per-session memory ceiling on
+	// each side.
+	MaxReceiveBuffer = 16 << 20 // 16 MiB
+
+	// KeepAliveInterval is how often smux sends a NOP frame on an idle
+	// session. Matches the WS-level bridgePingInterval so an idle mux
+	// session and an idle v1 bridge present the same liveness shape to
+	// Azure Relay's ~120 s idle-tear-down timer.
+	KeepAliveInterval = 30 * time.Second
+
+	// KeepAliveTimeout is the smux read-deadline for any incoming
+	// frame; on expiry smux closes the session. Three times the
+	// interval gives two missed pings of headroom before tear-down.
+	KeepAliveTimeout = 90 * time.Second
+)
+
+// SmuxConfig returns a *smux.Config preset with aztunnel's shared
+// settings. The protocol version, keepalive cadence, and buffer sizes
+// must match on both ends; callers should not mutate those fields after
+// calling this. Caller-specific tuning (none today) can be applied to
+// the returned config before handing it to smux.Client / smux.Server.
+func SmuxConfig() *smux.Config {
+	c := smux.DefaultConfig()
+	c.Version = 2
+	c.KeepAliveDisabled = false
+	c.KeepAliveInterval = KeepAliveInterval
+	c.KeepAliveTimeout = KeepAliveTimeout
+	c.MaxStreamBuffer = MaxStreamBuffer
+	c.MaxReceiveBuffer = MaxReceiveBuffer
+	return c
+}

--- a/internal/protocol/envelope.go
+++ b/internal/protocol/envelope.go
@@ -1,12 +1,38 @@
 // Package protocol defines the wire format for the aztunnel relay protocol.
 //
-// Every connection through the relay begins with a single JSON envelope
-// exchange (one text WebSocket message in each direction), followed by
-// raw binary WebSocket frames for data.
+// # v1 (single connection)
+//
+// The sender sends one ConnectEnvelope as a WebSocket text message; the
+// listener replies with one ConnectResponse as a WebSocket text message;
+// from then on the WebSocket carries raw binary frames for data.
+//
+// # v2 (multiplexed)
+//
+// The sender sends a MuxHandshake as a WebSocket text message; the listener
+// replies with a ConnectResponse as a WebSocket text message. The two sides
+// then switch to an smux session over the WebSocket (wrapped as a
+// net.Conn). Each smux stream carries an independent target connection:
+// the sender writes a length-prefixed ConnectEnvelope, the listener writes
+// a length-prefixed ConnectResponse, and the rest of the stream is raw
+// target bytes.
+//
+// Per-stream envelopes are length-prefixed (not newline-delimited or
+// json.Decoder-buffered) so that a bufio/json reader cannot accidentally
+// consume bytes that arrive immediately after the response — whether a
+// server-first banner (SSH "SSH-2.0…", SMTP "220…") or a client-first
+// startup payload (e.g. Postgres, HTTP).
 package protocol
 
-// ConnectEnvelope is sent by the relay-sender to the relay-listener
-// immediately after the rendezvous WebSocket is established.
+import (
+	"encoding/binary"
+	"encoding/json"
+	"fmt"
+	"io"
+)
+
+// ConnectEnvelope is sent by the relay-sender to the relay-listener at the
+// start of every target connection: as a WebSocket text message in v1, and
+// as the first length-prefixed frame on each smux stream in v2.
 type ConnectEnvelope struct {
 	// Version is the protocol version (currently 1).
 	Version int `json:"version"`
@@ -55,9 +81,6 @@ type ConnectResponse struct {
 	ListenerID string `json:"listener_id,omitempty"`
 }
 
-// CurrentVersion is the current protocol version.
-const CurrentVersion = 1
-
 // Connection-failure codes carried in ConnectResponse.Code. Used to map
 // listener-side dial failures to client-visible status (e.g. SOCKS5 REP
 // bytes). The set is intentionally small; new categories should only be
@@ -91,3 +114,156 @@ const (
 	// sent; the underlying network may be fine.
 	CodeDNSTimeout = "dns_timeout"
 )
+
+// MuxHandshake is sent by the sender as the FIRST WebSocket message on a
+// relay rendezvous in v2 (multiplexed) mode. The listener inspects Version
+// and Mode via FirstMessage and replies with a ConnectResponse.
+type MuxHandshake struct {
+	// Version is the protocol version (MuxVersion).
+	Version int `json:"version"`
+
+	// Mode identifies this as a mux handshake (MuxMode).
+	Mode string `json:"mode"`
+
+	// Capabilities carries optional, forward-compatible negotiation
+	// hints. Unknown fields must be ignored by the receiver.
+	Capabilities *MuxCapabilities `json:"capabilities,omitempty"`
+}
+
+// MuxCapabilities carries forward-compatible negotiation hints in a
+// MuxHandshake. Receivers must ignore unknown fields and tolerate missing
+// ones (any sub-field may be zero).
+type MuxCapabilities struct {
+	// ClientVersion is a free-form identifier of the sender build
+	// (e.g. "aztunnel/0.3.0"). Informational only.
+	ClientVersion string `json:"clientVersion,omitempty"`
+
+	// KeepAliveSeconds is the sender's smux keepalive interval in seconds.
+	// The listener uses this only as a hint; it sets its own values.
+	KeepAliveSeconds int `json:"keepAliveSeconds,omitempty"`
+
+	// MaxStreams is the maximum number of concurrent streams the sender
+	// will open on this session. Informational; the listener still enforces
+	// its own cap.
+	MaxStreams int `json:"maxStreams,omitempty"`
+}
+
+// FirstMessage is used by the listener to inspect the version and mode of
+// the first WebSocket message before deciding how to handle the connection.
+// JSON is forward-compatible: unknown fields are ignored, so both v1
+// ConnectEnvelope and v2 MuxHandshake parse cleanly into this type.
+type FirstMessage struct {
+	Version int    `json:"version"`
+	Mode    string `json:"mode,omitempty"`
+}
+
+const (
+	// CurrentVersion is the v1 (single-connection) protocol version.
+	CurrentVersion = 1
+
+	// MuxVersion is the v2 (multiplexed) protocol version.
+	MuxVersion = 2
+
+	// MuxMode is the value of MuxHandshake.Mode that identifies mux mode.
+	MuxMode = "mux"
+)
+
+// IsMux reports whether the first message indicates v2 mux mode.
+func (f FirstMessage) IsMux() bool {
+	return f.Version == MuxVersion && f.Mode == MuxMode
+}
+
+// maxStreamFrameSize bounds a single length-prefixed stream frame. It is
+// generous (envelopes are small JSON objects, typically well under 1 KiB)
+// but strict enough to prevent a malicious or corrupt peer from forcing
+// huge allocations or stalling the bridge. Must fit in uint16.
+const maxStreamFrameSize = 8 * 1024
+
+// WriteStreamEnvelope writes a ConnectEnvelope to an smux stream using
+// 2-byte big-endian length-prefixed framing. The framing is what
+// matters: it lets the receiver (ReadStreamEnvelope) consume exactly
+// the envelope bytes and no more — see ReadStreamResponse for the
+// banner-overread rationale this avoids.
+func WriteStreamEnvelope(w io.Writer, env ConnectEnvelope) error {
+	data, err := json.Marshal(env)
+	if err != nil {
+		return fmt.Errorf("marshal envelope: %w", err)
+	}
+	return writeLengthPrefixed(w, data)
+}
+
+// ReadStreamEnvelope reads a length-prefixed ConnectEnvelope.
+func ReadStreamEnvelope(r io.Reader) (ConnectEnvelope, error) {
+	data, err := readLengthPrefixed(r)
+	if err != nil {
+		return ConnectEnvelope{}, fmt.Errorf("read envelope: %w", err)
+	}
+	var env ConnectEnvelope
+	if err := json.Unmarshal(data, &env); err != nil {
+		return ConnectEnvelope{}, fmt.Errorf("unmarshal envelope: %w", err)
+	}
+	return env, nil
+}
+
+// WriteStreamResponse writes a ConnectResponse to an smux stream using
+// 2-byte big-endian length-prefixed framing.
+func WriteStreamResponse(w io.Writer, resp ConnectResponse) error {
+	data, err := json.Marshal(resp)
+	if err != nil {
+		return fmt.Errorf("marshal response: %w", err)
+	}
+	return writeLengthPrefixed(w, data)
+}
+
+// ReadStreamResponse reads a length-prefixed ConnectResponse. The
+// length prefix is what matters: it lets us consume exactly the
+// response bytes and no more, so a target banner that arrives
+// immediately after the response on a server-first protocol (SSH
+// "SSH-2.0...", SMTP "220 ...", etc.) cannot be lost into a decoder's
+// internal buffer. The regression test for this lives in
+// envelope_test.go:TestReadStreamResponse_NoOverreadOfBanner.
+func ReadStreamResponse(r io.Reader) (ConnectResponse, error) {
+	data, err := readLengthPrefixed(r)
+	if err != nil {
+		return ConnectResponse{}, fmt.Errorf("read response: %w", err)
+	}
+	var resp ConnectResponse
+	if err := json.Unmarshal(data, &resp); err != nil {
+		return ConnectResponse{}, fmt.Errorf("unmarshal response: %w", err)
+	}
+	return resp, nil
+}
+
+func writeLengthPrefixed(w io.Writer, data []byte) error {
+	if len(data) > maxStreamFrameSize {
+		return fmt.Errorf("frame too large: %d > %d", len(data), maxStreamFrameSize)
+	}
+	var hdr [2]byte
+	binary.BigEndian.PutUint16(hdr[:], uint16(len(data)))
+	if _, err := w.Write(hdr[:]); err != nil {
+		return fmt.Errorf("write length: %w", err)
+	}
+	if _, err := w.Write(data); err != nil {
+		return fmt.Errorf("write payload: %w", err)
+	}
+	return nil
+}
+
+func readLengthPrefixed(r io.Reader) ([]byte, error) {
+	var hdr [2]byte
+	if _, err := io.ReadFull(r, hdr[:]); err != nil {
+		return nil, fmt.Errorf("read length: %w", err)
+	}
+	n := int(binary.BigEndian.Uint16(hdr[:]))
+	if n == 0 {
+		return nil, fmt.Errorf("empty frame")
+	}
+	if n > maxStreamFrameSize {
+		return nil, fmt.Errorf("frame too large: %d > %d", n, maxStreamFrameSize)
+	}
+	buf := make([]byte, n)
+	if _, err := io.ReadFull(r, buf); err != nil {
+		return nil, fmt.Errorf("read payload: %w", err)
+	}
+	return buf, nil
+}

--- a/internal/protocol/envelope_test.go
+++ b/internal/protocol/envelope_test.go
@@ -1,7 +1,11 @@
 package protocol
 
 import (
+	"bytes"
+	"encoding/binary"
 	"encoding/json"
+	"errors"
+	"io"
 	"strings"
 	"testing"
 )
@@ -111,5 +115,232 @@ func TestResponseOmitEmptyListenerID(t *testing.T) {
 	s := string(data)
 	if strings.Contains(s, "listener_id") {
 		t.Errorf("expected listener_id to be omitted, got: %s", s)
+	}
+}
+
+func TestMuxHandshakeRoundTrip(t *testing.T) {
+	hs := MuxHandshake{
+		Version: MuxVersion,
+		Mode:    MuxMode,
+		Capabilities: &MuxCapabilities{
+			ClientVersion:    "aztunnel/test",
+			KeepAliveSeconds: 30,
+			MaxStreams:       256,
+		},
+	}
+	data, err := json.Marshal(hs)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	var got MuxHandshake
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got.Version != MuxVersion || got.Mode != MuxMode {
+		t.Errorf("got version=%d mode=%q, want %d/%q", got.Version, got.Mode, MuxVersion, MuxMode)
+	}
+	if got.Capabilities == nil || got.Capabilities.MaxStreams != 256 {
+		t.Errorf("capabilities lost in round-trip: %+v", got.Capabilities)
+	}
+}
+
+func TestFirstMessageIsMux(t *testing.T) {
+	tests := []struct {
+		name    string
+		payload string
+		isMux   bool
+	}{
+		{"v1 envelope", `{"version":1,"target":"10.0.0.5:22"}`, false},
+		{"v2 mux handshake", `{"version":2,"mode":"mux"}`, true},
+		{"v2 no mode", `{"version":2}`, false},
+		{"v1 with mode (defensive)", `{"version":1,"mode":"mux"}`, false},
+		{"unknown version", `{"version":99,"mode":"mux"}`, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var fm FirstMessage
+			if err := json.Unmarshal([]byte(tt.payload), &fm); err != nil {
+				t.Fatalf("unmarshal: %v", err)
+			}
+			if got := fm.IsMux(); got != tt.isMux {
+				t.Errorf("IsMux() = %v, want %v (payload=%s)", got, tt.isMux, tt.payload)
+			}
+		})
+	}
+}
+
+func TestStreamEnvelopeRoundTrip(t *testing.T) {
+	var buf bytes.Buffer
+	want := ConnectEnvelope{Version: CurrentVersion, Target: "10.0.0.5:22"}
+	if err := WriteStreamEnvelope(&buf, want); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	got, err := ReadStreamEnvelope(&buf)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if got.Target != want.Target || got.Version != want.Version {
+		t.Errorf("got %+v, want %+v", got, want)
+	}
+	if buf.Len() != 0 {
+		t.Errorf("expected reader fully consumed, %d bytes left", buf.Len())
+	}
+}
+
+func TestStreamResponseRoundTrip(t *testing.T) {
+	var buf bytes.Buffer
+	want := ConnectResponse{Version: CurrentVersion, OK: true}
+	if err := WriteStreamResponse(&buf, want); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	got, err := ReadStreamResponse(&buf)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if got.OK != want.OK {
+		t.Errorf("got %+v, want %+v", got, want)
+	}
+}
+
+// TestStreamResponseRoundTrip_ListenerID guards the integration: the
+// length-prefixed framing must preserve every field on ConnectResponse,
+// including the post-rebase ListenerID, so mux-mode senders can
+// correlate listener_id on accept the same way v1 senders do.
+func TestStreamResponseRoundTrip_ListenerID(t *testing.T) {
+	var buf bytes.Buffer
+	want := ConnectResponse{Version: CurrentVersion, OK: true, ListenerID: "ABCDEFGHIJKLMNOP"}
+	if err := WriteStreamResponse(&buf, want); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	got, err := ReadStreamResponse(&buf)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if got.ListenerID != want.ListenerID {
+		t.Errorf("listener_id = %q, want %q", got.ListenerID, want.ListenerID)
+	}
+}
+
+// TestStreamEnvelopeRoundTrip_BridgeID mirrors the response test: every
+// stream-mode envelope the sender writes must carry BridgeID through
+// the length-prefixed framing so the listener can bind bridge_id on
+// its per-stream logger.
+func TestStreamEnvelopeRoundTrip_BridgeID(t *testing.T) {
+	var buf bytes.Buffer
+	want := ConnectEnvelope{Version: CurrentVersion, Target: "10.0.0.5:22", BridgeID: "ABCDEFGHIJKLMNOP"}
+	if err := WriteStreamEnvelope(&buf, want); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	got, err := ReadStreamEnvelope(&buf)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if got.BridgeID != want.BridgeID {
+		t.Errorf("bridge_id = %q, want %q", got.BridgeID, want.BridgeID)
+	}
+}
+
+// TestReadStreamResponse_NoOverreadOfBanner is the critical regression test
+// for the bug the rubber-duck review caught in the prototype: json.Decoder
+// buffers and would consume target-banner bytes (SSH "SSH-2.0...", SMTP
+// "220 ...", etc.) emitted by a server-first target immediately after the
+// listener's response. Length-prefixed framing must stop exactly at the
+// JSON boundary so any following bytes remain on the wire for the bridge.
+func TestReadStreamResponse_NoOverreadOfBanner(t *testing.T) {
+	banner := []byte("SSH-2.0-OpenSSH_9.6p1\r\n")
+	// Build: [2-byte length][JSON response][banner]
+	resp := ConnectResponse{Version: CurrentVersion, OK: true}
+	respJSON, _ := json.Marshal(resp)
+	var buf bytes.Buffer
+	var hdr [2]byte
+	binary.BigEndian.PutUint16(hdr[:], uint16(len(respJSON)))
+	buf.Write(hdr[:])
+	buf.Write(respJSON)
+	buf.Write(banner)
+
+	got, err := ReadStreamResponse(&buf)
+	if err != nil {
+		t.Fatalf("read response: %v", err)
+	}
+	if !got.OK {
+		t.Fatalf("got %+v, want ok=true", got)
+	}
+	// Critical: the banner must still be readable from the same stream.
+	remaining, _ := io.ReadAll(&buf)
+	if !bytes.Equal(remaining, banner) {
+		t.Fatalf("banner lost or corrupted: got %q, want %q", remaining, banner)
+	}
+}
+
+// TestReadStreamEnvelope_NoOverreadOfPayload is the listener-side mirror:
+// after reading the envelope, subsequent stream bytes (e.g. an HTTP request
+// the sender wrote immediately) must still be available.
+func TestReadStreamEnvelope_NoOverreadOfPayload(t *testing.T) {
+	payload := []byte("GET / HTTP/1.1\r\nHost: example.com\r\n\r\n")
+	env := ConnectEnvelope{Version: CurrentVersion, Target: "example.com:80"}
+	envJSON, _ := json.Marshal(env)
+	var buf bytes.Buffer
+	var hdr [2]byte
+	binary.BigEndian.PutUint16(hdr[:], uint16(len(envJSON)))
+	buf.Write(hdr[:])
+	buf.Write(envJSON)
+	buf.Write(payload)
+
+	got, err := ReadStreamEnvelope(&buf)
+	if err != nil {
+		t.Fatalf("read envelope: %v", err)
+	}
+	if got.Target != "example.com:80" {
+		t.Errorf("got target %q, want example.com:80", got.Target)
+	}
+	remaining, _ := io.ReadAll(&buf)
+	if !bytes.Equal(remaining, payload) {
+		t.Errorf("payload lost or corrupted: got %q, want %q", remaining, payload)
+	}
+}
+
+func TestReadStreamResponse_FrameTooLarge(t *testing.T) {
+	var buf bytes.Buffer
+	var hdr [2]byte
+	// maxStreamFrameSize is 8 KiB; ask for something bigger.
+	binary.BigEndian.PutUint16(hdr[:], maxStreamFrameSize+1)
+	buf.Write(hdr[:])
+	_, err := ReadStreamResponse(&buf)
+	if err == nil {
+		t.Fatal("expected error for oversized frame")
+	}
+	if !strings.Contains(err.Error(), "too large") {
+		t.Errorf("expected size error, got: %v", err)
+	}
+}
+
+func TestReadStreamResponse_EmptyFrame(t *testing.T) {
+	var buf bytes.Buffer
+	var hdr [2]byte
+	binary.BigEndian.PutUint16(hdr[:], 0)
+	buf.Write(hdr[:])
+	_, err := ReadStreamResponse(&buf)
+	if err == nil {
+		t.Fatal("expected error for empty frame")
+	}
+}
+
+func TestReadStreamResponse_TruncatedHeader(t *testing.T) {
+	_, err := ReadStreamResponse(bytes.NewReader([]byte{0x01}))
+	if err == nil {
+		t.Fatal("expected error for truncated header")
+	}
+	if !errors.Is(err, io.ErrUnexpectedEOF) && !strings.Contains(err.Error(), "read length") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestWriteStreamEnvelope_FrameTooLarge(t *testing.T) {
+	big := strings.Repeat("x", maxStreamFrameSize+1)
+	env := ConnectEnvelope{Version: CurrentVersion, Target: big}
+	err := WriteStreamEnvelope(io.Discard, env)
+	if err == nil {
+		t.Fatal("expected error writing oversized envelope")
 	}
 }

--- a/internal/relay/control.go
+++ b/internal/relay/control.go
@@ -315,7 +315,7 @@ func runControlLoop(ctx context.Context, cfg ControlConfig) (connected bool, err
 
 		acceptLogger.Info(EventAcceptAttempted)
 
-		if !sem.tryAcquire(loopCtx) {
+		if !sem.tryAcquire() {
 			acceptLogger.Warn(EventAcceptDropped, "reason", AcceptDroppedSemaphoreFull)
 			continue
 		}

--- a/internal/relay/net.go
+++ b/internal/relay/net.go
@@ -1,7 +1,6 @@
 package relay
 
 import (
-	"context"
 	"net"
 	"time"
 )
@@ -33,15 +32,15 @@ func newConnSemaphore(max int) *connSemaphore {
 	return &connSemaphore{ch: make(chan struct{}, max)}
 }
 
-func (s *connSemaphore) tryAcquire(ctx context.Context) bool {
+// tryAcquire is non-blocking: it returns true if a slot was reserved,
+// false if the semaphore is at capacity.
+func (s *connSemaphore) tryAcquire() bool {
 	if s.ch == nil {
 		return true
 	}
 	select {
 	case s.ch <- struct{}{}:
 		return true
-	case <-ctx.Done():
-		return false
 	default:
 		return false
 	}

--- a/internal/relay/net_test.go
+++ b/internal/relay/net_test.go
@@ -1,7 +1,6 @@
 package relay
 
 import (
-	"context"
 	"testing"
 )
 
@@ -9,7 +8,7 @@ func TestConnSemaphore_Unlimited(t *testing.T) {
 	sem := newConnSemaphore(0)
 	// Should always succeed with no limit.
 	for range 100 {
-		if !sem.tryAcquire(context.Background()) {
+		if !sem.tryAcquire() {
 			t.Fatal("unlimited semaphore should always acquire")
 		}
 	}
@@ -19,34 +18,20 @@ func TestConnSemaphore_Unlimited(t *testing.T) {
 
 func TestConnSemaphore_Limited(t *testing.T) {
 	sem := newConnSemaphore(2)
-	ctx := context.Background()
 
-	if !sem.tryAcquire(ctx) {
+	if !sem.tryAcquire() {
 		t.Fatal("first acquire should succeed")
 	}
-	if !sem.tryAcquire(ctx) {
+	if !sem.tryAcquire() {
 		t.Fatal("second acquire should succeed")
 	}
 	// Third should fail (non-blocking).
-	if sem.tryAcquire(ctx) {
+	if sem.tryAcquire() {
 		t.Fatal("third acquire should fail at capacity")
 	}
 	// Release one and retry.
 	sem.release()
-	if !sem.tryAcquire(ctx) {
+	if !sem.tryAcquire() {
 		t.Fatal("acquire after release should succeed")
-	}
-}
-
-func TestConnSemaphore_ContextCancel(t *testing.T) {
-	sem := newConnSemaphore(1)
-	ctx := context.Background()
-
-	sem.tryAcquire(ctx) // fill it
-
-	cancelCtx, cancel := context.WithCancel(context.Background())
-	cancel() // already cancelled
-	if sem.tryAcquire(cancelCtx) {
-		t.Fatal("acquire with cancelled context should fail")
 	}
 }

--- a/internal/sender/dial_budget_test.go
+++ b/internal/sender/dial_budget_test.go
@@ -111,7 +111,7 @@ func TestForwardConnection_DialBudgetBoundsRetry(t *testing.T) {
 	errCh := make(chan error, 1)
 	start := time.Now()
 	go func() {
-		errCh <- forwardConnection(ctx, local, cfg.Target, cfg)
+		errCh <- forwardConnection(ctx, local, cfg.Target, cfg, nil)
 	}()
 
 	select {
@@ -220,7 +220,7 @@ func TestForwardConnection_HappyPathSurvivesDialBudget(t *testing.T) {
 
 	errCh := make(chan error, 1)
 	go func() {
-		errCh <- forwardConnection(ctx, local, cfg.Target, cfg)
+		errCh <- forwardConnection(ctx, local, cfg.Target, cfg, nil)
 	}()
 
 	// Drive the bridge: write a payload from the app side, read
@@ -309,7 +309,7 @@ func TestForwardConnection_NegativeBudgetUsesDefault(t *testing.T) {
 	errCh := make(chan error, 1)
 	start := time.Now()
 	go func() {
-		errCh <- forwardConnection(ctx, local, cfg.Target, cfg)
+		errCh <- forwardConnection(ctx, local, cfg.Target, cfg, nil)
 	}()
 
 	select {

--- a/internal/sender/muxdialer.go
+++ b/internal/sender/muxdialer.go
@@ -1,0 +1,543 @@
+package sender
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/coder/websocket"
+	"github.com/philsphicas/aztunnel/internal/metrics"
+	"github.com/philsphicas/aztunnel/internal/muxconfig"
+	"github.com/philsphicas/aztunnel/internal/protocol"
+	"github.com/philsphicas/aztunnel/internal/relay"
+	"github.com/xtaci/smux"
+)
+
+const (
+	// muxHandshakeTimeout bounds the v2 handshake (envelope + response)
+	// on the outer WebSocket. Independent of per-stream operations.
+	muxHandshakeTimeout = 15 * time.Second
+
+	// muxStreamHandshakeTimeout is the default budget for the per-stream
+	// envelope+response exchange after a fresh smux stream is opened on
+	// an established mux session. Without this bound, a peer that
+	// accepts the smux stream but never replies (crash, hang, malicious
+	// actor) would pin the sender's pool slot indefinitely on
+	// ReadStreamResponse. The deadline is cleared once the response
+	// arrives so the bridge can run with no time bound.
+	//
+	// This cap MUST exceed the listener's worst-case target-dial budget
+	// (cfg.ConnectTimeout, default 30s in listener.Config), because the
+	// listener dials the target before writing the response. Operators
+	// who configure the listener with `--connect-timeout` above the
+	// default should also raise the sender's
+	// `--mux-stream-handshake-timeout` (env
+	// AZTUNNEL_MUX_STREAM_HANDSHAKE_TIMEOUT) to match.
+	muxStreamHandshakeTimeout = 60 * time.Second
+
+	// muxUnavailableTTL is how long the dialer remembers that a listener
+	// rejected the v2 handshake. During this window OpenStream returns
+	// ErrMuxUnsupported immediately so the caller falls back to v1
+	// without re-dialing the relay.
+	muxUnavailableTTL = 60 * time.Second
+)
+
+// ErrMuxUnsupported is returned by MuxDialer.OpenStream when the listener
+// the sender reached does not understand the v2 mux protocol. Callers
+// should retry the same logical TCP session through the v1 single-
+// connection path.
+var ErrMuxUnsupported = errors.New("mux: peer does not support mux protocol")
+
+// ErrMuxDialerClosed is returned by MuxDialer.OpenStream after the dialer's
+// parentCtx has been cancelled (for example, by MuxPool eviction during
+// graceful rotation). It signals "this dialer is permanently dead; do not
+// retry on me".
+var ErrMuxDialerClosed = errors.New("mux: dialer closed")
+
+// ErrMuxDialFailed is wrapped around dial/handshake errors that originate
+// from the underlying relay dial (i.e. were already recorded as a connection
+// error by MuxDialer.connectLocked via DialReason — the mux path calls
+// relay.DialWithRetry directly and emits ConnectionError itself rather than
+// going through metrics.InstrumentedDial, so it can suppress the dial-error
+// metric when the cause is parentCtx cancellation). Upstream callers should
+// check errors.Is(err, ErrMuxDialFailed) before recording their own
+// ConnectionError, to avoid double-counting a single dial failure.
+var ErrMuxDialFailed = errors.New("mux: relay dial failed")
+
+// MuxDialer maintains a persistent smux session over a single relay
+// WebSocket. Each call to OpenStream returns a new logical net.Conn
+// (smux stream) that carries one tunneled TCP session.
+//
+// The session is established lazily on the first OpenStream call and
+// re-established transparently if the underlying WebSocket dies. If the
+// listener does not support the v2 mux protocol, OpenStream returns
+// ErrMuxUnsupported for muxUnavailableTTL so callers can fall back to v1
+// without re-paying the rendezvous cost.
+type MuxDialer struct {
+	mu         sync.Mutex
+	session    *smux.Session
+	ws         *websocket.Conn
+	parentCtx  context.Context
+	endpoint   string
+	entityPath string
+	tp         relay.TokenProvider
+	clientOpts relay.ClientOptions
+	logger     *slog.Logger
+	metrics    *metrics.Metrics
+	// muxUnavailUntil holds the sticky v1-fallback expiry as unix-nano
+	// timestamps so Unavailable() can be a lock-free read. Stored as
+	// wall-clock time (not monotonic); the 60s TTL means clock jumps
+	// have negligible practical impact.
+	muxUnavailUntil atomic.Int64
+}
+
+// NewMuxDialer constructs a MuxDialer. The provided context governs the
+// lifetime of the eventual smux session (not individual OpenStream calls);
+// cancelling it tears down the session and frees all in-flight streams.
+func NewMuxDialer(ctx context.Context, endpoint, entityPath string, tp relay.TokenProvider, opts relay.ClientOptions, logger *slog.Logger, m *metrics.Metrics) *MuxDialer {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &MuxDialer{
+		parentCtx:  ctx,
+		endpoint:   endpoint,
+		entityPath: entityPath,
+		tp:         tp,
+		clientOpts: opts,
+		logger:     logger,
+		metrics:    m,
+	}
+}
+
+// OpenStream returns a new smux stream over the persistent mux session,
+// connecting the session lazily if needed. The supplied ctx bounds the
+// connect handshake but does not govern the lifetime of the returned
+// stream — the caller's bridge logic owns that.
+//
+// Returns ErrMuxUnsupported if the listener rejected the v2 handshake;
+// the rejection is sticky for muxUnavailableTTL so concurrent callers
+// fall back to v1 quickly.
+func (d *MuxDialer) OpenStream(ctx context.Context) (net.Conn, error) {
+	// Fast path: parentCtx cancellation makes this dialer permanently
+	// dead. The pool cancels each session's ctx when evicting (during
+	// rotation or after ErrMuxUnsupported), so any in-flight OpenStream
+	// that raced past the pool's selector must NOT reconnect on this
+	// opener — that would create an untracked zombie relay rendezvous.
+	if err := d.parentCtx.Err(); err != nil {
+		return nil, ErrMuxDialerClosed
+	}
+
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	// Re-check after acquiring the lock to close a TOCTOU race with
+	// concurrent ctx cancellation.
+	if err := d.parentCtx.Err(); err != nil {
+		return nil, ErrMuxDialerClosed
+	}
+
+	if d.isUnavailableNow() {
+		return nil, ErrMuxUnsupported
+	}
+
+	if d.session != nil && !d.session.IsClosed() {
+		if stream, err := d.session.OpenStream(); err == nil {
+			// Final parentCtx re-check before returning. Pool
+			// eviction cancels parentCtx WITHOUT needing d.mu,
+			// so it can fire between the lock-acquire check
+			// above and here. Returning a stream from a
+			// logically-evicted session would surface as an
+			// opaque smux read/write failure to the caller
+			// instead of triggering the pool's retry-on-
+			// ErrMuxDialerClosed loop.
+			if err := d.parentCtx.Err(); err != nil {
+				_ = stream.Close()
+				return nil, ErrMuxDialerClosed
+			}
+			// Honor the caller's per-call ctx too: the smux
+			// OpenStream call above did not consult it (smux
+			// has no ctx-aware OpenStream), so an admission
+			// deadline that expired during that call would
+			// otherwise return a stream past the deadline.
+			// Close the stream and surface ctx.Err() so the
+			// pool's retry/admission accounting can recognize
+			// it (see muxpool.go's ctx-typed-error branch).
+			if err := ctx.Err(); err != nil {
+				_ = stream.Close()
+				return nil, err
+			}
+			return stream, nil
+		} else {
+			d.logger.Debug("mux session broken, reconnecting", "error", err)
+			d.closeSessionLocked()
+		}
+	} else if d.session != nil {
+		// Session was remotely closed (IsClosed() == true). Tear down
+		// our refs so the new connect doesn't leak the
+		// mux_sessions_active gauge (closeSessionLocked decrements it)
+		// or hold the dead WebSocket reference.
+		d.closeSessionLocked()
+	}
+
+	if err := d.connectLocked(ctx); err != nil {
+		return nil, err
+	}
+
+	stream, err := d.session.OpenStream()
+	if err != nil {
+		d.closeSessionLocked()
+		return nil, fmt.Errorf("open stream after connect: %w", err)
+	}
+	// Same parentCtx re-check as the fast path: the session we just
+	// created could have been evicted between connectLocked's final
+	// guard and this OpenStream call.
+	if err := d.parentCtx.Err(); err != nil {
+		_ = stream.Close()
+		return nil, ErrMuxDialerClosed
+	}
+	// Caller-ctx re-check, mirroring the fast path. connectLocked
+	// honors ctx during the relay dial/handshake, but the smux
+	// OpenStream call above does not — so a ctx that expired between
+	// connectLocked returning and OpenStream completing would
+	// otherwise produce a stream past the caller's deadline.
+	if err := ctx.Err(); err != nil {
+		_ = stream.Close()
+		return nil, err
+	}
+	return stream, nil
+}
+
+// Close tears down the underlying mux session and WebSocket. Safe to call
+// multiple times.
+func (d *MuxDialer) Close() {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.closeSessionLocked()
+}
+
+// Unavailable reports whether the dialer is in its sticky v1-fallback
+// window — i.e. a recent handshake was rejected with a v1-style error.
+// Pool implementations use this to skip the dialer when selecting a
+// session for a new stream.
+//
+// This is a lock-free atomic read. The pool calls Unavailable() while
+// holding its own p.mu, and the dialer mutex (d.mu) may be held for
+// the duration of a long relay dial; making this lock-free prevents
+// the pool from blocking behind in-flight rendezvous.
+func (d *MuxDialer) Unavailable() bool {
+	return d.isUnavailableNow()
+}
+
+// isUnavailableNow returns true iff the sticky v1-fallback marker is
+// set and has not yet expired. Lock-free.
+func (d *MuxDialer) isUnavailableNow() bool {
+	until := d.muxUnavailUntil.Load()
+	return until != 0 && time.Now().UnixNano() < until
+}
+
+// markUnavailable arms the sticky v1-fallback marker for muxUnavailableTTL
+// from now. Called when a listener rejects the v2 handshake.
+func (d *MuxDialer) markUnavailable() {
+	d.muxUnavailUntil.Store(time.Now().Add(muxUnavailableTTL).UnixNano())
+}
+
+func (d *MuxDialer) closeSessionLocked() {
+	if d.session != nil {
+		_ = d.session.Close()
+		d.session = nil
+		d.metrics.MuxSessionClosed("sender")
+	}
+	if d.ws != nil {
+		_ = d.ws.CloseNow()
+		d.ws = nil
+	}
+}
+
+func (d *MuxDialer) connectLocked(ctx context.Context) (retErr error) {
+	// Tie the dial/handshake ctx to BOTH the caller's ctx and
+	// d.parentCtx. Without this, an eviction (which cancels
+	// d.parentCtx via the pool's sessCancel) cannot abort an
+	// in-flight dial — opener.Close() would block behind d.mu until
+	// the caller's ctx expired, and a late-completing dial could
+	// publish an untracked session into d.session while the dialer
+	// has already been evicted by the pool.
+	dialCtx, dialCancel := mergeCancelCtx(ctx, d.parentCtx)
+	defer dialCancel()
+
+	// Rewrite any error returned from dial/handshake into
+	// ErrMuxDialerClosed if d.parentCtx is cancelled. The pool's
+	// retry loop in OpenStream only treats ErrMuxDialerClosed as a
+	// retryable eviction signal, so a parent-cancellation that
+	// surfaces as e.g. "dial relay: ... context canceled" would
+	// otherwise be returned to the caller as a hard failure instead
+	// of triggering a retry against a fresh session.
+	defer func() {
+		if retErr != nil && retErr != ErrMuxUnsupported && d.parentCtx.Err() != nil {
+			retErr = ErrMuxDialerClosed
+		}
+	}()
+
+	// Dial via relay.DialWithRetry directly so we can suppress the
+	// dial-error metric when the failure is caused by parentCtx
+	// cancellation (internal eviction/rotation/shutdown). Using
+	// metrics.InstrumentedDial here would emit a connection_errors_total
+	// sample with reason=relay_failed BEFORE we have a chance to
+	// reclassify the parent-cancel case via the defer above.
+	dialStart := time.Now()
+	ws, err := relay.DialWithRetry(dialCtx, d.endpoint, d.entityPath, d.tp, d.clientOpts, d.logger)
+	d.metrics.ObserveDialDuration("sender", time.Since(dialStart).Seconds())
+	if err != nil {
+		if d.parentCtx.Err() == nil {
+			// Real dial failure — record so it's not lost when
+			// the defer below leaves ErrMuxDialFailed unwrapped
+			// to the caller.
+			d.metrics.ConnectionError("sender", metrics.DialReason(err, metrics.ReasonRelayFailed))
+		}
+		// Wrap with ErrMuxDialFailed so upstream callers can
+		// distinguish "already counted" from other open failures
+		// (e.g. handshake parse). Avoids double-counting connection
+		// errors.
+		return fmt.Errorf("%w: %w", ErrMuxDialFailed, err)
+	}
+
+	// Outer handshake (MuxHandshake + ConnectResponse) uses WebSocket
+	// message framing — smux is not yet running on this conn. Per-stream
+	// envelopes will use length-prefixed framing inside each smux stream.
+	hsCtx, cancel := context.WithTimeout(dialCtx, muxHandshakeTimeout)
+	defer cancel()
+
+	hs := protocol.MuxHandshake{
+		Version: protocol.MuxVersion,
+		Mode:    protocol.MuxMode,
+	}
+	hsData, _ := json.Marshal(hs)
+	if err := ws.Write(hsCtx, websocket.MessageText, hsData); err != nil {
+		_ = ws.CloseNow()
+		return fmt.Errorf("send mux handshake: %w", err)
+	}
+
+	_, respData, err := ws.Read(hsCtx)
+	if err != nil {
+		_ = ws.CloseNow()
+		return fmt.Errorf("read mux response: %w", err)
+	}
+	var resp protocol.ConnectResponse
+	if err := json.Unmarshal(respData, &resp); err != nil {
+		_ = ws.CloseNow()
+		return fmt.Errorf("parse mux response: %w", err)
+	}
+	if !resp.OK {
+		_ = ws.CloseNow()
+		if isMuxUnsupportedRejection(resp.Error) {
+			d.markUnavailable()
+			d.logger.Warn("listener does not support mux protocol; falling back to v1",
+				"error", resp.Error, "fallbackTTL", muxUnavailableTTL)
+			return ErrMuxUnsupported
+		}
+		return fmt.Errorf("mux handshake rejected: %s", resp.Error)
+	}
+
+	// Hand the WS over to smux. From this point nothing else may read,
+	// write, or ping the underlying WS — smux owns it.
+	netConn := websocket.NetConn(d.parentCtx, ws, websocket.MessageBinary)
+	sess, err := smux.Client(netConn, muxconfig.SmuxConfig())
+	if err != nil {
+		_ = ws.CloseNow()
+		return fmt.Errorf("create smux client: %w", err)
+	}
+
+	// One final parentCtx check before publishing the session into
+	// d.session. If the pool evicted this dialer while we were
+	// dialing/handshaking, we must NOT publish — otherwise we leak
+	// the gauge and create an untracked session that the pool no
+	// longer references.
+	if err := d.parentCtx.Err(); err != nil {
+		_ = sess.Close()
+		_ = ws.CloseNow()
+		return ErrMuxDialerClosed
+	}
+
+	d.session = sess
+	d.ws = ws
+	d.metrics.MuxSessionOpened("sender")
+	d.logger.Info("mux session established")
+
+	// Spawn an async-close watcher so the mux_sessions_active gauge is
+	// decremented promptly when the smux session dies on its own (smux
+	// keepalive timeout, peer-initiated close, transport-level read
+	// failure). Without this, an idle MuxDialer with a dead session
+	// would report active==1 until the next OpenStream call (which
+	// takes the IsClosed() branch and decrements via
+	// closeSessionLocked) or until pool eviction. The watcher is
+	// idempotent with respect to the synchronous close paths: if
+	// closeSessionLocked has already replaced d.session by the time
+	// the watcher fires, the d.session==sess check skips the
+	// double-decrement.
+	go d.watchSession(sess)
+
+	return nil
+}
+
+// watchSession waits for the smux session to die (peer-initiated close,
+// transport read/write error, smux keepalive timeout, or local Close)
+// and then decrements the active-session gauge — provided d.session
+// still references the same session (i.e. closeSessionLocked from
+// another path hasn't already handled it).
+//
+// We use AcceptStream rather than CloseChan because smux's CloseChan
+// only fires on an explicit Close() call; internal transport errors
+// (detected by recvLoop) set chSocketReadError and break AcceptStream,
+// but do NOT close die / fire CloseChan. AcceptStream is the only
+// public signal that responds to BOTH the explicit-close and async
+// transport-failure paths.
+//
+// Our protocol is asymmetric — only the sender (this side) opens
+// streams. A peer-initiated stream is therefore a protocol violation;
+// we close it defensively and continue watching.
+func (d *MuxDialer) watchSession(sess *smux.Session) {
+	for {
+		stream, err := sess.AcceptStream()
+		if err != nil {
+			break
+		}
+		_ = stream.Close()
+	}
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if d.session == sess {
+		d.closeSessionLocked()
+	}
+}
+
+// mergeCancelCtx returns a new context that is cancelled when EITHER
+// of the input contexts is cancelled. The returned cancel func MUST be
+// called to release the watcher goroutine.
+//
+// Used to scope the dial/handshake to both the caller's ctx and the
+// dialer's parentCtx, so that pool eviction (which cancels parentCtx)
+// aborts a slow in-flight dial instead of waiting for the caller to
+// give up.
+func mergeCancelCtx(a, b context.Context) (context.Context, context.CancelFunc) {
+	merged, cancel := context.WithCancel(a)
+	stop := make(chan struct{})
+	go func() {
+		select {
+		case <-b.Done():
+			cancel()
+		case <-stop:
+		}
+	}()
+	var once sync.Once
+	return merged, func() {
+		once.Do(func() { close(stop) })
+		cancel()
+	}
+}
+
+// isMuxUnsupportedRejection inspects a listener's ConnectResponse.Error to
+// decide whether the rejection means the listener doesn't speak v2 (and so
+// the sender should fall back to v1). A v1 listener parses MuxHandshake
+// as a ConnectEnvelope, sees Target=="" and responds "missing target", and
+// also rejects unknown protocol versions with "unsupported protocol version".
+func isMuxUnsupportedRejection(msg string) bool {
+	low := strings.ToLower(msg)
+	return strings.Contains(low, "unsupported protocol version") ||
+		strings.Contains(low, "missing target") ||
+		strings.Contains(low, "invalid envelope")
+}
+
+// sendEnvelopeOverStream performs the per-stream handshake using length-
+// prefixed framing. CRITICAL: do NOT use json.NewDecoder here — its
+// internal buffer would consume bytes that arrive immediately after the
+// response (server banners like SSH or SMTP, or client-first startup
+// payloads). See protocol.ReadStreamResponse.
+//
+// The envelope exchange is bounded by handshakeTimeout (or the caller's
+// ctx deadline, whichever is sooner) and by ctx cancellation. If
+// handshakeTimeout is zero, the default muxStreamHandshakeTimeout const
+// is used. Without this bound, a peer that accepts the smux stream but
+// never replies could block ReadStreamResponse indefinitely and pin the
+// pool slot until process shutdown. On success the deadline is cleared
+// so the bridge runs without a time bound.
+//
+// The cap must exceed the listener's worst-case target-dial budget
+// (cfg.ConnectTimeout, default 30s in listener.Config) because the
+// listener dials the target before writing the response. Operators
+// who configure the listener with `--connect-timeout` above the default
+// should also raise the sender's mux-stream-handshake-timeout to match.
+//
+// bridgeID is propagated to the listener via ConnectEnvelope.BridgeID so
+// logs on both ends carry the same value. The returned listenerID is the
+// value from ConnectResponse.ListenerID: non-empty for current-version
+// listeners (success or rejection), empty for pre-listener_id listeners
+// or for failures that occur before any response was read.
+func sendEnvelopeOverStream(ctx context.Context, stream net.Conn, target, bridgeID string, handshakeTimeout time.Duration) (string, error) {
+	if handshakeTimeout <= 0 {
+		handshakeTimeout = muxStreamHandshakeTimeout
+	}
+	deadline := time.Now().Add(handshakeTimeout)
+	if d, ok := ctx.Deadline(); ok && d.Before(deadline) {
+		deadline = d
+	}
+	if err := stream.SetDeadline(deadline); err != nil {
+		return "", fmt.Errorf("set envelope deadline: %w", err)
+	}
+
+	// Watchdog: propagate ctx cancellation by collapsing the stream
+	// deadline so any in-flight Read/Write returns immediately. We
+	// MUST join the watchdog before clearing the deadline on the
+	// success path; otherwise a late ctx cancellation could race the
+	// clear and leave the bridge with a past-now deadline.
+	done := make(chan struct{})
+	watchdogExited := make(chan struct{})
+	go func() {
+		defer close(watchdogExited)
+		select {
+		case <-ctx.Done():
+			// Past-now deadline forces immediate timeout.
+			_ = stream.SetDeadline(time.Unix(1, 0))
+		case <-done:
+		}
+	}()
+	stopped := false
+	stopWatchdog := func() {
+		if stopped {
+			return
+		}
+		stopped = true
+		close(done)
+		<-watchdogExited
+	}
+	defer stopWatchdog()
+
+	env := protocol.ConnectEnvelope{
+		Version:  protocol.CurrentVersion,
+		Target:   target,
+		BridgeID: bridgeID,
+	}
+	if err := protocol.WriteStreamEnvelope(stream, env); err != nil {
+		return "", fmt.Errorf("send envelope: %w", err)
+	}
+	resp, err := protocol.ReadStreamResponse(stream)
+	if err != nil {
+		return "", fmt.Errorf("read response: %w", err)
+	}
+	if !resp.OK {
+		return resp.ListenerID, &connectRejected{Message: resp.Error, Code: resp.Code, ListenerID: resp.ListenerID}
+	}
+	// Stop and join the watchdog before clearing the deadline. After
+	// stopWatchdog returns the watchdog goroutine has exited, so no
+	// other goroutine can race the SetDeadline(zero) below.
+	stopWatchdog()
+	if err := stream.SetDeadline(time.Time{}); err != nil {
+		return "", fmt.Errorf("clear envelope deadline: %w", err)
+	}
+	return resp.ListenerID, nil
+}

--- a/internal/sender/muxdialer_test.go
+++ b/internal/sender/muxdialer_test.go
@@ -1,0 +1,1069 @@
+package sender
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	dto "github.com/prometheus/client_model/go"
+
+	"github.com/philsphicas/aztunnel/internal/metrics"
+	"github.com/philsphicas/aztunnel/internal/muxconfig"
+	"github.com/philsphicas/aztunnel/internal/protocol"
+	"github.com/philsphicas/aztunnel/internal/relay"
+	"github.com/xtaci/smux"
+)
+
+// TestSendEnvelopeOverStream_NoBannerOverread is the critical regression
+// test for the bug the rubber-duck review caught: using json.NewDecoder
+// on an smux stream lets the decoder's internal buffer swallow target
+// bytes that arrive immediately after the response.
+//
+// Many real-world target protocols send bytes immediately on connect —
+// server-first banners (SSH "SSH-2.0…", SMTP "220…") or client-first
+// startup payloads (Postgres, HTTP). In either case the listener writes
+// ConnectResponse{OK:true} and then immediately proxies the target
+// socket; the first payload bytes follow the response with no gap. The
+// sender MUST be able to see those bytes.
+func TestSendEnvelopeOverStream_NoBannerOverread(t *testing.T) {
+	clientConn, serverConn := net.Pipe()
+
+	clientCfg := smuxClientCfg()
+	serverCfg := smuxClientCfg() // same config both sides for keepalive parity
+
+	clientSess, err := smux.Client(clientConn, clientCfg)
+	if err != nil {
+		t.Fatalf("smux.Client: %v", err)
+	}
+	defer clientSess.Close() //nolint:errcheck // test cleanup
+	serverSess, err := smux.Server(serverConn, serverCfg)
+	if err != nil {
+		t.Fatalf("smux.Server: %v", err)
+	}
+	defer serverSess.Close() //nolint:errcheck // test cleanup
+
+	const banner = "SSH-2.0-OpenSSH_9.0\r\n"
+
+	serverErr := make(chan error, 1)
+	go func() {
+		stream, err := serverSess.AcceptStream()
+		if err != nil {
+			serverErr <- err
+			return
+		}
+		defer stream.Close() //nolint:errcheck // test cleanup
+
+		env, err := protocol.ReadStreamEnvelope(stream)
+		if err != nil {
+			serverErr <- err
+			return
+		}
+		if env.Target != "ssh-host:22" {
+			serverErr <- errors.New("unexpected target: " + env.Target)
+			return
+		}
+		if err := protocol.WriteStreamResponse(stream, protocol.ConnectResponse{
+			Version: protocol.CurrentVersion,
+			OK:      true,
+		}); err != nil {
+			serverErr <- err
+			return
+		}
+		// Immediately push the "target" banner with no gap.
+		if _, err := stream.Write([]byte(banner)); err != nil {
+			serverErr <- err
+			return
+		}
+		serverErr <- nil
+	}()
+
+	stream, err := clientSess.OpenStream()
+	if err != nil {
+		t.Fatalf("OpenStream: %v", err)
+	}
+	defer stream.Close() //nolint:errcheck // test cleanup
+
+	if _, err := sendEnvelopeOverStream(context.Background(), stream, "ssh-host:22", "", 0); err != nil {
+		t.Fatalf("sendEnvelopeOverStream: %v", err)
+	}
+
+	// Read what's left on the stream after sendEnvelopeOverStream
+	// returns. With length-prefixed framing this is exactly the banner.
+	// With json.NewDecoder it would be empty (banner consumed into the
+	// decoder's buffer and discarded), so this assertion catches the
+	// regression.
+	got := make([]byte, len(banner))
+	if err := stream.SetReadDeadline(time.Now().Add(2 * time.Second)); err != nil {
+		t.Fatalf("SetReadDeadline: %v", err)
+	}
+	if _, err := io.ReadFull(stream, got); err != nil {
+		t.Fatalf("read banner: %v (got %q)", err, got)
+	}
+	if string(got) != banner {
+		t.Fatalf("banner = %q, want %q", got, banner)
+	}
+
+	select {
+	case err := <-serverErr:
+		if err != nil {
+			t.Fatalf("server: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("server did not finish in time")
+	}
+}
+
+// TestSendEnvelopeOverStream_Rejection covers the listener-rejects-target
+// case (allowlist denial, dial failure). The error should bubble up with
+// the listener's message intact.
+func TestSendEnvelopeOverStream_Rejection(t *testing.T) {
+	clientConn, serverConn := net.Pipe()
+	clientSess, err := smux.Client(clientConn, smuxClientCfg())
+	if err != nil {
+		t.Fatalf("smux.Client: %v", err)
+	}
+	defer clientSess.Close() //nolint:errcheck // test cleanup
+	serverSess, err := smux.Server(serverConn, smuxClientCfg())
+	if err != nil {
+		t.Fatalf("smux.Server: %v", err)
+	}
+	defer serverSess.Close() //nolint:errcheck // test cleanup
+
+	go func() {
+		stream, err := serverSess.AcceptStream()
+		if err != nil {
+			return
+		}
+		defer stream.Close() //nolint:errcheck // test cleanup
+		if _, err := protocol.ReadStreamEnvelope(stream); err != nil {
+			return
+		}
+		_ = protocol.WriteStreamResponse(stream, protocol.ConnectResponse{
+			Version: protocol.CurrentVersion,
+			Error:   "target not allowed",
+		})
+	}()
+
+	stream, err := clientSess.OpenStream()
+	if err != nil {
+		t.Fatalf("OpenStream: %v", err)
+	}
+	defer stream.Close() //nolint:errcheck // test cleanup
+
+	_, err = sendEnvelopeOverStream(context.Background(), stream, "blocked-host:22", "", 0)
+	if err == nil {
+		t.Fatal("expected error for rejected target")
+	}
+	if !bytes.Contains([]byte(err.Error()), []byte("target not allowed")) {
+		t.Errorf("error = %v, want it to contain 'target not allowed'", err)
+	}
+}
+
+// TestSendEnvelopeOverStream_StreamDeath covers the case where the smux
+// session dies after the envelope is sent but before a response arrives
+// (e.g. WS dropped). sendEnvelopeOverStream must return an error rather
+// than block forever.
+func TestSendEnvelopeOverStream_StreamDeath(t *testing.T) {
+	clientConn, serverConn := net.Pipe()
+	clientSess, err := smux.Client(clientConn, smuxClientCfg())
+	if err != nil {
+		t.Fatalf("smux.Client: %v", err)
+	}
+	defer clientSess.Close() //nolint:errcheck // test cleanup
+	serverSess, err := smux.Server(serverConn, smuxClientCfg())
+	if err != nil {
+		t.Fatalf("smux.Server: %v", err)
+	}
+
+	// Server: accept a stream, read the envelope, then tear down the
+	// session before responding.
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		stream, err := serverSess.AcceptStream()
+		if err != nil {
+			return
+		}
+		_, _ = protocol.ReadStreamEnvelope(stream)
+		_ = serverSess.Close()
+	}()
+
+	stream, err := clientSess.OpenStream()
+	if err != nil {
+		t.Fatalf("OpenStream: %v", err)
+	}
+	defer stream.Close() //nolint:errcheck // test cleanup
+	_ = stream.SetReadDeadline(time.Now().Add(2 * time.Second))
+
+	_, err = sendEnvelopeOverStream(context.Background(), stream, "host:22", "", 0)
+	if err == nil {
+		t.Fatal("expected error after session death, got nil")
+	}
+	wg.Wait()
+}
+
+// TestSendEnvelopeOverStream_DeadlineUnresponsivePeer is the regression
+// guard for the "envelope read has no deadline, so a peer that accepts
+// the smux stream but never replies pins the pool slot until process
+// shutdown" finding. The server here accepts the stream and reads the
+// envelope but never sends a response. sendEnvelopeOverStream must
+// return within muxStreamHandshakeTimeout (capped here at 1s via
+// ctx.Deadline so the test is fast).
+func TestSendEnvelopeOverStream_DeadlineUnresponsivePeer(t *testing.T) {
+	clientConn, serverConn := net.Pipe()
+	clientSess, err := smux.Client(clientConn, smuxClientCfg())
+	if err != nil {
+		t.Fatalf("smux.Client: %v", err)
+	}
+	defer clientSess.Close() //nolint:errcheck // test cleanup
+	serverSess, err := smux.Server(serverConn, smuxClientCfg())
+	if err != nil {
+		t.Fatalf("smux.Server: %v", err)
+	}
+	defer serverSess.Close() //nolint:errcheck // test cleanup
+
+	// Server: accept the stream, read the envelope, then sit forever
+	// without sending a response.
+	var wg sync.WaitGroup
+	wg.Add(1)
+	stop := make(chan struct{})
+	go func() {
+		defer wg.Done()
+		stream, err := serverSess.AcceptStream()
+		if err != nil {
+			return
+		}
+		defer stream.Close() //nolint:errcheck // test cleanup
+		_, _ = protocol.ReadStreamEnvelope(stream)
+		<-stop // never reply
+	}()
+
+	stream, err := clientSess.OpenStream()
+	if err != nil {
+		t.Fatalf("OpenStream: %v", err)
+	}
+	defer stream.Close() //nolint:errcheck // test cleanup
+
+	// Caller ctx with a 1s deadline — sendEnvelopeOverStream should
+	// honour the tighter of (ctx deadline, muxStreamHandshakeTimeout).
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := sendEnvelopeOverStream(ctx, stream, "host:22", "", 0)
+		done <- err
+	}()
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("expected error from unresponsive peer, got nil")
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("sendEnvelopeOverStream blocked > 3s on unresponsive peer (deadline not applied)")
+	}
+	close(stop)
+	wg.Wait()
+}
+
+// TestSendEnvelopeOverStream_CtxCancelUnresponsivePeer asserts that a
+// caller-driven ctx cancellation (e.g. user kills curl) unblocks the
+// envelope exchange even when neither the stream deadline nor any
+// other timeout has fired.
+func TestSendEnvelopeOverStream_CtxCancelUnresponsivePeer(t *testing.T) {
+	clientConn, serverConn := net.Pipe()
+	clientSess, err := smux.Client(clientConn, smuxClientCfg())
+	if err != nil {
+		t.Fatalf("smux.Client: %v", err)
+	}
+	defer clientSess.Close() //nolint:errcheck // test cleanup
+	serverSess, err := smux.Server(serverConn, smuxClientCfg())
+	if err != nil {
+		t.Fatalf("smux.Server: %v", err)
+	}
+	defer serverSess.Close() //nolint:errcheck // test cleanup
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	stop := make(chan struct{})
+	go func() {
+		defer wg.Done()
+		stream, err := serverSess.AcceptStream()
+		if err != nil {
+			return
+		}
+		defer stream.Close() //nolint:errcheck // test cleanup
+		_, _ = protocol.ReadStreamEnvelope(stream)
+		<-stop // never reply
+	}()
+
+	stream, err := clientSess.OpenStream()
+	if err != nil {
+		t.Fatalf("OpenStream: %v", err)
+	}
+	defer stream.Close() //nolint:errcheck // test cleanup
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := sendEnvelopeOverStream(ctx, stream, "host:22", "", 0)
+		done <- err
+	}()
+
+	// Give the goroutine a moment to enter ReadStreamResponse.
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("expected error after ctx cancel, got nil")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("sendEnvelopeOverStream did not return within 2s of ctx cancel")
+	}
+	close(stop)
+	wg.Wait()
+}
+
+func TestIsMuxUnsupportedRejection(t *testing.T) {
+	tests := []struct {
+		msg  string
+		want bool
+	}{
+		{"missing target", true},
+		{"Missing target", true},
+		{"unsupported protocol version", true},
+		{"Unsupported Protocol Version 99", true},
+		{"invalid envelope", true},
+		{"target not allowed", false},
+		{"connection failed", false},
+		{"connection refused", false},
+		{"", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.msg, func(t *testing.T) {
+			if got := isMuxUnsupportedRejection(tt.msg); got != tt.want {
+				t.Errorf("isMuxUnsupportedRejection(%q) = %v, want %v", tt.msg, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNewMuxDialer_Defaults(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	d := NewMuxDialer(ctx, "https://example.servicebus.windows.net", "test-hc", stubTokenProvider{}, relay.ClientOptions{}, nil, nil)
+	if d == nil {
+		t.Fatal("NewMuxDialer returned nil")
+	}
+	if d.logger == nil {
+		t.Error("logger should default to slog.Default()")
+	}
+	if d.parentCtx != ctx {
+		t.Error("parentCtx not preserved")
+	}
+	// Close should be safe on an un-connected dialer.
+	d.Close()
+	d.Close() // idempotent
+}
+
+func TestMuxDialer_StickyFallback(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	tp := stubTokenProvider{}
+	d := NewMuxDialer(ctx, "https://example.servicebus.windows.net", "test-hc", tp, relay.ClientOptions{}, nil, nil)
+	// Simulate a prior rejection — the rejection is sticky for
+	// muxUnavailableTTL so concurrent callers fast-path to v1 without
+	// re-paying the rendezvous cost.
+	d.muxUnavailUntil.Store(time.Now().Add(muxUnavailableTTL).UnixNano())
+
+	_, err := d.OpenStream(ctx)
+	if !errors.Is(err, ErrMuxUnsupported) {
+		t.Fatalf("OpenStream should return ErrMuxUnsupported during sticky window, got %v", err)
+	}
+
+	// After the TTL elapses, the next call attempts a real dial. We use
+	// a pre-cancelled ctx to force a fast deterministic failure that is
+	// NOT ErrMuxUnsupported.
+	d.muxUnavailUntil.Store(time.Now().Add(-time.Second).UnixNano())
+	cancelledCtx, cancelNow := context.WithCancel(context.Background())
+	cancelNow()
+	_, err = d.OpenStream(cancelledCtx)
+	if errors.Is(err, ErrMuxUnsupported) {
+		t.Fatal("after TTL expiry, OpenStream should attempt a real dial, not return ErrMuxUnsupported")
+	}
+	if err == nil {
+		t.Fatal("expected dial error against cancelled ctx")
+	}
+}
+
+// TestMuxDialer_TerminalAfterCtxCancel guards the "no zombie reconnect"
+// invariant that MuxPool relies on for safe per-session eviction during
+// graceful rotation. Once the dialer's parentCtx is cancelled (the pool
+// cancels each session's per-session ctx in evictSession), OpenStream
+// must NOT attempt a fresh dial — it must return ErrMuxDialerClosed.
+//
+// Without this guarantee, a goroutine that reserved a slot on session
+// S, then raced past the pool's selector before S was evicted, could
+// trigger an untracked relay rendezvous on an "already-evicted" dialer.
+func TestMuxDialer_TerminalAfterCtxCancel(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	d := NewMuxDialer(ctx, "https://example.servicebus.windows.net", "test-hc", stubTokenProvider{}, relay.ClientOptions{}, nil, nil)
+	cancel()
+
+	_, err := d.OpenStream(context.Background())
+	if !errors.Is(err, ErrMuxDialerClosed) {
+		t.Fatalf("expected ErrMuxDialerClosed after parentCtx cancel, got %v", err)
+	}
+}
+
+// TestMuxDialer_RemoteClosedSession_NoGaugeLeak is the regression test
+// for the mux_sessions_active leak that occurred when a session was
+// closed by the peer (or hit smux keepalive death) and OpenStream was
+// then called again on the same dialer. The old code path took the
+// `d.session != nil` branch but the OpenStream call returned an error,
+// triggering reconnect through connectLocked without first running
+// closeSessionLocked — leaking one gauge increment per dead session.
+//
+// The fix in OpenStream calls closeSessionLocked() when IsClosed() is
+// true, so a subsequent connectLocked starts from a clean slate.
+func TestMuxDialer_RemoteClosedSession_NoGaugeLeak(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	m := metrics.New()
+
+	d := NewMuxDialer(
+		ctx,
+		"https://example.servicebus.windows.net",
+		"test-hc",
+		stubTokenProvider{},
+		relay.ClientOptions{},
+		nil,
+		m,
+	)
+
+	// Build a real smux session paired across net.Pipe, then close it
+	// so IsClosed() returns true. The dialer treats this as a remotely
+	// closed session.
+	clientConn, serverConn := net.Pipe()
+	clientSess, err := smux.Client(clientConn, smuxClientCfg())
+	if err != nil {
+		t.Fatalf("smux.Client: %v", err)
+	}
+	serverSess, err := smux.Server(serverConn, smuxClientCfg())
+	if err != nil {
+		t.Fatalf("smux.Server: %v", err)
+	}
+	t.Cleanup(func() { _ = serverSess.Close() })
+
+	// Simulate a prior successful connect by incrementing the gauge,
+	// then assigning the session and closing it.
+	m.MuxSessionOpened("sender")
+	d.session = clientSess
+	if err := clientSess.Close(); err != nil {
+		t.Fatalf("close clientSess: %v", err)
+	}
+	if !clientSess.IsClosed() {
+		t.Fatal("clientSess should be closed")
+	}
+
+	// OpenStream goes through the IsClosed() branch, calls
+	// closeSessionLocked (gauge → 0), then connectLocked. We use a
+	// pre-cancelled ctx so the dial fails immediately rather than
+	// attempting a real DNS lookup against example.servicebus.windows.net.
+	// The gauge decrement happens before connectLocked, so an early
+	// dial failure does not affect the assertion.
+	cancelledCtx, cancelNow := context.WithCancel(context.Background())
+	cancelNow()
+	_, _ = d.OpenStream(cancelledCtx)
+
+	if got := gaugeValue(t, m.Registry, "aztunnel_mux_sessions_active", "sender"); got != 0 {
+		t.Fatalf("mux_sessions_active{sender} = %v after OpenStream on a closed session, want 0 (gauge leak)", got)
+	}
+}
+
+// TestMuxDialer_FastPathHonorsCallerCtx is the regression test for the
+// per-call ctx hole on the established-session fast path. The smux
+// session's OpenStream is not ctx-aware, so without an explicit
+// re-check the dialer would return a stream past the caller's
+// admission deadline. The fix closes the just-opened stream and
+// returns ctx.Err() so the pool's ctx-typed-error handling path can
+// release the slot and surface the cancellation to the caller.
+func TestMuxDialer_FastPathHonorsCallerCtx(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	m := metrics.New()
+	d := NewMuxDialer(
+		ctx,
+		"https://example.servicebus.windows.net",
+		"test-hc",
+		stubTokenProvider{},
+		relay.ClientOptions{},
+		nil,
+		m,
+	)
+
+	// Plant a real, open smux session in the dialer so the
+	// established-session fast path is reachable without a relay
+	// dial. Mirrors the setup in
+	// TestMuxDialer_RemoteClosedSession_NoGaugeLeak.
+	clientConn, serverConn := net.Pipe()
+	clientSess, err := smux.Client(clientConn, smuxClientCfg())
+	if err != nil {
+		t.Fatalf("smux.Client: %v", err)
+	}
+	serverSess, err := smux.Server(serverConn, smuxClientCfg())
+	if err != nil {
+		t.Fatalf("smux.Server: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = clientSess.Close()
+		_ = serverSess.Close()
+	})
+	// Accept-loop on the server side so the fast-path
+	// clientSess.OpenStream completes (smux requires the peer to
+	// accept the new stream).
+	go func() {
+		for {
+			s, err := serverSess.AcceptStream()
+			if err != nil {
+				return
+			}
+			_ = s.Close()
+		}
+	}()
+	d.session = clientSess
+
+	// Pre-cancelled caller ctx. The dialer's parentCtx is still
+	// alive, so without the fix the fast path would happily return
+	// a stream.
+	cancelledCtx, cancelNow := context.WithCancel(context.Background())
+	cancelNow()
+	stream, err := d.OpenStream(cancelledCtx)
+	if err == nil {
+		_ = stream.Close()
+		t.Fatalf("OpenStream returned a stream for pre-cancelled ctx; want ctx.Canceled")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("OpenStream err = %v, want context.Canceled", err)
+	}
+}
+
+// gaugeValue reads a single label combination of a gauge from a
+// Prometheus registry. Returns 0 if the metric / label combination is
+// absent.
+func gaugeValue(t *testing.T, reg interface {
+	Gather() ([]*dto.MetricFamily, error)
+}, name, role string,
+) float64 {
+	t.Helper()
+	fams, err := reg.Gather()
+	if err != nil {
+		t.Fatalf("Gather: %v", err)
+	}
+	for _, fam := range fams {
+		if fam.GetName() != name {
+			continue
+		}
+		for _, m := range fam.GetMetric() {
+			for _, lp := range m.GetLabel() {
+				if lp.GetName() == "role" && lp.GetValue() == role {
+					return m.GetGauge().GetValue()
+				}
+			}
+		}
+	}
+	return 0
+}
+
+// counterValue reads a counter from a Prometheus registry, summing
+// across all samples whose labels match the supplied label/value pairs.
+// Pairs are flat: ["role", "sender", "reason", "relay_failed"].
+// Returns 0 if no matching samples are found.
+func counterValue(t *testing.T, reg interface {
+	Gather() ([]*dto.MetricFamily, error)
+}, name string, pairs ...string,
+) float64 {
+	t.Helper()
+	if len(pairs)%2 != 0 {
+		t.Fatalf("counterValue: pairs length must be even, got %d", len(pairs))
+	}
+	want := make(map[string]string, len(pairs)/2)
+	for i := 0; i < len(pairs); i += 2 {
+		want[pairs[i]] = pairs[i+1]
+	}
+	fams, err := reg.Gather()
+	if err != nil {
+		t.Fatalf("Gather: %v", err)
+	}
+	var total float64
+	for _, fam := range fams {
+		if fam.GetName() != name {
+			continue
+		}
+		for _, m := range fam.GetMetric() {
+			got := map[string]string{}
+			for _, lp := range m.GetLabel() {
+				got[lp.GetName()] = lp.GetValue()
+			}
+			match := true
+			for k, v := range want {
+				if got[k] != v {
+					match = false
+					break
+				}
+			}
+			if match {
+				total += m.GetCounter().GetValue()
+			}
+		}
+	}
+	return total
+}
+
+// stubTokenProvider is a minimal TokenProvider for tests that need a
+// non-nil tp but never actually dial (ctx is cancelled first).
+type stubTokenProvider struct{}
+
+func (stubTokenProvider) GetToken(ctx context.Context, resourceURI string) (string, error) {
+	return "", ctx.Err()
+}
+
+// smuxClientCfg returns the same config muxdialer.go uses, so tests use
+// the production timings (specifically the keepalive interval that must be
+// shorter than Azure Relay's idle timeout in production).
+func smuxClientCfg() *smux.Config {
+	return muxconfig.SmuxConfig()
+}
+
+// TestMergeCancelCtx_CancelsOnA verifies the merged ctx fires when the
+// caller's ctx (a) is cancelled — preserving normal "caller gave up"
+// semantics.
+func TestMergeCancelCtx_CancelsOnA(t *testing.T) {
+	t.Parallel()
+	a, cancelA := context.WithCancel(context.Background())
+	b, cancelB := context.WithCancel(context.Background())
+	defer cancelB()
+
+	merged, cancelMerged := mergeCancelCtx(a, b)
+	defer cancelMerged()
+
+	cancelA()
+	select {
+	case <-merged.Done():
+	case <-time.After(time.Second):
+		t.Fatal("merged ctx did not fire when a was cancelled")
+	}
+}
+
+// TestMergeCancelCtx_CancelsOnB is the regression test for the Fix A
+// concurrency hole: when the pool evicts a dialer, it cancels the
+// dialer's parentCtx (b). Without mergeCancelCtx, a slow in-flight dial
+// scoped only to the caller's ctx would NOT see the eviction signal and
+// could publish an untracked session after eviction completed.
+//
+// The merged ctx MUST fire when b alone is cancelled.
+func TestMergeCancelCtx_CancelsOnB(t *testing.T) {
+	t.Parallel()
+	a, cancelA := context.WithCancel(context.Background())
+	defer cancelA()
+	b, cancelB := context.WithCancel(context.Background())
+
+	merged, cancelMerged := mergeCancelCtx(a, b)
+	defer cancelMerged()
+
+	cancelB()
+	select {
+	case <-merged.Done():
+	case <-time.After(time.Second):
+		t.Fatal("merged ctx did not fire when b (parentCtx) was cancelled — eviction would not abort dial")
+	}
+}
+
+// TestMergeCancelCtx_ReleasesWatcher ensures the watcher goroutine
+// exits when neither ctx fires and the caller invokes the returned
+// cancel func — i.e. the helper does not leak goroutines on the happy
+// path where the dial completes before any ctx is cancelled.
+func TestMergeCancelCtx_ReleasesWatcher(t *testing.T) {
+	t.Parallel()
+	a, cancelA := context.WithCancel(context.Background())
+	defer cancelA()
+	b, cancelB := context.WithCancel(context.Background())
+	defer cancelB()
+
+	merged, cancelMerged := mergeCancelCtx(a, b)
+	cancelMerged() // simulates the deferred cancel after a successful dial
+
+	select {
+	case <-merged.Done():
+	case <-time.After(time.Second):
+		t.Fatal("merged ctx did not fire after cancelMerged was called")
+	}
+	// Goroutine leak would be detected by -race / -count=1 / leaktest
+	// frameworks. The select{stop} branch should fire.
+}
+
+// TestMergeCancelCtx_CancelIdempotent verifies the returned cancel func
+// is safe to call multiple times. The internal `close(stop)` would
+// panic on a second call without sync.Once protection — a sharp edge
+// that would land if a future refactor added an explicit dialCancel()
+// alongside the defer (common pattern).
+func TestMergeCancelCtx_CancelIdempotent(t *testing.T) {
+	t.Parallel()
+	a, cancelA := context.WithCancel(context.Background())
+	defer cancelA()
+	b, cancelB := context.WithCancel(context.Background())
+	defer cancelB()
+
+	_, cancelMerged := mergeCancelCtx(a, b)
+	cancelMerged()
+	cancelMerged() // must NOT panic
+}
+
+// TestConnectLocked_RewritesErrorOnParentCancel is the regression test
+// for the eviction-during-dial bug GPT-5.5 flagged. When d.parentCtx
+// is cancelled while connectLocked is in flight, the underlying dial
+// returns a wrapped context.Canceled error like "dial relay: ... :
+// context canceled". MuxPool.OpenStream only retries on
+// ErrMuxDialerClosed — so without the defer rewrite, the caller would
+// see a hard failure instead of the pool selecting another session.
+//
+// This test pre-cancels parentCtx so the underlying relay.DialWithRetry
+// fails immediately (real DNS skipped), then asserts the returned error
+// is ErrMuxDialerClosed via errors.Is.
+func TestConnectLocked_RewritesErrorOnParentCancel(t *testing.T) {
+	t.Parallel()
+
+	parent, cancelParent := context.WithCancel(context.Background())
+	d := NewMuxDialer(parent, "https://example.servicebus.windows.net", "test-hc",
+		stubTokenProvider{}, relay.ClientOptions{}, nil, nil)
+	cancelParent()
+
+	d.mu.Lock()
+	err := d.connectLocked(context.Background())
+	d.mu.Unlock()
+
+	if !errors.Is(err, ErrMuxDialerClosed) {
+		t.Fatalf("expected ErrMuxDialerClosed when parentCtx is cancelled mid-dial, got %v", err)
+	}
+}
+
+// TestWatchSession_DecrementsGaugeOnAsyncClose is the regression test
+// for the gauge-leak Copilot flagged: when a smux session is closed
+// asynchronously (peer close, keepalive timeout, transport error),
+// nothing was observing that state until the next OpenStream call —
+// so aztunnel_mux_sessions_active could report a dead session as
+// active for arbitrarily long.
+//
+// The fix spawns a watcher goroutine that blocks on sess.AcceptStream
+// (NOT sess.CloseChan — smux v1.5.57 only fires CloseChan on explicit
+// Close, not on transport-level errors). When AcceptStream returns an
+// error, the watcher decrements via closeSessionLocked once the
+// session dies. This test publishes a live session into d.session,
+// increments the gauge to simulate the post-connect state, starts the
+// watcher, then breaks the transport from the peer side and asserts
+// the gauge drops to 0 within a bounded time without any intervening
+// OpenStream call.
+func TestWatchSession_DecrementsGaugeOnAsyncClose(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	m := metrics.New()
+	d := NewMuxDialer(
+		ctx,
+		"https://example.servicebus.windows.net",
+		"test-hc",
+		stubTokenProvider{},
+		relay.ClientOptions{},
+		nil,
+		m,
+	)
+
+	clientConn, serverConn := net.Pipe()
+	clientSess, err := smux.Client(clientConn, smuxClientCfg())
+	if err != nil {
+		t.Fatalf("smux.Client: %v", err)
+	}
+	serverSess, err := smux.Server(serverConn, smuxClientCfg())
+	if err != nil {
+		t.Fatalf("smux.Server: %v", err)
+	}
+	t.Cleanup(func() { _ = serverSess.Close() })
+
+	// Simulate the post-connectLocked state.
+	m.MuxSessionOpened("sender")
+	d.session = clientSess
+	if got := gaugeValue(t, m.Registry, "aztunnel_mux_sessions_active", "sender"); got != 1 {
+		t.Fatalf("setup: mux_sessions_active{sender} = %v, want 1", got)
+	}
+
+	go d.watchSession(clientSess)
+
+	// Trigger async close (simulates peer-side close / keepalive
+	// timeout / network error): closing the underlying pipe from the
+	// server side breaks the transport. smux's recvLoop hits a read
+	// error and AcceptStream returns — which is what the watcher is
+	// blocked on.
+	_ = serverConn.Close()
+
+	// Poll the gauge until it drops to 0 (bounded by smux keepalive
+	// detection + watcher scheduling). 2 seconds is generous.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if gaugeValue(t, m.Registry, "aztunnel_mux_sessions_active", "sender") == 0 {
+			return // success
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	t.Fatalf("mux_sessions_active{sender} = %v after async session close, want 0 (watcher did not fire / decrement leaked)",
+		gaugeValue(t, m.Registry, "aztunnel_mux_sessions_active", "sender"))
+}
+
+// TestWatchSession_NoDoubleDecrementWithSyncClose verifies that the
+// watcher does NOT double-decrement when closeSessionLocked is called
+// synchronously from another path (e.g. MuxDialer.Close or the
+// IsClosed() branch of OpenStream). The watcher's `d.session == sess`
+// guard must skip the second decrement.
+func TestWatchSession_NoDoubleDecrementWithSyncClose(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	m := metrics.New()
+	d := NewMuxDialer(
+		ctx,
+		"https://example.servicebus.windows.net",
+		"test-hc",
+		stubTokenProvider{},
+		relay.ClientOptions{},
+		nil,
+		m,
+	)
+
+	clientConn, serverConn := net.Pipe()
+	clientSess, err := smux.Client(clientConn, smuxClientCfg())
+	if err != nil {
+		t.Fatalf("smux.Client: %v", err)
+	}
+	serverSess, err := smux.Server(serverConn, smuxClientCfg())
+	if err != nil {
+		t.Fatalf("smux.Server: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = serverSess.Close()
+		_ = serverConn.Close()
+	})
+
+	m.MuxSessionOpened("sender")
+	d.session = clientSess
+
+	go d.watchSession(clientSess)
+
+	// Synchronous close path: simulates MuxDialer.Close racing with the
+	// watcher. closeSessionLocked decrements first, sets d.session=nil;
+	// the watcher then sees d.session != sess and must skip.
+	d.Close()
+
+	// Wait for the watcher to observe the close + drop the lock.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		// Watcher will eventually return from AcceptStream, acquire
+		// d.mu, see d.session != sess (because the sync Close path
+		// already nilled it) and exit without decrementing again.
+		// Repeated reads of the gauge stay at 0.
+		if gaugeValue(t, m.Registry, "aztunnel_mux_sessions_active", "sender") != 0 {
+			t.Fatalf("gauge went negative or above 0 — double-decrement: %v",
+				gaugeValue(t, m.Registry, "aztunnel_mux_sessions_active", "sender"))
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	if got := gaugeValue(t, m.Registry, "aztunnel_mux_sessions_active", "sender"); got != 0 {
+		t.Fatalf("final gauge = %v, want 0", got)
+	}
+}
+
+// TestSendEnvelopeOverStream_RespectsCustomTimeout verifies that a
+// caller-supplied handshakeTimeout (smaller than the package default)
+// bounds the envelope+response exchange. Regression guard for the
+// configurable --mux-stream-handshake-timeout flag.
+func TestSendEnvelopeOverStream_RespectsCustomTimeout(t *testing.T) {
+	clientConn, serverConn := net.Pipe()
+	clientSess, err := smux.Client(clientConn, smuxClientCfg())
+	if err != nil {
+		t.Fatalf("smux.Client: %v", err)
+	}
+	defer clientSess.Close() //nolint:errcheck // test cleanup
+	serverSess, err := smux.Server(serverConn, smuxClientCfg())
+	if err != nil {
+		t.Fatalf("smux.Server: %v", err)
+	}
+	defer serverSess.Close() //nolint:errcheck // test cleanup
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	stop := make(chan struct{})
+	go func() {
+		defer wg.Done()
+		stream, err := serverSess.AcceptStream()
+		if err != nil {
+			return
+		}
+		defer stream.Close() //nolint:errcheck // test cleanup
+		_, _ = protocol.ReadStreamEnvelope(stream)
+		<-stop // never reply
+	}()
+
+	stream, err := clientSess.OpenStream()
+	if err != nil {
+		t.Fatalf("OpenStream: %v", err)
+	}
+	defer stream.Close() //nolint:errcheck // test cleanup
+
+	// Custom 300ms timeout. Default is 60s; if the custom value is not
+	// honoured this test would block until that fires.
+	start := time.Now()
+	done := make(chan error, 1)
+	go func() {
+		_, err := sendEnvelopeOverStream(context.Background(), stream, "host:22", "", 300*time.Millisecond)
+		done <- err
+	}()
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("expected timeout error, got nil")
+		}
+		if elapsed := time.Since(start); elapsed > 2*time.Second {
+			t.Errorf("custom handshakeTimeout not honoured: returned after %v, expected ~300ms", elapsed)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("sendEnvelopeOverStream blocked > 2s with custom 300ms handshakeTimeout")
+	}
+	close(stop)
+	wg.Wait()
+}
+
+// TestMuxDialer_UnavailableLockFree is the regression guard for the
+// finding that opener.Unavailable() called under p.mu could block the
+// entire pool when the dialer mutex (d.mu) was held by a long relay
+// dial. Unavailable() must be a lock-free atomic read.
+func TestMuxDialer_UnavailableLockFree(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	d := NewMuxDialer(ctx, "https://example.servicebus.windows.net", "test-hc",
+		stubTokenProvider{}, relay.ClientOptions{}, nil, nil)
+
+	// Acquire d.mu in a separate goroutine and hold it for 500ms,
+	// simulating an in-flight relay dial under connectLocked.
+	held := make(chan struct{})
+	release := make(chan struct{})
+	go func() {
+		d.mu.Lock()
+		defer d.mu.Unlock()
+		close(held)
+		<-release
+	}()
+	<-held
+	defer close(release)
+
+	// Unavailable() must return quickly even though d.mu is held.
+	type result struct {
+		val     bool
+		elapsed time.Duration
+	}
+	res := make(chan result, 1)
+	go func() {
+		t0 := time.Now()
+		v := d.Unavailable()
+		res <- result{val: v, elapsed: time.Since(t0)}
+	}()
+	select {
+	case r := <-res:
+		if r.elapsed > 50*time.Millisecond {
+			t.Errorf("Unavailable() took %v while d.mu was held; must be lock-free", r.elapsed)
+		}
+		if r.val {
+			t.Errorf("unset dialer should report Unavailable()=false")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Unavailable() blocked on d.mu — regression in lock-free read")
+	}
+
+	// Repeat with the sticky flag armed to confirm the positive case
+	// also stays lock-free.
+	d.muxUnavailUntil.Store(time.Now().Add(muxUnavailableTTL).UnixNano())
+	go func() {
+		t0 := time.Now()
+		v := d.Unavailable()
+		res <- result{val: v, elapsed: time.Since(t0)}
+	}()
+	select {
+	case r := <-res:
+		if r.elapsed > 50*time.Millisecond {
+			t.Errorf("Unavailable() took %v while d.mu was held (armed); must be lock-free", r.elapsed)
+		}
+		if !r.val {
+			t.Errorf("armed dialer should report Unavailable()=true")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Unavailable() blocked on d.mu while armed")
+	}
+}
+
+// TestMuxDialer_ParentCancelSuppressesDialMetric is the regression
+// guard for the false-positive `connection_errors_total{relay_failed}`
+// emission when parentCtx is cancelled mid-dial (internal pool
+// eviction/rotation/shutdown). The dial returns ctx.Canceled but
+// because parentCtx is also done, the failure is an internal signal
+// the pool will recover from — not a relay-side failure.
+func TestMuxDialer_ParentCancelSuppressesDialMetric(t *testing.T) {
+	m := metrics.New()
+	parentCtx, cancel := context.WithCancel(context.Background())
+	d := NewMuxDialer(parentCtx, "https://test.invalid", "test-hc",
+		stubTokenProvider{}, relay.ClientOptions{}, nil, m)
+
+	// Cancel parentCtx BEFORE the dial — DialWithRetry will return
+	// ctx.Canceled immediately without network I/O, and the
+	// parentCtx-suppression path must not call ConnectionError.
+	cancel()
+
+	// Bypass OpenStream's fast-path parentCtx check so we exercise
+	// connectLocked's dial+metric handling directly.
+	d.mu.Lock()
+	err := d.connectLocked(context.Background())
+	d.mu.Unlock()
+
+	if !errors.Is(err, ErrMuxDialerClosed) {
+		t.Fatalf("expected ErrMuxDialerClosed, got %v", err)
+	}
+
+	// Sum across all reasons — the false metric appears as
+	// reason=relay_failed today, but the suppression must hold
+	// regardless of how DialReason classifies a context.Canceled.
+	for _, reason := range []string{
+		metrics.ReasonRelayFailed,
+		metrics.ReasonDialTimeout,
+		metrics.ReasonDialFailed,
+	} {
+		if got := counterValue(t, m.Registry, "aztunnel_connection_errors_total", "role", "sender", "reason", reason); got != 0 {
+			t.Errorf("connection_errors_total{sender, %s} = %v, want 0 (parent-cancel must not record dial failure)", reason, got)
+		}
+	}
+}

--- a/internal/sender/muxpool.go
+++ b/internal/sender/muxpool.go
@@ -1,0 +1,922 @@
+package sender
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/philsphicas/aztunnel/internal/metrics"
+	"github.com/philsphicas/aztunnel/internal/relay"
+)
+
+// ErrMuxPoolClosed is returned by MuxPool.OpenStream after the pool has
+// been closed. It is distinct from net.ErrClosed so callers can
+// distinguish "the pool went away" from "a particular stream's connection
+// was closed".
+var ErrMuxPoolClosed = errors.New("mux pool: closed")
+
+// Pool sizing and rotation timing defaults. Exported so callers can
+// log effective values before NewMuxPool is invoked (see PortForward
+// and SOCKS5Proxy). See MuxPoolOptions.RotateAfter / RotateGrace for
+// the rotation rationale.
+const (
+	// DefaultMuxSessions is the default cap on non-draining mux
+	// sessions kept open by the pool (MuxPoolOptions.MaxSessions). 2
+	// lets the pool grow lazily for bursty multi-stream workloads (and
+	// spreads them across two HA listeners when available) while
+	// staying at a single rendezvous for typical single-stream
+	// workloads — `selectOrGrowLocked` keeps session 0 pinned until
+	// concurrent traffic actually forces a grow.
+	DefaultMuxSessions = 2
+
+	// DefaultMaxStreamsPerSession is the default per-session stream
+	// cap (MuxPoolOptions.MaxStreamsPerSession). Sized to comfortably
+	// cover typical port-forward / SOCKS5 fan-out without saturating
+	// smux's internal frame buffers.
+	DefaultMaxStreamsPerSession = 256
+
+	// defaultMuxRotateAfter is the default age at which a session is
+	// marked for graceful rotation. Empirical probing against Azure
+	// Relay shows that sender rendezvous WebSockets survive past their
+	// SAS token's `se=` timestamp indefinitely as long as keepalives
+	// flow — token validation happens at handshake only. So rotation
+	// is primarily defensive (fleet rebalancing across HA listeners,
+	// guarding against unknown long-term relay limits), not a
+	// correctness requirement. 6h gives 4 rotations/day for HA spread
+	// without disrupting typical long-lived streams.
+	defaultMuxRotateAfter = 6 * time.Hour
+
+	// defaultMuxRotateGrace bounds how long the rotation watcher waits
+	// for in-flight streams to drain before force-closing the session.
+	// Force-close is destructive: streams that overlap the rotation
+	// boundary by more than the grace window are killed. At a 6h
+	// cadence it fires rarely, but when it does, workloads that need
+	// a single stream to live across the boundary uninterrupted
+	// should pin the sender to v1 (--max-protocol-version=1) instead.
+	defaultMuxRotateGrace = 5 * time.Minute
+)
+
+// muxOpener is the abstraction MuxPool needs from each session it
+// manages. *MuxDialer implements this directly; tests inject fakes.
+type muxOpener interface {
+	// OpenStream opens a new logical stream over this session's underlying
+	// mux. Returns ErrMuxUnsupported if the peer rejected the v2 handshake.
+	OpenStream(ctx context.Context) (net.Conn, error)
+
+	// Close tears down the underlying session and frees its resources.
+	Close()
+
+	// Unavailable reports whether this opener is in its sticky v1-fallback
+	// window. The pool uses this to skip the session for new streams and
+	// to decide when to propagate ErrMuxUnsupported to the caller.
+	Unavailable() bool
+}
+
+// dialerFactory builds a fresh muxOpener bound to the supplied lifetime
+// context. The pool calls this to grow lazily, passing a per-session
+// cancelable ctx (NOT the pool ctx) so that eviction can permanently kill
+// a single session without affecting other pool members. Production
+// wires the factory to NewMuxDialer; tests inject fakes.
+type dialerFactory func(sessCtx context.Context) muxOpener
+
+// MuxPoolOptions configures a MuxPool. All fields are required unless
+// noted otherwise. See NewMuxPool for defaults.
+type MuxPoolOptions struct {
+	Endpoint      string
+	EntityPath    string
+	TokenProvider relay.TokenProvider
+	ClientOptions relay.ClientOptions
+	Logger        *slog.Logger
+	Metrics       *metrics.Metrics
+
+	// MaxSessions caps the number of non-draining mux sessions the pool
+	// will keep open at once. Draining sessions (in their rotation grace
+	// window) do NOT count toward this limit, so a rotation never
+	// stalls new streams. Larger values may spread load across multiple
+	// HA listeners. Defaults to 1.
+	MaxSessions int
+
+	// MaxStreamsPerSession bounds the number of concurrent logical
+	// streams per session. Stream openers block (with ctx) until a slot
+	// frees up when all sessions are at this cap and the pool is at
+	// MaxSessions. Defaults to 256.
+	MaxStreamsPerSession int
+
+	// RotateAfter is how long after a session is established it gets
+	// flagged for graceful rotation. Rotation is primarily defensive
+	// (HA fleet rebalancing and defence-in-depth against unknown
+	// long-term relay limits); empirical probing shows Azure Relay does
+	// not actively tear down rendezvous WebSockets at SAS token
+	// expiry. Defaults to 6 hours when set to 0; set to a large value
+	// (e.g. 24h) to effectively disable rotation in tests.
+	RotateAfter time.Duration
+
+	// RotateGrace bounds how long the rotation watcher waits for active
+	// streams to finish naturally after the session begins draining.
+	// On expiry the watcher force-closes the underlying mux, killing
+	// any remaining streams. Defaults to 5 minutes.
+	RotateGrace time.Duration
+}
+
+// MuxPool holds a set of persistent mux sessions and dispatches each new
+// logical stream to one of them. The pool grows lazily up to
+// MaxSessions whenever every existing session is currently servicing one
+// or more in-flight streams; this gives bursty traffic a chance to spread
+// across multiple Azure Relay rendezvous (and thus, in practice, multiple
+// listeners in an HA fleet) without paying the cost of N rendezvous up
+// front. Single-stream-at-a-time workloads stay on session 0 forever.
+//
+// Sessions are rotated periodically (see RotateAfter). Rotation is
+// defensive — Azure Relay validates SAS tokens at handshake time only,
+// and rendezvous WebSockets survive past the token's `se=` indefinitely
+// as long as keepalives flow — so rotation primarily exists for HA fleet
+// rebalancing and defence-in-depth against unknown long-term relay
+// limits. Rotation drains gracefully when possible and force-closes
+// after RotateGrace.
+type MuxPool struct {
+	opts    MuxPoolOptions
+	factory dialerFactory
+
+	// poolCtx is derived from the caller's ctx at construction; cancelled
+	// by Close. Per-session ctxs are derived from poolCtx so that pool
+	// teardown cancels every session.
+	poolCtx context.Context
+	cancel  context.CancelFunc
+
+	mu       sync.Mutex
+	sessions []*pooledSession
+	notifyCh chan struct{} // close-and-replace on every slot release/close (broadcast wakeup)
+	closed   bool
+
+	// unsupportedUntil is a pool-level sticky cache for the v1-fallback
+	// signal. When any session evicts due to ErrMuxUnsupported (the
+	// listener is v1-only), we record the rejection here so subsequent
+	// OpenStream calls fast-path to ErrMuxUnsupported without dialing.
+	// Without this, MaxSessions > 1 against an all-v1 fleet would re-
+	// dial and evict fresh v2 attempts on every local connection until
+	// enough unavailable sessions accumulated to hit allUnavail — adding
+	// repeated failed rendezvous latency. Mirrors the per-dialer
+	// muxUnavailUntil TTL.
+	unsupportedUntil time.Time
+}
+
+// pooledSession wraps a single muxOpener with bookkeeping. inFlight and
+// slots together implement per-session admission control:
+//   - slots is a buffered channel sized to MaxStreamsPerSession;
+//     reserving a slot is a non-blocking send;
+//     releasing is a single receive.
+//   - inFlight is atomically updated alongside slot reservation so the
+//     pool can pick the least-loaded session without taking p.mu.
+//
+// Rotation fields (set when the session is created):
+//   - sessCtx / sessCancel: cancelled by evictSession to make the
+//     underlying MuxDialer terminal — prevents zombie reconnects.
+//   - birth / rotateAt: timestamps of this *pool slot*, not of the
+//     underlying relay WebSocket. MuxDialer can transparently
+//     reconnect after its smux session dies (see MuxDialer.OpenStream's
+//     slow path), which gives the slot a fresher WebSocket without
+//     updating birth/rotateAt — so the slot's rotation cadence is
+//     decoupled from any individual WS's lifetime.
+//   - draining: set true under p.mu when rotateAt is reached; thereafter
+//     selectOrGrowLocked skips this session for new streams.
+//   - drained: closed by releaseSlot exactly once when draining AND
+//     inFlight reaches 0. The watcher selects on it to know when graceful
+//     drain has completed.
+//   - evicted: closed by evictSession exactly once. The watcher selects
+//     on it to bail out if some other path (e.g. ErrMuxUnsupported)
+//     evicted this session first.
+type pooledSession struct {
+	opener   muxOpener
+	slots    chan struct{}
+	inFlight atomic.Int64
+
+	sessCtx    context.Context
+	sessCancel context.CancelFunc
+
+	birth    time.Time
+	rotateAt time.Time
+
+	draining    atomic.Bool
+	drained     chan struct{}
+	drainedOnce sync.Once
+	evicted     chan struct{}
+	evictedOnce sync.Once
+	// recordOnce ensures the per-session lifecycle-exit metric is
+	// emitted at most once per session. Without it, a watchRotation
+	// that has passed the grace select and a Close() taking the same
+	// session snapshot could both call RecordMuxRotation for the same
+	// session, double-counting exits and ages.
+	recordOnce sync.Once
+}
+
+// recordRotation emits the per-session lifecycle-exit metric for s
+// exactly once. Despite the name, this covers all exit reasons
+// (scheduled rotation, forced rotation, ErrMuxUnsupported, open-failed
+// eviction, pool close) — not just scheduled rotations. Subsequent
+// calls (from any path: watchRotation, Close, the ErrMuxUnsupported
+// eviction path in OpenStream, the open-failed eviction path) are
+// no-ops.
+func (s *pooledSession) recordRotation(m *metrics.Metrics, reason string) {
+	s.recordOnce.Do(func() {
+		m.RecordMuxRotation("sender", time.Since(s.birth), reason)
+	})
+}
+
+// NewMuxPool builds a pool bound to ctx. The returned pool dials lazily;
+// the first OpenStream call creates session 0. Close is safe to call
+// multiple times.
+func NewMuxPool(ctx context.Context, opts MuxPoolOptions) *MuxPool {
+	if opts.Logger == nil {
+		opts.Logger = slog.Default()
+	}
+	if opts.MaxSessions <= 0 {
+		opts.MaxSessions = DefaultMuxSessions
+	}
+	if opts.MaxStreamsPerSession <= 0 {
+		opts.MaxStreamsPerSession = DefaultMaxStreamsPerSession
+	}
+	if opts.RotateAfter <= 0 {
+		opts.RotateAfter = defaultMuxRotateAfter
+	}
+	if opts.RotateGrace <= 0 {
+		opts.RotateGrace = defaultMuxRotateGrace
+	}
+	poolCtx, cancel := context.WithCancel(ctx)
+	p := &MuxPool{
+		opts:     opts,
+		poolCtx:  poolCtx,
+		cancel:   cancel,
+		notifyCh: make(chan struct{}),
+	}
+	p.factory = func(sessCtx context.Context) muxOpener {
+		return NewMuxDialer(sessCtx, opts.Endpoint, opts.EntityPath, opts.TokenProvider, opts.ClientOptions, opts.Logger, opts.Metrics)
+	}
+	return p
+}
+
+// newMuxPoolWithFactory is the test-only constructor that lets a test
+// inject a fake muxOpener factory. Behaviour is identical to NewMuxPool
+// in production.
+func newMuxPoolWithFactory(ctx context.Context, opts MuxPoolOptions, factory dialerFactory) *MuxPool {
+	p := NewMuxPool(ctx, opts)
+	p.factory = factory
+	return p
+}
+
+// OpenStream returns a new net.Conn-wrapped logical stream. The supplied
+// ctx scopes the underlying handshake; it does NOT govern the lifetime
+// of the returned stream (the caller's bridge owns that).
+//
+// Behaviour:
+//   - If a session is idle (inFlight == 0) and available, it is reused.
+//   - Otherwise, if the pool has room to grow (< MaxSessions), a fresh
+//     session is opened. This is what gives bursty workloads HA spread.
+//   - Otherwise, the least-loaded existing session is used (subject to
+//     its MaxStreamsPerSession cap).
+//   - If every session is at the per-session cap AND the pool is at
+//     MaxSessions, the call blocks until a slot frees (or ctx expires).
+//   - If every session is in the sticky v1-fallback window AND the pool
+//     is at MaxSessions, ErrMuxUnsupported is returned so the caller can
+//     fall through to v1.
+func (p *MuxPool) OpenStream(ctx context.Context) (net.Conn, error) {
+	start := time.Now()
+	// Bound the number of evictions per OpenStream call. Without this,
+	// growing-then-evicting an unsupported session loops forever when
+	// the relay only hosts v1 listeners. The bound is MaxSessions
+	// because that's a reasonable retry budget — but Azure Relay's
+	// listener selection is opaque (load balancing is non-uniform per
+	// the multi-listener e2e probe), so this is not a *guarantee* of
+	// reaching a v2-capable listener within MaxSessions tries. After
+	// the budget is exhausted, the pool-level sticky cache short-
+	// circuits subsequent calls to ErrMuxUnsupported for
+	// muxUnavailableTTL, so retry cost stays bounded across the whole
+	// run.
+	maxEvictions := p.opts.MaxSessions
+	if maxEvictions <= 0 {
+		maxEvictions = 1
+	}
+	evictions := 0
+	// preferExisting flips true after we evict a session for a non-
+	// Unsupported open failure. It instructs selectOrGrowLocked to skip
+	// the "grow a fresh session" path when an existing healthy non-
+	// draining session is available, so we route to that session's
+	// spare stream capacity instead of churning another fresh dial
+	// against the same outage. Reset semantics: this is a per-call
+	// flag; a fresh OpenStream invocation starts with it false.
+	preferExisting := false
+
+	for {
+		// Honor caller-ctx cancellation/expiry BEFORE reserving a
+		// slot. Without this, a caller whose ctx was already done at
+		// entry (e.g. an admission timeout that fired just before the
+		// goroutine got CPU time) would still receive a stream — the
+		// established-session fast path inside MuxDialer.OpenStream
+		// only checks parentCtx, not the caller's ctx. Checking here
+		// also closes the corresponding race for callers that cancel
+		// before entry. Bonus: this is the only way the saturation
+		// metric stays clean — a precancelled caller must not race the
+		// `select` below.
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		p.mu.Lock()
+		if p.closed {
+			p.mu.Unlock()
+			return nil, ErrMuxPoolClosed
+		}
+		// If the parent ctx (passed to NewMuxPool) was cancelled
+		// WITHOUT pool.Close() being called, poolCtx is done but
+		// p.closed is still false. Every session's dialer ctx is
+		// derived from poolCtx, so each opener.OpenStream returns
+		// ErrMuxDialerClosed and the retry loop below would spin
+		// indefinitely. Treat a done poolCtx as closed so shutdown
+		// returns deterministically.
+		if p.poolCtx.Err() != nil {
+			p.mu.Unlock()
+			return nil, ErrMuxPoolClosed
+		}
+		// Pool-level sticky v1-fallback: if a recent eviction confirmed
+		// the listener fleet is v1-only, fast-path to ErrMuxUnsupported
+		// for muxUnavailableTTL so we don't re-pay the rendezvous cost
+		// on every new local connection.
+		if !p.unsupportedUntil.IsZero() && time.Now().Before(p.unsupportedUntil) {
+			p.mu.Unlock()
+			return nil, ErrMuxUnsupported
+		}
+		sess, allUnavail := p.selectOrGrowLocked(preferExisting)
+		waitCh := p.notifyCh
+		p.mu.Unlock()
+
+		if allUnavail {
+			p.mu.Lock()
+			p.unsupportedUntil = time.Now().Add(muxUnavailableTTL)
+			p.mu.Unlock()
+			return nil, ErrMuxUnsupported
+		}
+
+		if sess != nil {
+			stream, err := sess.opener.OpenStream(ctx)
+			if err != nil {
+				if errors.Is(err, ErrMuxUnsupported) {
+					evictions++
+					// Evict the now-known-v1 session so the slot
+					// frees and a fresh rendezvous can be attempted.
+					// Evict BEFORE releasing the slot so a concurrent
+					// waiter cannot reserve this session in the window
+					// between releaseSlot's broadcast and eviction.
+					sess.recordRotation(p.opts.Metrics, metrics.MuxRotationUnsupported)
+					p.evictSession(sess)
+					p.releaseSlot(sess)
+					if evictions >= maxEvictions {
+						// We've exhausted the retry budget against an
+						// all-v1 listener fleet. Set the pool-level
+						// sticky cache so subsequent OpenStream calls
+						// within muxUnavailableTTL fast-path to
+						// ErrMuxUnsupported without re-dialing — but
+						// ONLY if we have no working v2 session left.
+						// With MaxSessions > 1, a single busy v2
+						// session can coexist in another slot with
+						// repeated growth failures here; setting the
+						// pool-wide cache then would incorrectly
+						// disable mux for traffic that could still
+						// reuse the existing v2 session.
+						p.mu.Lock()
+						hasV2 := false
+						for _, s := range p.sessions {
+							if !s.draining.Load() && !s.opener.Unavailable() {
+								hasV2 = true
+								break
+							}
+						}
+						if !hasV2 {
+							p.unsupportedUntil = time.Now().Add(muxUnavailableTTL)
+							p.mu.Unlock()
+							return nil, ErrMuxUnsupported
+						}
+						// hasV2 = true: an existing v2 session may have
+						// spare stream capacity that the selector's
+						// grow-first ordering bypassed (the session was
+						// non-idle, so path 2 grew instead of trying
+						// pickLeastLoaded). Make one last attempt to
+						// reserve a slot on the least-loaded existing
+						// session before falling back to v1. If no slot
+						// is reservable OR the open fails, the caller
+						// gets ErrMuxUnsupported and uses v1 — a
+						// bounded operation — rather than blocking on
+						// the existing slot to free (potentially
+						// unbounded if the session has long-lived
+						// streams).
+						lastChance := p.pickLeastLoadedLocked()
+						p.mu.Unlock()
+						if lastChance == nil {
+							return nil, ErrMuxUnsupported
+						}
+						stream, err := lastChance.opener.OpenStream(ctx)
+						if err != nil {
+							// Caller-cancellation: surface the real
+							// reason, do not disturb the session's
+							// pool state. The session itself may
+							// still be healthy and useful to other
+							// callers.
+							if ctx.Err() != nil &&
+								(errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)) {
+								p.releaseSlot(lastChance)
+								return nil, fmt.Errorf("mux pool: open stream: %w", err)
+							}
+							// Genuine session-side failure (smux
+							// setup, handshake parse, ErrMuxDialerClosed
+							// from a concurrent eviction, or a rare
+							// mid-life ErrMuxUnsupported). Evict the
+							// session and record the rotation so it
+							// can't be reselected and operators see
+							// the signal in
+							// aztunnel_mux_rotations_total{reason=
+							// "open_failed"|"unsupported"}, mirroring
+							// the main retry loop's default failure
+							// handling. Then return ErrMuxUnsupported
+							// so the caller falls back to v1 — the
+							// one-shot is best-effort: a failure here
+							// should not turn into a hard connection
+							// error when v1 is available.
+							reason := metrics.MuxRotationOpenFailed
+							if errors.Is(err, ErrMuxUnsupported) {
+								reason = metrics.MuxRotationUnsupported
+							}
+							lastChance.recordRotation(p.opts.Metrics, reason)
+							p.evictSession(lastChance)
+							p.releaseSlot(lastChance)
+							// If the last-chance attempt itself
+							// confirmed v1 (ErrMuxUnsupported), the
+							// pool may now hold no v2-capable session.
+							// Mirror the maxEvictions-exhaustion arm
+							// above: re-scan and arm the pool-wide
+							// sticky cache so subsequent OpenStream
+							// calls fast-path to ErrMuxUnsupported
+							// without re-dialing for muxUnavailableTTL.
+							// Only ErrMuxUnsupported justifies the
+							// cache; an open_failed result is a
+							// session-side error and doesn't prove the
+							// listener fleet is v1-only.
+							if errors.Is(err, ErrMuxUnsupported) {
+								p.mu.Lock()
+								hasV2 := false
+								for _, s := range p.sessions {
+									if !s.draining.Load() && !s.opener.Unavailable() {
+										hasV2 = true
+										break
+									}
+								}
+								if !hasV2 {
+									p.unsupportedUntil = time.Now().Add(muxUnavailableTTL)
+								}
+								p.mu.Unlock()
+							}
+							return nil, ErrMuxUnsupported
+						}
+						p.opts.Metrics.ObserveMuxStreamOpen("sender", time.Since(start).Seconds())
+						return newPooledStream(stream, lastChance, p), nil
+					}
+					// A fresh rendezvous may land on a v2 listener.
+					continue
+				}
+				if errors.Is(err, ErrMuxDialerClosed) {
+					// This session was evicted (by rotation or some
+					// other path) between selector and Open. Retry on
+					// a different session.
+					p.releaseSlot(sess)
+					continue
+				}
+				// Caller cancellation surfaces as a context-typed
+				// error wrapped by the dialer (e.g. ErrMuxDialFailed
+				// wrapping context.Canceled). Don't disturb the pool's
+				// session state — the session itself may still be
+				// healthy and useful to other callers. The narrow
+				// guard (err must itself be context-caused) prevents a
+				// real session failure from being preserved just
+				// because the caller's ctx happened to expire after
+				// the failure but before we got here.
+				if ctx.Err() != nil &&
+					(errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)) {
+					p.releaseSlot(sess)
+					return nil, fmt.Errorf("mux pool: open stream: %w", err)
+				}
+				// The session's dialer is in an unhealthy state: the
+				// relay dial, handshake, or smux setup failed and its
+				// underlying session is now nil. Evict so the
+				// selector doesn't keep picking this broken-but-idle
+				// candidate over healthy busy sessions in other
+				// slots, and set preferExisting so the retry routes
+				// to those healthy sessions (sharing their spare
+				// stream capacity) instead of growing another fresh
+				// session that would hit the same outage. Bounded by
+				// the same eviction budget as the ErrMuxUnsupported
+				// path so a persistent outage cannot loop
+				// indefinitely; the caller's next OpenStream starts
+				// with a fresh budget.
+				evictions++
+				sess.recordRotation(p.opts.Metrics, metrics.MuxRotationOpenFailed)
+				p.evictSession(sess)
+				p.releaseSlot(sess)
+				if evictions >= maxEvictions {
+					return nil, fmt.Errorf("mux pool: open stream: %w", err)
+				}
+				preferExisting = true
+				continue
+			}
+			p.opts.Metrics.ObserveMuxStreamOpen("sender", time.Since(start).Seconds())
+			return newPooledStream(stream, sess, p), nil
+		}
+
+		// All sessions full and pool at MaxSessions. Wait.
+		select {
+		case <-waitCh:
+		case <-ctx.Done():
+			// Only count genuine pool saturation: caller's
+			// deadline expired while waiting AND we aren't in
+			// pool shutdown. Plain ctx.Canceled (caller-initiated
+			// shutdown) or a poolCtx race with ctx is not a
+			// saturation event.
+			if errors.Is(ctx.Err(), context.DeadlineExceeded) && p.poolCtx.Err() == nil {
+				p.opts.Metrics.MuxPoolSaturated("sender")
+			}
+			return nil, ctx.Err()
+		case <-p.poolCtx.Done():
+			return nil, ErrMuxPoolClosed
+		}
+	}
+}
+
+// selectOrGrowLocked is called with p.mu held. It either reserves a slot
+// on an existing/new session and returns it, returns (nil, true) if all
+// pool slots are exhausted by sticky-unavailable sessions (signalling v1
+// fallback), or returns (nil, false) if the caller should wait.
+//
+// Draining sessions (those in their rotation grace window) are skipped
+// in every path and are NOT counted toward MaxSessions — so a rotation
+// in progress never stalls new streams.
+//
+// preferExisting=true reorders the selector so existing-session
+// least-loaded selection is tried BEFORE growing a fresh session. The
+// OpenStream retry loop sets this after evicting a session that failed
+// to open a stream (dial/handshake/smux setup error), so the retry
+// routes to spare stream capacity on a healthy busy session rather
+// than churning another fresh dial that would likely hit the same
+// outage. Growth is still allowed as a fallback when no existing
+// session has a reservable slot, so the caller doesn't hang on
+// waitCh while pool budget remains.
+func (p *MuxPool) selectOrGrowLocked(preferExisting bool) (*pooledSession, bool) {
+	// 1. Look for an idle, available, non-draining session — single-
+	//    stream-at-a-time workloads stay on session 0 forever, avoiding
+	//    wasted relay dials.
+	for _, s := range p.sessions {
+		if s.draining.Load() {
+			continue
+		}
+		if !s.opener.Unavailable() && s.inFlight.Load() == 0 {
+			if p.tryReserveLocked(s) {
+				return s, false
+			}
+		}
+	}
+
+	// preferExisting routes the retry to spare capacity on an
+	// existing healthy session before attempting growth. If no
+	// existing session has a reservable slot, falls through to the
+	// growth path below.
+	if preferExisting {
+		if best := p.pickLeastLoadedLocked(); best != nil {
+			return best, false
+		}
+	}
+
+	// 2. If no idle session exists and the non-draining session count is
+	//    below MaxSessions, grow. Bursty traffic ends up spread across
+	//    new sessions, each of which may land on a different listener.
+	//    Draining sessions don't count toward the cap so a rotation
+	//    cannot starve new streams.
+	nonDraining := 0
+	for _, s := range p.sessions {
+		if !s.draining.Load() {
+			nonDraining++
+		}
+	}
+	if nonDraining < p.opts.MaxSessions {
+		ns := p.newSessionLocked()
+		p.tryReserveLocked(ns) // always succeeds — fresh channel
+		return ns, false
+	}
+
+	// 3. Pool at MaxSessions non-draining sessions. Pick the least-
+	//    loaded available, non-draining session that still has a free
+	//    slot. (Already attempted above if preferExisting was set, but
+	//    the pool composition can change under p.mu between the two
+	//    calls only via paths that hold p.mu — and we've held it the
+	//    whole time. The second call is harmless: it just returns nil
+	//    again. Avoiding it would require carrying the result through
+	//    the growth branch, which doesn't improve clarity.)
+	if best := p.pickLeastLoadedLocked(); best != nil {
+		return best, false
+	}
+
+	// 4. No slot free among non-draining sessions. Are ALL non-draining
+	//    sessions sticky-unavailable? (Draining sessions are excluded —
+	//    they're on their way out and will be replaced shortly.)
+	allUnavail := nonDraining > 0
+	for _, s := range p.sessions {
+		if s.draining.Load() {
+			continue
+		}
+		if !s.opener.Unavailable() {
+			allUnavail = false
+			break
+		}
+	}
+	return nil, allUnavail
+}
+
+// pickLeastLoadedLocked returns a reserved slot on the least-loaded
+// non-draining, non-unavailable session that still has free capacity.
+// Returns nil if no such session exists. Caller must hold p.mu.
+//
+// Reserves slots speculatively on each candidate to avoid TOCTOU
+// between inFlight read and reservation, then unreserves losers.
+func (p *MuxPool) pickLeastLoadedLocked() *pooledSession {
+	var best *pooledSession
+	for _, s := range p.sessions {
+		if s.draining.Load() || s.opener.Unavailable() {
+			continue
+		}
+		if p.tryReserveLocked(s) {
+			if best == nil || s.inFlight.Load() < best.inFlight.Load() {
+				if best != nil {
+					p.unreserveLocked(best)
+				}
+				best = s
+			} else {
+				p.unreserveLocked(s)
+			}
+		}
+	}
+	return best
+}
+
+// newSessionLocked constructs a fresh pooledSession with its own
+// cancelable ctx (rooted at poolCtx), appends it to p.sessions, and
+// starts the rotation watcher goroutine. Caller must hold p.mu.
+func (p *MuxPool) newSessionLocked() *pooledSession {
+	now := time.Now()
+	sessCtx, sessCancel := context.WithCancel(p.poolCtx)
+	ns := &pooledSession{
+		opener:     p.factory(sessCtx),
+		slots:      make(chan struct{}, p.opts.MaxStreamsPerSession),
+		sessCtx:    sessCtx,
+		sessCancel: sessCancel,
+		birth:      now,
+		rotateAt:   now.Add(p.opts.RotateAfter),
+		drained:    make(chan struct{}),
+		evicted:    make(chan struct{}),
+	}
+	p.sessions = append(p.sessions, ns)
+	go p.watchRotation(ns)
+	return ns
+}
+
+// watchRotation runs for the lifetime of one pooledSession. It sleeps
+// until rotateAt, marks the session draining (under p.mu, so it
+// serialises with selectOrGrowLocked), waits for active streams to
+// finish (or RotateGrace to elapse), then evicts the session. The
+// watcher exits early if the session is evicted by some other path
+// (ErrMuxUnsupported eviction in OpenStream, or pool Close).
+func (p *MuxPool) watchRotation(s *pooledSession) {
+	wait := time.Until(s.rotateAt)
+	if wait < 0 {
+		wait = 0
+	}
+	timer := time.NewTimer(wait)
+	defer timer.Stop()
+
+	select {
+	case <-timer.C:
+	case <-p.poolCtx.Done():
+		return
+	case <-s.evicted:
+		return
+	}
+
+	// Mark draining under p.mu so that:
+	//   - any concurrent selectOrGrowLocked either reserves BEFORE this
+	//     point (and thus is reflected in inFlight when we read it
+	//     below), or sees draining=true and skips this session.
+	//   - releaseSlot's "drain complete" close-of-drained race is
+	//     resolved with our own check below.
+	p.mu.Lock()
+	s.draining.Store(true)
+	alreadyDrained := s.inFlight.Load() == 0
+	p.mu.Unlock()
+	p.broadcast() // wake any waiters; they'll re-select past this session
+
+	if alreadyDrained {
+		s.drainedOnce.Do(func() { close(s.drained) })
+	}
+
+	graceTimer := time.NewTimer(p.opts.RotateGrace)
+	defer graceTimer.Stop()
+	reason := metrics.MuxRotationScheduled
+	select {
+	case <-s.drained:
+		// Graceful: all streams finished within the grace window.
+	case <-graceTimer.C:
+		// Grace window expired with streams still in flight. Force-
+		// close: this is a rotation-policy decision (we'd rather
+		// drop a few in-flight streams now than let sessions live
+		// indefinitely past our defensive 6h cap), not a correctness
+		// requirement — Azure validates SAS at handshake time only,
+		// so the WS itself would survive past rotateAfter as long
+		// as keepalives flow.
+		reason = metrics.MuxRotationForced
+	case <-p.poolCtx.Done():
+		return
+	case <-s.evicted:
+		return
+	}
+
+	age := time.Since(s.birth)
+	p.opts.Logger.Info("mux session rotated",
+		"age", age,
+		"reason", reason,
+		"in_flight_at_close", s.inFlight.Load())
+	s.recordRotation(p.opts.Metrics, reason)
+	p.evictSession(s)
+}
+
+// tryReserveLocked atomically reserves a slot on s and bumps its
+// inFlight counter. Returns false if s is already at the per-session cap.
+// Caller must hold p.mu.
+func (p *MuxPool) tryReserveLocked(s *pooledSession) bool {
+	select {
+	case s.slots <- struct{}{}:
+		s.inFlight.Add(1)
+		return true
+	default:
+		return false
+	}
+}
+
+// unreserveLocked is the inverse of tryReserveLocked. Caller must hold
+// p.mu.
+func (p *MuxPool) unreserveLocked(s *pooledSession) {
+	<-s.slots
+	s.inFlight.Add(-1)
+}
+
+// releaseSlot is called from the wrapped stream's Close, and from
+// OpenStream's error paths. It is the lock-free release counterpart of
+// tryReserveLocked + the broadcast wakeup.
+//
+// If this release brings inFlight to zero on a draining session, it
+// signals the rotation watcher that graceful drain is complete.
+func (p *MuxPool) releaseSlot(s *pooledSession) {
+	<-s.slots
+	rem := s.inFlight.Add(-1)
+	if rem == 0 && s.draining.Load() {
+		s.drainedOnce.Do(func() { close(s.drained) })
+	}
+	p.broadcast()
+}
+
+// broadcast wakes every waiter currently blocked in OpenStream. The
+// close-and-replace pattern is used because a 1-buffered notify channel
+// would coalesce wakeups and strand waiters when several slots free at
+// once.
+func (p *MuxPool) broadcast() {
+	p.mu.Lock()
+	old := p.notifyCh
+	p.notifyCh = make(chan struct{})
+	p.mu.Unlock()
+	close(old)
+}
+
+// evictSession removes s from the pool's slice and closes its opener.
+// Idempotent: a second call (e.g. from the rotation watcher after
+// OpenStream already evicted on ErrMuxUnsupported) is a no-op.
+//
+// The session's ctx is cancelled BEFORE the session is removed from
+// selector visibility (i.e. inside the p.mu critical section). This
+// is what makes MuxDialer terminal: any in-flight
+// MuxDialer.OpenStream that already selected this session and is
+// about to call session.OpenStream observes parentCtx.Err() != nil
+// on its post-OpenStream re-check and returns ErrMuxDialerClosed
+// instead of returning a stream from a doomed session. The pool's
+// retry loop then picks a fresh session.
+//
+// The actual opener.Close() (which tears down smux + websocket) is
+// deferred outside the lock — it's expensive and does not re-enter
+// MuxPool, so the lock can be released first.
+func (p *MuxPool) evictSession(s *pooledSession) {
+	p.mu.Lock()
+	found := false
+	for i, x := range p.sessions {
+		if x == s {
+			p.sessions = append(p.sessions[:i], p.sessions[i+1:]...)
+			found = true
+			break
+		}
+	}
+	if found {
+		s.evictedOnce.Do(func() { close(s.evicted) })
+		s.sessCancel()
+	}
+	p.mu.Unlock()
+	if !found {
+		return
+	}
+	s.opener.Close()
+	p.broadcast()
+}
+
+// Close tears down every session and makes future OpenStream calls fail
+// with ErrMuxPoolClosed. Idempotent.
+//
+// Like evictSession, the per-session contexts are cancelled INSIDE the
+// p.mu critical section — so concurrent OpenStream calls that already
+// selected a session observe parentCtx.Err() != nil on their post-
+// OpenStream re-check and return ErrMuxDialerClosed instead of a doomed
+// stream. The pool's poolCtx is then cancelled (outside the lock) so
+// new OpenStream callers fast-path to ErrMuxPoolClosed.
+func (p *MuxPool) Close() {
+	p.mu.Lock()
+	if p.closed {
+		p.mu.Unlock()
+		return
+	}
+	p.closed = true
+	sessions := p.sessions
+	p.sessions = nil
+	for _, s := range sessions {
+		s.evictedOnce.Do(func() { close(s.evicted) })
+		s.sessCancel()
+	}
+	p.mu.Unlock()
+
+	for _, s := range sessions {
+		s.recordRotation(p.opts.Metrics, metrics.MuxRotationPoolClosed)
+		s.opener.Close()
+	}
+	p.cancel()
+	p.broadcast()
+}
+
+// sessionCount returns the number of live sessions currently tracked by
+// the pool. Intended for tests that need to assert rotation eviction
+// happened.
+func (p *MuxPool) sessionCount() int {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return len(p.sessions)
+}
+
+// pooledStream wraps the smux.Stream net.Conn so Close() decrements the
+// pool's slot bookkeeping. Idempotent: double-close is safe.
+//
+// CloseWrite is implemented to delegate to the underlying conn so that
+// the half-close-aware bridge in metrics.TrackedStreamBridge actually
+// works for mux streams. Embedding net.Conn alone does not promote
+// CloseWrite from the underlying *smux.Stream (the embedded type is the
+// interface, not the concrete) — without this method, the bridge falls
+// back to Close() on EOF and tears down the whole stream before the
+// peer can drain remaining bytes for half-close protocols (HTTP/1.0,
+// SSH, SMTP).
+type pooledStream struct {
+	net.Conn
+	sess      *pooledSession
+	pool      *MuxPool
+	closeOnce sync.Once
+}
+
+func newPooledStream(c net.Conn, sess *pooledSession, pool *MuxPool) *pooledStream {
+	return &pooledStream{Conn: c, sess: sess, pool: pool}
+}
+
+func (s *pooledStream) Close() error {
+	closeErr := s.Conn.Close()
+	s.closeOnce.Do(func() {
+		s.pool.releaseSlot(s.sess)
+	})
+	return closeErr
+}
+
+// CloseWrite signals end-of-input to the peer without tearing down the
+// read direction. *smux.Stream implements CloseWrite; if the underlying
+// conn does not, fall back to Close() so callers still get a definite
+// signal (preserves prior behaviour for non-smux test fakes).
+func (s *pooledStream) CloseWrite() error {
+	if cw, ok := s.Conn.(interface{ CloseWrite() error }); ok {
+		return cw.CloseWrite()
+	}
+	return s.Conn.Close()
+}

--- a/internal/sender/muxpool_test.go
+++ b/internal/sender/muxpool_test.go
@@ -1,0 +1,1456 @@
+package sender
+
+import (
+	"context"
+	"errors"
+	"net"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/philsphicas/aztunnel/internal/metrics"
+)
+
+// --- fake opener for pool tests ---
+
+// fakeOpener is a deterministic muxOpener for MuxPool tests. It does not
+// actually open WebSockets; OpenStream returns net.Pipe() halves. The
+// fake exposes counters so tests can assert how many sessions the pool
+// created and how it distributed streams across them.
+type fakeOpener struct {
+	id          int
+	created     time.Time
+	mu          sync.Mutex
+	streamsOpen int
+	totalOpens  int
+	closed      atomic.Bool
+
+	// ctx is the per-session ctx passed to the factory by the pool.
+	// Tests assert that evictSession cancels it.
+	ctx context.Context
+
+	// behaviour knobs
+	openDelay    time.Duration
+	failOnce     atomic.Pointer[error] // single-shot OpenStream error
+	unavailable  atomic.Bool           // sticky v1-fallback
+	holdOnOpenCh chan struct{}         // nil = no hold; non-nil = OpenStream blocks until receive
+	// honorSessCtx makes OpenStream return ErrMuxDialerClosed when the
+	// per-session ctx (f.ctx, set by the pool factory) is done. This
+	// mirrors the real MuxDialer behaviour and is opt-in so existing
+	// tests that don't care about parent-ctx propagation stay simple.
+	honorSessCtx atomic.Bool
+}
+
+func (f *fakeOpener) OpenStream(ctx context.Context) (net.Conn, error) {
+	if f.honorSessCtx.Load() && f.ctx != nil && f.ctx.Err() != nil {
+		return nil, ErrMuxDialerClosed
+	}
+	if f.openDelay > 0 {
+		select {
+		case <-time.After(f.openDelay):
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+	}
+	if f.holdOnOpenCh != nil {
+		select {
+		case <-f.holdOnOpenCh:
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+	}
+	if errPtr := f.failOnce.Swap(nil); errPtr != nil {
+		return nil, *errPtr
+	}
+	f.mu.Lock()
+	f.streamsOpen++
+	f.totalOpens++
+	f.mu.Unlock()
+	a, b := net.Pipe()
+	return &countingFakeStream{Conn: a, parent: f, remote: b}, nil
+}
+
+func (f *fakeOpener) Close() {
+	f.closed.Store(true)
+}
+
+func (f *fakeOpener) Unavailable() bool {
+	return f.unavailable.Load()
+}
+
+type countingFakeStream struct {
+	net.Conn
+	parent *fakeOpener
+	remote net.Conn
+	once   sync.Once
+}
+
+func (s *countingFakeStream) Close() error {
+	s.once.Do(func() {
+		s.parent.mu.Lock()
+		s.parent.streamsOpen--
+		s.parent.mu.Unlock()
+		_ = s.remote.Close()
+	})
+	return s.Conn.Close()
+}
+
+// fakeFactory builds a dialerFactory backed by fakeOpener. Each factory
+// invocation returns a fresh opener and stores it in `created` so tests
+// can inspect/reach into the openers post-hoc. The optional `customize`
+// hook lets the test set per-opener knobs (e.g. mark some unavailable).
+func fakeFactory(t *testing.T, customize func(int, *fakeOpener)) (dialerFactory, *[]*fakeOpener) {
+	t.Helper()
+	var (
+		mu      sync.Mutex
+		created []*fakeOpener
+	)
+	factory := func(ctx context.Context) muxOpener {
+		mu.Lock()
+		id := len(created)
+		f := &fakeOpener{id: id, created: time.Now(), ctx: ctx}
+		if customize != nil {
+			customize(id, f)
+		}
+		created = append(created, f)
+		mu.Unlock()
+		return f
+	}
+	return factory, &created
+}
+
+// --- tests ---
+
+func newTestPool(t *testing.T, opts MuxPoolOptions, factory dialerFactory) *MuxPool {
+	t.Helper()
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	p := newMuxPoolWithFactory(ctx, opts, factory)
+	t.Cleanup(p.Close)
+	return p
+}
+
+// TestMuxPool_SerialReuseOneSession is the "idle session" optimization:
+// when traffic is strictly serial (open, use, close, repeat), the pool
+// must stick to session 0 forever and NOT create extra sessions just
+// because MaxSessions > 1. This avoids burning N rendezvous on light
+// workloads.
+func TestMuxPool_SerialReuseOneSession(t *testing.T) {
+	factory, created := fakeFactory(t, nil)
+	pool := newTestPool(t, MuxPoolOptions{MaxSessions: 4, MaxStreamsPerSession: 8}, factory)
+
+	for i := range 5 {
+		stream, err := pool.OpenStream(context.Background())
+		if err != nil {
+			t.Fatalf("OpenStream #%d: %v", i, err)
+		}
+		_ = stream.Close()
+	}
+
+	if got := len(*created); got != 1 {
+		t.Errorf("len(created) = %d, want 1 (serial workload should reuse one session)", got)
+	}
+}
+
+// TestMuxPool_GrowsUnderConcurrency verifies the HA-spread design goal:
+// when several streams are in flight at once, the pool grows up to
+// MaxSessions so the streams are spread across multiple rendezvous (and
+// thus, in practice, may land on different HA listeners).
+func TestMuxPool_GrowsUnderConcurrency(t *testing.T) {
+	factory, created := fakeFactory(t, nil)
+	pool := newTestPool(t, MuxPoolOptions{MaxSessions: 3, MaxStreamsPerSession: 100}, factory)
+
+	streams := make([]net.Conn, 3)
+	for i := range 3 {
+		s, err := pool.OpenStream(context.Background())
+		if err != nil {
+			t.Fatalf("OpenStream #%d: %v", i, err)
+		}
+		streams[i] = s
+	}
+	for _, s := range streams {
+		defer s.Close() //nolint:errcheck // test cleanup
+	}
+
+	if got := len(*created); got != 3 {
+		t.Errorf("len(created) = %d, want 3 (concurrent workload should grow to MaxSessions)", got)
+	}
+}
+
+// TestMuxPool_GrowthCappedAtMaxSessions verifies that once the pool
+// reaches MaxSessions, additional concurrent streams reuse existing
+// sessions rather than creating more.
+func TestMuxPool_GrowthCappedAtMaxSessions(t *testing.T) {
+	factory, created := fakeFactory(t, nil)
+	pool := newTestPool(t, MuxPoolOptions{MaxSessions: 2, MaxStreamsPerSession: 100}, factory)
+
+	const N = 5
+	streams := make([]net.Conn, 0, N)
+	for range N {
+		s, err := pool.OpenStream(context.Background())
+		if err != nil {
+			t.Fatalf("OpenStream: %v", err)
+		}
+		streams = append(streams, s)
+	}
+	defer func() {
+		for _, s := range streams {
+			_ = s.Close()
+		}
+	}()
+
+	if got := len(*created); got != 2 {
+		t.Errorf("len(created) = %d, want 2 (capped at MaxSessions)", got)
+	}
+}
+
+// TestMuxPool_BlocksAtCap_AndWakesOnRelease covers admission control:
+// with MaxSessions=1 and MaxStreamsPerSession=1, the first OpenStream
+// succeeds, the second blocks, and closing the first wakes the second.
+func TestMuxPool_BlocksAtCap_AndWakesOnRelease(t *testing.T) {
+	factory, _ := fakeFactory(t, nil)
+	pool := newTestPool(t, MuxPoolOptions{MaxSessions: 1, MaxStreamsPerSession: 1}, factory)
+
+	first, err := pool.OpenStream(context.Background())
+	if err != nil {
+		t.Fatalf("OpenStream #1: %v", err)
+	}
+
+	type result struct {
+		s   net.Conn
+		err error
+	}
+	secondCh := make(chan result, 1)
+	go func() {
+		s, err := pool.OpenStream(context.Background())
+		secondCh <- result{s, err}
+	}()
+
+	select {
+	case r := <-secondCh:
+		t.Fatalf("second OpenStream should have blocked, got s=%v err=%v", r.s, r.err)
+	case <-time.After(100 * time.Millisecond):
+		// ok — still blocked
+	}
+
+	if err := first.Close(); err != nil {
+		t.Fatalf("close first: %v", err)
+	}
+
+	select {
+	case r := <-secondCh:
+		if r.err != nil {
+			t.Fatalf("second OpenStream returned error after release: %v", r.err)
+		}
+		_ = r.s.Close()
+	case <-time.After(2 * time.Second):
+		t.Fatal("second OpenStream did not unblock after first was closed")
+	}
+}
+
+// TestMuxPool_BlocksAtCap_RespectsCtx ensures a waiting OpenStream
+// returns ctx.Err() promptly when its caller ctx is cancelled.
+func TestMuxPool_BlocksAtCap_RespectsCtx(t *testing.T) {
+	factory, _ := fakeFactory(t, nil)
+	pool := newTestPool(t, MuxPoolOptions{MaxSessions: 1, MaxStreamsPerSession: 1}, factory)
+
+	first, err := pool.OpenStream(context.Background())
+	if err != nil {
+		t.Fatalf("OpenStream #1: %v", err)
+	}
+	defer first.Close() //nolint:errcheck // test cleanup
+
+	ctx, cancel := context.WithCancel(context.Background())
+	type result struct{ err error }
+	ch := make(chan result, 1)
+	go func() {
+		_, err := pool.OpenStream(ctx)
+		ch <- result{err}
+	}()
+
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+
+	select {
+	case r := <-ch:
+		if !errors.Is(r.err, context.Canceled) {
+			t.Fatalf("expected context.Canceled, got %v", r.err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("OpenStream did not return after ctx cancel")
+	}
+}
+
+// TestMuxPool_EvictsAndRetriesOnUnsupported covers mixed-version HA
+// rollouts: when a session reports ErrMuxUnsupported, the pool evicts it
+// (it does NOT remain in the pool as a sticky-unavailable slot — that was
+// the old behaviour before the bounded retry budget) and retries with a
+// fresh rendezvous, which may land on a different v2-capable listener.
+// After the bounded retry budget is exhausted the pool sets its sticky
+// fallback cache and returns ErrMuxUnsupported.
+func TestMuxPool_EvictsAndRetriesOnUnsupported(t *testing.T) {
+	mu := &sync.Mutex{}
+	v1OpenerCount := 0
+
+	factory, created := fakeFactory(t, func(id int, f *fakeOpener) {
+		mu.Lock()
+		isV1 := v1OpenerCount < 2
+		if isV1 {
+			v1OpenerCount++
+		}
+		mu.Unlock()
+		if isV1 {
+			err := ErrMuxUnsupported
+			f.failOnce.Store(&err)
+			f.unavailable.Store(true)
+		}
+	})
+	pool := newTestPool(t, MuxPoolOptions{MaxSessions: 4, MaxStreamsPerSession: 1}, factory)
+
+	stream, err := pool.OpenStream(context.Background())
+	if err != nil {
+		t.Fatalf("OpenStream: %v (created %d openers)", err, len(*created))
+	}
+	defer stream.Close() //nolint:errcheck // test cleanup
+
+	if got := len(*created); got != 3 {
+		t.Errorf("len(created) = %d, want 3 (2 v1-evict, then 1 v2-success)", got)
+	}
+}
+
+// TestMuxPool_AllUnavailableReturnsErrMuxUnsupported verifies the
+// terminal v1-fallback path: when every dial within the bounded
+// eviction budget returns ErrMuxUnsupported, the pool evicts each
+// session as it fails, stops after MaxSessions attempts, returns
+// ErrMuxUnsupported, AND populates the pool-level sticky
+// `unsupportedUntil` cache so subsequent calls within
+// muxUnavailableTTL short-circuit without re-dialing.
+func TestMuxPool_AllUnavailableReturnsErrMuxUnsupported(t *testing.T) {
+	factory, created := fakeFactory(t, func(_ int, f *fakeOpener) {
+		err := ErrMuxUnsupported
+		f.failOnce.Store(&err)
+		f.unavailable.Store(true)
+	})
+	pool := newTestPool(t, MuxPoolOptions{MaxSessions: 2, MaxStreamsPerSession: 1}, factory)
+
+	_, err := pool.OpenStream(context.Background())
+	if !errors.Is(err, ErrMuxUnsupported) {
+		t.Fatalf("expected ErrMuxUnsupported when all sessions unavailable, got %v", err)
+	}
+	// With MaxSessions=2 we should attempt exactly 2 mux rendezvous
+	// before declaring the fleet v1-only — not 3. Each extra failed
+	// rendezvous is a full WebSocket dial + envelope exchange paid on
+	// every cold-start v1 fallback.
+	if got := len(*created); got != 2 {
+		t.Errorf("first OpenStream against all-v1 fleet dialed %d openers; want 2 (MaxSessions)", got)
+	}
+
+	// Pool-level sticky cache: a follow-up OpenStream call within
+	// muxUnavailableTTL must short-circuit without dialing a fresh
+	// opener (which would re-pay the rendezvous cost against the same
+	// known-v1 fleet).
+	dialsBefore := len(*created)
+	_, err = pool.OpenStream(context.Background())
+	if !errors.Is(err, ErrMuxUnsupported) {
+		t.Fatalf("expected ErrMuxUnsupported on second call within sticky window, got %v", err)
+	}
+	if got := len(*created); got != dialsBefore {
+		t.Errorf("second OpenStream call dialed %d additional opener(s); want 0 (sticky cache leak)", got-dialsBefore)
+	}
+}
+
+// TestMuxPool_UnsupportedScopedToNoV2Left is the regression guard for
+// the "setting pool-wide unsupported cache after maxEvictions can
+// disable mux even when a working v2 session still exists in another
+// slot" finding. The sticky cache must only be committed when there is
+// no working v2 session left in the pool — otherwise traffic that
+// could reuse the established v2 session is forced to v1 for the next
+// muxUnavailableTTL.
+func TestMuxPool_UnsupportedScopedToNoV2Left(t *testing.T) {
+	// Session 0 is v2 and works. Sessions 1+ are v1-only: each first
+	// OpenStream returns ErrMuxUnsupported and the opener is sticky-
+	// unavailable so selectOrGrowLocked skips it in the future.
+	factory, _ := fakeFactory(t, func(id int, f *fakeOpener) {
+		if id >= 1 {
+			err := ErrMuxUnsupported
+			f.failOnce.Store(&err)
+			f.unavailable.Store(true)
+		}
+	})
+	pool := newTestPool(t, MuxPoolOptions{MaxSessions: 2, MaxStreamsPerSession: 1}, factory)
+
+	// Warm up session 0. Hold its slot so subsequent OpenStream
+	// forces growth into session 1+ (the v1-only fleet).
+	s0, err := pool.OpenStream(context.Background())
+	if err != nil {
+		t.Fatalf("warmup OpenStream: %v", err)
+	}
+
+	// Trigger growth. Each new session lands on the v1-only fake
+	// fleet and returns ErrMuxUnsupported. After maxEvictions, the
+	// pool's per-call budget is exhausted and OpenStream returns
+	// ErrMuxUnsupported — but session 0 is still alive and v2, so
+	// the pool-wide sticky cache MUST NOT be set.
+	_, err = pool.OpenStream(context.Background())
+	if !errors.Is(err, ErrMuxUnsupported) {
+		t.Fatalf("growth-failure OpenStream: got %v, want ErrMuxUnsupported", err)
+	}
+
+	// Release session 0's slot and reopen. With the fix, the pool's
+	// unsupportedUntil is unset (session 0 is still v2), so the next
+	// OpenStream picks session 0 and succeeds. Without the fix, the
+	// sticky cache short-circuits this call to ErrMuxUnsupported and
+	// mux is wrongly disabled for muxUnavailableTTL.
+	_ = s0.Close()
+	s2, err := pool.OpenStream(context.Background())
+	if err != nil {
+		t.Fatalf("post-growth-failure OpenStream (session 0 should still be usable): got %v", err)
+	}
+	_ = s2.Close()
+}
+
+// TestMuxPool_CloseWakesWaiter verifies pool teardown wakes blocked
+// OpenStream goroutines with ErrMuxPoolClosed.
+func TestMuxPool_CloseWakesWaiter(t *testing.T) {
+	factory, _ := fakeFactory(t, nil)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	pool := newMuxPoolWithFactory(ctx, MuxPoolOptions{MaxSessions: 1, MaxStreamsPerSession: 1}, factory)
+
+	first, err := pool.OpenStream(context.Background())
+	if err != nil {
+		t.Fatalf("OpenStream #1: %v", err)
+	}
+	defer first.Close() //nolint:errcheck // test cleanup
+
+	type result struct {
+		s   net.Conn
+		err error
+	}
+	ch := make(chan result, 1)
+	go func() {
+		s, err := pool.OpenStream(context.Background())
+		ch <- result{s, err}
+	}()
+
+	time.Sleep(50 * time.Millisecond)
+	pool.Close()
+
+	select {
+	case r := <-ch:
+		if !errors.Is(r.err, ErrMuxPoolClosed) {
+			t.Fatalf("expected ErrMuxPoolClosed after Close, got %v", r.err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("OpenStream did not return after Close")
+	}
+}
+
+// TestMuxPool_CloseIsPermanent ensures OpenStream calls after Close
+// return ErrMuxPoolClosed and do NOT silently create new sessions. This
+// is the regression guard for the "MuxPool.Close must be permanent"
+// finding from review.
+func TestMuxPool_CloseIsPermanent(t *testing.T) {
+	factory, created := fakeFactory(t, nil)
+	pool := newTestPool(t, MuxPoolOptions{MaxSessions: 4, MaxStreamsPerSession: 4}, factory)
+
+	// Warm up so the pool has at least one session, then close.
+	s, err := pool.OpenStream(context.Background())
+	if err != nil {
+		t.Fatalf("warmup OpenStream: %v", err)
+	}
+	_ = s.Close()
+	priorCount := len(*created)
+	pool.Close()
+
+	// Idempotent: second Close is a no-op.
+	pool.Close()
+
+	for range 3 {
+		_, err := pool.OpenStream(context.Background())
+		if !errors.Is(err, ErrMuxPoolClosed) {
+			t.Fatalf("OpenStream after Close returned %v, want ErrMuxPoolClosed", err)
+		}
+	}
+	if got := len(*created); got != priorCount {
+		t.Errorf("Close should not allow new session creation; created went from %d to %d", priorCount, got)
+	}
+}
+
+// TestMuxPool_ParentCtxCancelReturnsClosed is the regression guard for
+// the "OpenStream spins when parent ctx is cancelled but pool.Close()
+// is never called" finding. Because each pooled session's sessCtx is
+// derived from p.poolCtx, cancelling the parent ctx causes every
+// dialer to return ErrMuxDialerClosed; without a poolCtx.Err() check
+// at the top of the retry loop, OpenStream would spin forever because
+// p.closed is still false. The fix surfaces ErrMuxPoolClosed instead.
+//
+// Note: this test opts the fakeOpener into honorSessCtx so it faithfully
+// mirrors MuxDialer's parent-ctx propagation (returns ErrMuxDialerClosed
+// when its session ctx is done) — this is what makes the loop spin
+// without the fix.
+func TestMuxPool_ParentCtxCancelReturnsClosed(t *testing.T) {
+	factory, created := fakeFactory(t, func(_ int, f *fakeOpener) {
+		f.honorSessCtx.Store(true)
+	})
+	parentCtx, cancelParent := context.WithCancel(context.Background())
+	pool := newMuxPoolWithFactory(parentCtx, MuxPoolOptions{MaxSessions: 2, MaxStreamsPerSession: 4}, factory)
+	t.Cleanup(pool.Close)
+
+	// Warm up so a session exists.
+	s, err := pool.OpenStream(context.Background())
+	if err != nil {
+		t.Fatalf("warmup OpenStream: %v", err)
+	}
+	_ = s.Close()
+	priorCreated := len(*created)
+
+	// Cancel the parent ctx without calling pool.Close(). The pool's
+	// internal poolCtx is now done but p.closed is still false. Every
+	// existing session's f.ctx is done, so its fake opener will return
+	// ErrMuxDialerClosed (mirroring MuxDialer); without the fix, the
+	// retry loop would also keep growing fresh sessions whose newly
+	// minted f.ctx is born-cancelled.
+	cancelParent()
+
+	// Subsequent OpenStream calls must surface ErrMuxPoolClosed in
+	// bounded time — never spin.
+	done := make(chan error, 1)
+	go func() {
+		s, err := pool.OpenStream(context.Background())
+		if s != nil {
+			_ = s.Close()
+		}
+		done <- err
+	}()
+	select {
+	case err := <-done:
+		if !errors.Is(err, ErrMuxPoolClosed) {
+			t.Fatalf("OpenStream after parent-ctx cancel returned %v, want ErrMuxPoolClosed", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("OpenStream did not return after parent-ctx cancel (likely spinning on ErrMuxDialerClosed)")
+	}
+
+	// Sanity: OpenStream returning ErrMuxPoolClosed must not have
+	// spun the loop growing dozens of doomed sessions.
+	if got := len(*created); got > priorCreated+1 {
+		t.Errorf("OpenStream grew %d new sessions after parent-ctx cancel; want <= 1", got-priorCreated)
+	}
+}
+
+// TestMuxPool_MultipleWaitersWakeOnReleases is the regression guard for
+// the "1-buffered notify channel coalesces wakeups and strands waiters"
+// finding from review. With broadcast wakeups, all waiters re-check on
+// every release.
+func TestMuxPool_MultipleWaitersWakeOnReleases(t *testing.T) {
+	factory, _ := fakeFactory(t, nil)
+	pool := newTestPool(t, MuxPoolOptions{MaxSessions: 1, MaxStreamsPerSession: 1}, factory)
+
+	first, err := pool.OpenStream(context.Background())
+	if err != nil {
+		t.Fatalf("OpenStream #1: %v", err)
+	}
+
+	const waiters = 5
+	results := make(chan error, waiters)
+	streams := make(chan net.Conn, waiters)
+	for range waiters {
+		go func() {
+			s, err := pool.OpenStream(context.Background())
+			if err != nil {
+				results <- err
+				return
+			}
+			streams <- s
+			results <- nil
+		}()
+	}
+
+	time.Sleep(100 * time.Millisecond)
+
+	// Release slots one at a time; each release should wake exactly one
+	// waiter (since slots is sized 1 and we only release 1 at a time).
+	_ = first.Close()
+	collected := []net.Conn{}
+	for range waiters {
+		select {
+		case err := <-results:
+			if err != nil {
+				t.Fatalf("waiter returned err: %v", err)
+			}
+			s := <-streams
+			_ = s.Close() // this release wakes the next waiter
+			collected = append(collected, s)
+		case <-time.After(3 * time.Second):
+			t.Fatalf("timed out after %d waiters completed", len(collected))
+		}
+	}
+}
+
+// TestMuxPool_LeastLoadedSelection verifies that when the pool is at
+// MaxSessions and a new stream arrives, the least-loaded session is
+// preferred. This keeps load balanced across HA listeners over time.
+func TestMuxPool_LeastLoadedSelection(t *testing.T) {
+	factory, created := fakeFactory(t, nil)
+	pool := newTestPool(t, MuxPoolOptions{MaxSessions: 2, MaxStreamsPerSession: 10}, factory)
+
+	// Open 4 streams. The pool grows to 2 sessions during the first 2,
+	// then picks the least-loaded for #3 and #4.
+	openStreams := make([]net.Conn, 0, 4)
+	for range 4 {
+		s, err := pool.OpenStream(context.Background())
+		if err != nil {
+			t.Fatalf("OpenStream: %v", err)
+		}
+		openStreams = append(openStreams, s)
+	}
+	defer func() {
+		for _, s := range openStreams {
+			_ = s.Close()
+		}
+	}()
+
+	if got := len(*created); got != 2 {
+		t.Fatalf("len(created) = %d, want 2", got)
+	}
+
+	// Both sessions should have 2 streams each — least-loaded balanced.
+	s0InFlight := (*created)[0].streamsOpen
+	s1InFlight := (*created)[1].streamsOpen
+	if s0InFlight != 2 || s1InFlight != 2 {
+		t.Errorf("streamsOpen per session = (%d, %d), want (2, 2) — least-loaded should balance",
+			s0InFlight, s1InFlight)
+	}
+}
+
+// TestMuxPool_StreamCloseIdempotent guards against double-close
+// decrementing the slot counter twice (which would let the next caller
+// over-subscribe the cap).
+func TestMuxPool_StreamCloseIdempotent(t *testing.T) {
+	factory, created := fakeFactory(t, nil)
+	pool := newTestPool(t, MuxPoolOptions{MaxSessions: 1, MaxStreamsPerSession: 1}, factory)
+
+	s, err := pool.OpenStream(context.Background())
+	if err != nil {
+		t.Fatalf("OpenStream: %v", err)
+	}
+	if err := s.Close(); err != nil {
+		t.Fatalf("first close: %v", err)
+	}
+	// Second close must be safe.
+	_ = s.Close()
+
+	sess := (*created)[0]
+	sess.mu.Lock()
+	open := sess.streamsOpen
+	sess.mu.Unlock()
+	if open != 0 {
+		t.Errorf("streamsOpen = %d, want 0 after close", open)
+	}
+	// A subsequent OpenStream must succeed (cap was 1, slot freed once).
+	if _, err := pool.OpenStream(context.Background()); err != nil {
+		t.Errorf("OpenStream after close: %v", err)
+	}
+}
+
+// TestMuxPool_Defaults_OptsAreNormalized covers the NewMuxPool ctor's
+// option-defaulting branches.
+func TestMuxPool_Defaults_OptsAreNormalized(t *testing.T) {
+	// Pin the published defaults so a silent change to DefaultMuxSessions /
+	// DefaultMaxStreamsPerSession trips this test — the CLI flag defaults
+	// in cmd/aztunnel/cli.go, help.go, README.md, and docs/mux.md are kept
+	// in sync with these constants by hand. Update all of them together.
+	if DefaultMuxSessions != 2 {
+		t.Errorf("DefaultMuxSessions = %d, want 2 (update CLI/help/docs together if changing)", DefaultMuxSessions)
+	}
+	if DefaultMaxStreamsPerSession != 256 {
+		t.Errorf("DefaultMaxStreamsPerSession = %d, want 256 (update CLI/help/docs together if changing)", DefaultMaxStreamsPerSession)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	p := NewMuxPool(ctx, MuxPoolOptions{
+		TokenProvider: stubTokenProvider{},
+	})
+	defer p.Close()
+	if p.opts.MaxSessions != DefaultMuxSessions {
+		t.Errorf("default MaxSessions = %d, want %d", p.opts.MaxSessions, DefaultMuxSessions)
+	}
+	if p.opts.MaxStreamsPerSession != DefaultMaxStreamsPerSession {
+		t.Errorf("default MaxStreamsPerSession = %d, want %d", p.opts.MaxStreamsPerSession, DefaultMaxStreamsPerSession)
+	}
+	if p.opts.RotateAfter != 6*time.Hour {
+		t.Errorf("default RotateAfter = %v, want 6h", p.opts.RotateAfter)
+	}
+	if p.opts.RotateGrace != 5*time.Minute {
+		t.Errorf("default RotateGrace = %v, want 5m", p.opts.RotateGrace)
+	}
+	if p.opts.Logger == nil {
+		t.Error("default Logger should be slog.Default()")
+	}
+}
+
+// --- Rotation tests ---
+
+// rotationOpts returns options tuned for fast deterministic rotation
+// behaviour in tests.
+func rotationOpts(maxSessions int, rotateAfter, rotateGrace time.Duration) MuxPoolOptions {
+	return MuxPoolOptions{
+		MaxSessions:          maxSessions,
+		MaxStreamsPerSession: 8,
+		RotateAfter:          rotateAfter,
+		RotateGrace:          rotateGrace,
+	}
+}
+
+// waitFor polls the predicate until it returns true or the timeout
+// expires. Polling avoids relying on a single fragile sleep.
+func waitFor(t *testing.T, timeout time.Duration, pred func() bool) bool {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if pred() {
+			return true
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	return pred()
+}
+
+// TestMuxPool_RotationDrainGraceful: when rotateAt fires and inFlight
+// is already 0 (or drops to 0 within grace), the session is evicted and
+// its opener is closed. This is the primary "happy path" for rotation.
+func TestMuxPool_RotationDrainGraceful(t *testing.T) {
+	factory, created := fakeFactory(t, nil)
+	pool := newTestPool(t, rotationOpts(2, 30*time.Millisecond, 1*time.Second), factory)
+
+	s, err := pool.OpenStream(context.Background())
+	if err != nil {
+		t.Fatalf("OpenStream: %v", err)
+	}
+	_ = s.Close() // inFlight back to 0; rotation drains immediately when it fires
+
+	if !waitFor(t, 2*time.Second, func() bool {
+		return (*created)[0].closed.Load() && pool.sessionCount() == 0
+	}) {
+		t.Fatalf("rotation did not evict session: closed=%v sessionCount=%d",
+			(*created)[0].closed.Load(), pool.sessionCount())
+	}
+}
+
+// TestMuxPool_RotationForceCloseAfterGrace: when streams are still
+// in-flight at rotateAt + RotateGrace, the watcher force-closes the
+// session anyway. This is a destructive operation, but bounded by the
+// grace window as a rotation-policy decision: we'd rather kill the
+// session and let the pool dial a fresh one than let stuck streams
+// pin a session past its intended rotation point. The grace window
+// is NOT correctness-driven (Azure Relay tolerates sender WebSockets
+// past SAS `se=`; see the relay probe memory) — it's a defensive
+// bound on per-session lifetime.
+func TestMuxPool_RotationForceCloseAfterGrace(t *testing.T) {
+	factory, created := fakeFactory(t, nil)
+	pool := newTestPool(t, rotationOpts(2, 20*time.Millisecond, 50*time.Millisecond), factory)
+
+	s, err := pool.OpenStream(context.Background())
+	if err != nil {
+		t.Fatalf("OpenStream: %v", err)
+	}
+	defer s.Close() //nolint:errcheck // intentionally NOT closing before grace expires
+
+	// Wait long enough for rotateAt (20ms) + grace (50ms) + slack.
+	if !waitFor(t, 2*time.Second, func() bool {
+		return (*created)[0].closed.Load()
+	}) {
+		t.Fatalf("opener was not force-closed after RotateGrace expired (closed=%v)",
+			(*created)[0].closed.Load())
+	}
+	if pool.sessionCount() != 0 {
+		t.Errorf("sessionCount = %d after force-rotation, want 0", pool.sessionCount())
+	}
+}
+
+// TestMuxPool_RotationCreatesReplacementDuringDrain: with MaxSessions=1
+// and a long-lived stream on session 0, when session 0 enters draining
+// the pool must grow a NEW session for incoming streams rather than
+// blocking or returning errors. Draining sessions don't count toward
+// MaxSessions — this prevents rotation from stalling traffic.
+func TestMuxPool_RotationCreatesReplacementDuringDrain(t *testing.T) {
+	factory, created := fakeFactory(t, nil)
+	// Long grace so the original session is still in 'draining' (not yet
+	// evicted) when we try to open the second stream.
+	pool := newTestPool(t, rotationOpts(1, 20*time.Millisecond, 5*time.Second), factory)
+
+	first, err := pool.OpenStream(context.Background())
+	if err != nil {
+		t.Fatalf("first OpenStream: %v", err)
+	}
+	defer first.Close() //nolint:errcheck // hold open to keep session 0 in drain
+
+	// Wait until session 0 is marked draining.
+	if !waitFor(t, 2*time.Second, func() bool {
+		pool.mu.Lock()
+		defer pool.mu.Unlock()
+		if len(pool.sessions) == 0 {
+			return false
+		}
+		return pool.sessions[0].draining.Load()
+	}) {
+		t.Fatal("session 0 did not enter draining state")
+	}
+
+	// New stream during drain must grow a new session, NOT block on cap.
+	second, err := pool.OpenStream(context.Background())
+	if err != nil {
+		t.Fatalf("second OpenStream during drain: %v", err)
+	}
+	defer second.Close() //nolint:errcheck // test cleanup
+
+	if got := len(*created); got != 2 {
+		t.Errorf("len(created) = %d, want 2 (drain should spawn replacement)", got)
+	}
+}
+
+// TestMuxPool_RotationCancelsSessCtxOnEvict: the "no zombie reconnect"
+// invariant. evictSession must cancel the per-session ctx BEFORE
+// closing the opener so that any in-flight MuxDialer.OpenStream sees
+// parentCtx cancellation and bails out instead of re-dialing.
+func TestMuxPool_RotationCancelsSessCtxOnEvict(t *testing.T) {
+	factory, created := fakeFactory(t, nil)
+	pool := newTestPool(t, rotationOpts(2, 20*time.Millisecond, 1*time.Second), factory)
+
+	s, err := pool.OpenStream(context.Background())
+	if err != nil {
+		t.Fatalf("OpenStream: %v", err)
+	}
+	_ = s.Close()
+
+	if !waitFor(t, 2*time.Second, func() bool {
+		return (*created)[0].closed.Load()
+	}) {
+		t.Fatal("rotation did not close opener")
+	}
+
+	if err := (*created)[0].ctx.Err(); err == nil {
+		t.Error("expected per-session ctx to be cancelled after eviction, but ctx.Err() is nil")
+	}
+}
+
+// TestMuxPool_RotationWatcherExitsOnPoolClose: regression guard against
+// watcher-goroutine leaks. When the pool is closed, every rotation
+// watcher must terminate. In practice Close closes each session's
+// `evicted` channel before cancelling poolCtx, so watchers parked on
+// the rotation timer normally exit via the s.evicted select arm; the
+// poolCtx.Done() arm is the defensive fallback. This test asserts the
+// invariant the user cares about: no leaked watcher goroutine after
+// Close returns.
+func TestMuxPool_RotationWatcherExitsOnPoolClose(t *testing.T) {
+	factory, _ := fakeFactory(t, nil)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	// Long rotateAfter so the watcher is parked on the rotation timer
+	// (not the grace timer) when we close.
+	pool := newMuxPoolWithFactory(ctx, rotationOpts(1, 1*time.Hour, 1*time.Hour), factory)
+
+	s, err := pool.OpenStream(context.Background())
+	if err != nil {
+		t.Fatalf("OpenStream: %v", err)
+	}
+	_ = s.Close()
+	pool.Close()
+
+	// goleak isn't pulled in; use a small bounded sleep to give any leaked
+	// goroutine a chance to misbehave, then verify pool ctx is dead.
+	time.Sleep(20 * time.Millisecond)
+	if err := pool.poolCtx.Err(); err == nil {
+		t.Error("pool ctx should be cancelled after Close()")
+	}
+}
+
+// closeWriteCountingConn is a minimal net.Conn that records whether
+// CloseWrite() (vs Close()) was called. Used to verify *pooledStream's
+// CloseWrite delegation.
+type closeWriteCountingConn struct {
+	net.Conn
+	closeWriteCalls atomic.Int32
+	closeCalls      atomic.Int32
+}
+
+func (c *closeWriteCountingConn) CloseWrite() error {
+	c.closeWriteCalls.Add(1)
+	return nil
+}
+
+func (c *closeWriteCountingConn) Close() error {
+	c.closeCalls.Add(1)
+	return c.Conn.Close()
+}
+
+// closeOnlyConn is a minimal net.Conn that does NOT implement
+// CloseWrite. *pooledStream.CloseWrite must fall back to Close() so the
+// peer still gets a definite signal.
+type closeOnlyConn struct {
+	net.Conn
+	closeCalls atomic.Int32
+}
+
+func (c *closeOnlyConn) Close() error {
+	c.closeCalls.Add(1)
+	return c.Conn.Close()
+}
+
+// TestPooledStream_CloseWriteDelegates is the regression test for the
+// half-close bug where pooledStream embedded net.Conn (the interface,
+// not the concrete *smux.Stream) and therefore did NOT promote
+// CloseWrite — so the metrics bridge fell back to Close() on EOF,
+// tearing down the whole stream before the peer could drain remaining
+// bytes for half-close-aware protocols (HTTP/1.0, SSH, SMTP).
+func TestPooledStream_CloseWriteDelegates(t *testing.T) {
+	factory, _ := fakeFactory(t, nil)
+	pool := newTestPool(t, MuxPoolOptions{MaxSessions: 1, MaxStreamsPerSession: 1}, factory)
+	// We don't actually open through the pool — we just need a real
+	// pooledSession so newPooledStream's bookkeeping is consistent.
+	stream, err := pool.OpenStream(context.Background())
+	if err != nil {
+		t.Fatalf("OpenStream (to obtain a real pooledSession): %v", err)
+	}
+	ps := stream.(*pooledStream)
+	sess := ps.sess
+
+	t.Run("delegates to CloseWrite when underlying supports it", func(t *testing.T) {
+		a, _ := net.Pipe()
+		t.Cleanup(func() { _ = a.Close() })
+		cw := &closeWriteCountingConn{Conn: a}
+		s := &pooledStream{Conn: cw, sess: sess, pool: pool}
+		if err := s.CloseWrite(); err != nil {
+			t.Fatalf("CloseWrite: %v", err)
+		}
+		if got := cw.closeWriteCalls.Load(); got != 1 {
+			t.Errorf("CloseWrite calls = %d, want 1", got)
+		}
+		if got := cw.closeCalls.Load(); got != 0 {
+			t.Errorf("Close calls = %d, want 0 (CloseWrite must not tear down both directions)", got)
+		}
+	})
+
+	t.Run("falls back to Close when underlying lacks CloseWrite", func(t *testing.T) {
+		a, _ := net.Pipe()
+		t.Cleanup(func() { _ = a.Close() })
+		co := &closeOnlyConn{Conn: a}
+		s := &pooledStream{Conn: co, sess: sess, pool: pool}
+		if err := s.CloseWrite(); err != nil {
+			t.Fatalf("CloseWrite fallback: %v", err)
+		}
+		if got := co.closeCalls.Load(); got != 1 {
+			t.Errorf("Close fallback calls = %d, want 1", got)
+		}
+	})
+}
+
+// TestMuxPool_SaturationCounterOnlyOnDeadline is the regression guard
+// for the false-positive saturation counter the iter-8 Copilot review
+// caught. The counter must increment ONLY when:
+//   - the caller's ctx is DeadlineExceeded (a real saturation event), and
+//   - the pool itself is NOT shutting down (poolCtx is alive).
+//
+// In particular, plain caller-side cancellation (ctx.Canceled) is NOT
+// a saturation event — it's the application giving up. Counting those
+// would inflate the metric and trigger ops alerts during normal
+// shutdown.
+func TestMuxPool_SaturationCounterOnlyOnDeadline(t *testing.T) {
+	const role = "sender"
+
+	t.Run("DeadlineExceeded increments", func(t *testing.T) {
+		m := metrics.New()
+		factory, _ := fakeFactory(t, nil)
+		ctx, cancel := context.WithCancel(context.Background())
+		t.Cleanup(cancel)
+		pool := newMuxPoolWithFactory(ctx,
+			MuxPoolOptions{MaxSessions: 1, MaxStreamsPerSession: 1, Metrics: m},
+			factory)
+		t.Cleanup(pool.Close)
+
+		first, err := pool.OpenStream(context.Background())
+		if err != nil {
+			t.Fatalf("first OpenStream: %v", err)
+		}
+		defer first.Close() //nolint:errcheck // test cleanup
+
+		// Saturate: pool is full, this caller times out waiting.
+		waitCtx, waitCancel := context.WithTimeout(context.Background(), 75*time.Millisecond)
+		defer waitCancel()
+		_, err = pool.OpenStream(waitCtx)
+		if !errors.Is(err, context.DeadlineExceeded) {
+			t.Fatalf("expected DeadlineExceeded, got %v", err)
+		}
+		if got := counterValue(t, m.Registry, "aztunnel_mux_pool_saturated_total", "role", role); got != 1 {
+			t.Errorf("mux_pool_saturated_total{sender} = %v, want 1 after DeadlineExceeded", got)
+		}
+	})
+
+	t.Run("plain Canceled does not increment", func(t *testing.T) {
+		m := metrics.New()
+		factory, _ := fakeFactory(t, nil)
+		ctx, cancel := context.WithCancel(context.Background())
+		t.Cleanup(cancel)
+		pool := newMuxPoolWithFactory(ctx,
+			MuxPoolOptions{MaxSessions: 1, MaxStreamsPerSession: 1, Metrics: m},
+			factory)
+		t.Cleanup(pool.Close)
+
+		first, err := pool.OpenStream(context.Background())
+		if err != nil {
+			t.Fatalf("first OpenStream: %v", err)
+		}
+		defer first.Close() //nolint:errcheck // test cleanup
+
+		waitCtx, waitCancel := context.WithCancel(context.Background())
+		errCh := make(chan error, 1)
+		go func() {
+			_, err := pool.OpenStream(waitCtx)
+			errCh <- err
+		}()
+		// Give the caller a moment to enter the wait branch.
+		time.Sleep(50 * time.Millisecond)
+		waitCancel()
+
+		select {
+		case err := <-errCh:
+			if !errors.Is(err, context.Canceled) {
+				t.Fatalf("expected Canceled, got %v", err)
+			}
+		case <-time.After(2 * time.Second):
+			t.Fatal("OpenStream did not return after ctx cancel")
+		}
+		if got := counterValue(t, m.Registry, "aztunnel_mux_pool_saturated_total", "role", role); got != 0 {
+			t.Errorf("mux_pool_saturated_total{sender} = %v after plain ctx.Cancel, want 0", got)
+		}
+	})
+
+	t.Run("pool shutdown race does not increment", func(t *testing.T) {
+		m := metrics.New()
+		factory, _ := fakeFactory(t, nil)
+		ctx, cancel := context.WithCancel(context.Background())
+		t.Cleanup(cancel)
+		pool := newMuxPoolWithFactory(ctx,
+			MuxPoolOptions{MaxSessions: 1, MaxStreamsPerSession: 1, Metrics: m},
+			factory)
+
+		first, err := pool.OpenStream(context.Background())
+		if err != nil {
+			t.Fatalf("first OpenStream: %v", err)
+		}
+		defer first.Close() //nolint:errcheck // test cleanup
+
+		// Use a caller ctx that WILL hit DeadlineExceeded, but also
+		// shut the pool down so poolCtx is Done. The race is real
+		// but on shutdown we explicitly do NOT count it.
+		waitCtx, waitCancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+		defer waitCancel()
+		errCh := make(chan error, 1)
+		go func() {
+			_, err := pool.OpenStream(waitCtx)
+			errCh <- err
+		}()
+		// Shut down the pool while OpenStream is waiting.
+		time.Sleep(30 * time.Millisecond)
+		pool.Close()
+
+		select {
+		case <-errCh:
+		// We don't assert which error wins the race between
+		// DeadlineExceeded, ErrMuxPoolClosed, and Canceled —
+		// only that the saturation counter is not incremented
+		// when the pool itself is being torn down.
+		case <-time.After(2 * time.Second):
+			t.Fatal("OpenStream did not return after pool shutdown")
+		}
+		if got := counterValue(t, m.Registry, "aztunnel_mux_pool_saturated_total", "role", role); got != 0 {
+			t.Errorf("mux_pool_saturated_total{sender} = %v while pool shutting down, want 0", got)
+		}
+	})
+}
+
+// TestMuxPool_OpenFailureEvictsAndRoutesToHealthyBusySession is the
+// regression guard for the "non-Unsupported OpenStream failures leave a
+// broken-but-idle candidate in the pool, which the selector keeps
+// picking over a healthy busy session" finding. With the fix:
+//
+//  1. The broken session is evicted BEFORE its slot is released so a
+//     concurrent waiter cannot reserve it through the release-broadcast
+//     window.
+//  2. The retry loop sets preferExisting so selectOrGrowLocked routes
+//     to the healthy busy session's spare capacity (path 3) instead of
+//     growing yet another fresh session that would hit the same outage.
+//  3. The eviction is reported via RecordMuxRotation with
+//     reason=MuxRotationOpenFailed for operator visibility.
+//
+// Without the fix, the call would either spin growing failed fresh
+// sessions until maxEvictions and return the underlying error, or (on
+// a later call) pick the broken session as an idle candidate and fail
+// again.
+func TestMuxPool_OpenFailureEvictsAndRoutesToHealthyBusySession(t *testing.T) {
+	failErr := errors.New("simulated relay dial failure")
+	factory, created := fakeFactory(t, func(id int, f *fakeOpener) {
+		// Session id 1 fails its first OpenStream with a non-
+		// Unsupported, non-DialerClosed error. With the fix the
+		// pool evicts session 1 and routes the retry to session 0's
+		// spare slot capacity. Session 0 (the healthy warmup) and
+		// any later sessions succeed normally.
+		if id == 1 {
+			err := failErr
+			f.failOnce.Store(&err)
+		}
+	})
+
+	m := metrics.New()
+	pool := newTestPool(t,
+		MuxPoolOptions{MaxSessions: 2, MaxStreamsPerSession: 4, Metrics: m},
+		factory)
+
+	// Warm up session 0 and hold a stream so its slot stays busy. This
+	// is what forces the selector to grow (path 2 → session 1) on the
+	// next OpenStream call.
+	warmup, err := pool.OpenStream(context.Background())
+	if err != nil {
+		t.Fatalf("warmup OpenStream: %v", err)
+	}
+	defer warmup.Close() //nolint:errcheck // test cleanup
+
+	// Trigger the failure-and-route path. Without the fix this either
+	// returns an error (growth-only retry burns the eviction budget on
+	// fresh fail-on-first dials) or — on a follow-up call — picks the
+	// broken-but-idle session 1 and fails again. With the fix, the
+	// retry routes to session 0's spare capacity and succeeds.
+	stream, err := pool.OpenStream(context.Background())
+	if err != nil {
+		t.Fatalf("OpenStream after failed-grow: got %v, want success via healthy busy session", err)
+	}
+	defer stream.Close() //nolint:errcheck // test cleanup
+
+	// Only sessions 0 and 1 should have been created: session 0 (warmup,
+	// healthy) and session 1 (grown then evicted). The retry must NOT
+	// have grown a fresh session 2 — that would re-hit the outage.
+	if got := len(*created); got != 2 {
+		t.Errorf("len(created) = %d, want 2 (session 0 healthy + session 1 evicted; no fresh grow)", got)
+	}
+
+	// Session 1 must have been evicted (its opener.Close() called).
+	if len(*created) > 1 && !(*created)[1].closed.Load() {
+		t.Errorf("session 1 opener not closed; eviction did not happen")
+	}
+
+	// The returned stream must be on session 0 — that's the route-to-
+	// healthy-busy guarantee. streamsOpen counts net.Pipe halves
+	// currently held by the test (2 = warmup + this stream).
+	if len(*created) > 0 {
+		s0 := (*created)[0]
+		s0.mu.Lock()
+		open0 := s0.streamsOpen
+		s0.mu.Unlock()
+		if open0 != 2 {
+			t.Errorf("session 0 streamsOpen = %d, want 2 (warmup + retry-routed stream)", open0)
+		}
+	}
+
+	// Eviction must be recorded with reason=open_failed so operators
+	// can distinguish session unhealth from scheduled rotation or
+	// unsupported v1 rejection.
+	if got := counterValue(t, m.Registry, "aztunnel_mux_rotations_total",
+		"role", "sender", "reason", metrics.MuxRotationOpenFailed); got != 1 {
+		t.Errorf("mux_rotations_total{role=sender, reason=%s} = %v, want 1",
+			metrics.MuxRotationOpenFailed, got)
+	}
+}
+
+// TestMuxPool_OpenFailurePersistentOutageReturnsError verifies that
+// when every dial in the eviction budget fails (no healthy session in
+// the pool to route to), the pool exhausts maxEvictions and surfaces
+// the last underlying error rather than looping forever.
+func TestMuxPool_OpenFailurePersistentOutageReturnsError(t *testing.T) {
+	failErr := errors.New("simulated persistent relay outage")
+	factory, created := fakeFactory(t, func(_ int, f *fakeOpener) {
+		err := failErr
+		f.failOnce.Store(&err)
+	})
+	pool := newTestPool(t,
+		MuxPoolOptions{MaxSessions: 3, MaxStreamsPerSession: 4},
+		factory)
+
+	_, err := pool.OpenStream(context.Background())
+	if err == nil {
+		t.Fatalf("OpenStream succeeded against persistent outage; want failure")
+	}
+	if !errors.Is(err, failErr) {
+		t.Errorf("OpenStream error = %v, want chain containing %v", err, failErr)
+	}
+	// maxEvictions = MaxSessions = 3 → at most 3 dial attempts.
+	if got := len(*created); got > 3 {
+		t.Errorf("len(created) = %d after persistent outage; want <= maxEvictions (3) — runaway loop?",
+			got)
+	}
+}
+
+// TestMuxPool_OpenFailureCallerCancelDoesNotEvict verifies that a
+// caller-ctx cancellation does NOT tear down the selected session.
+// The dialer surfaces ctx-caused errors as ErrMuxDialFailed wrapping
+// context.Canceled / DeadlineExceeded; treating those as session
+// unhealth would wrongly evict a perfectly good session and force
+// the next caller to pay another relay rendezvous.
+func TestMuxPool_OpenFailureCallerCancelDoesNotEvict(t *testing.T) {
+	factory, created := fakeFactory(t, func(_ int, f *fakeOpener) {
+		// holdOnOpenCh blocks OpenStream until the test sends; the
+		// caller's ctx will fire first.
+		f.holdOnOpenCh = make(chan struct{})
+	})
+	pool := newTestPool(t,
+		MuxPoolOptions{MaxSessions: 2, MaxStreamsPerSession: 4},
+		factory)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		cancel()
+	}()
+	_, err := pool.OpenStream(ctx)
+	if err == nil {
+		t.Fatalf("OpenStream succeeded; want caller-cancel error")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("OpenStream error = %v, want chain containing context.Canceled", err)
+	}
+
+	// Session 0 must still be in the pool — not evicted. We probe this
+	// by asserting that its opener.Close() was NOT called.
+	if got := len(*created); got != 1 {
+		t.Fatalf("len(created) = %d, want 1", got)
+	}
+	if (*created)[0].closed.Load() {
+		t.Errorf("session 0 was evicted on caller-cancel; want it preserved")
+	}
+}
+
+// TestMuxPool_OpenFailurePreferExistingFallsBackToGrow guards against
+// the "preferExisting deadlocks when every viable existing session is
+// at MaxStreamsPerSession but growth is still allowed" scenario. With
+// preferExisting set, selectOrGrowLocked tries existing least-loaded
+// first, but MUST fall back to growth when no existing slot is
+// reservable — otherwise the caller hangs on waitCh while pool budget
+// remains.
+func TestMuxPool_OpenFailurePreferExistingFallsBackToGrow(t *testing.T) {
+	failErr := errors.New("simulated relay dial failure")
+	factory, created := fakeFactory(t, func(id int, f *fakeOpener) {
+		// Session id 1 (the first grow inside the test OpenStream)
+		// fails. Session id 2 (the fallback grow after preferExisting
+		// finds no reservable slot on sess 0) succeeds.
+		if id == 1 {
+			err := failErr
+			f.failOnce.Store(&err)
+		}
+	})
+
+	// MaxStreamsPerSession=1 forces sess 0 to be at cap once the
+	// warmup stream is held. After the failure-and-evict, preferExisting
+	// is set but sess 0 has no free slot — the retry must grow sess 2.
+	pool := newTestPool(t,
+		MuxPoolOptions{MaxSessions: 3, MaxStreamsPerSession: 1},
+		factory)
+
+	warmup, err := pool.OpenStream(context.Background())
+	if err != nil {
+		t.Fatalf("warmup OpenStream: %v", err)
+	}
+	defer warmup.Close() //nolint:errcheck // test cleanup
+
+	// Trigger the failed grow + fallback grow path.
+	streamCtx, streamCancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer streamCancel()
+	stream, err := pool.OpenStream(streamCtx)
+	if err != nil {
+		t.Fatalf("OpenStream with preferExisting fallback: got %v, want success via fresh grow", err)
+	}
+	defer stream.Close() //nolint:errcheck // test cleanup
+
+	// Sessions 0 (warmup, healthy), 1 (failed, evicted), 2 (fresh grow,
+	// healthy). preferExisting must not have suppressed the grow.
+	if got := len(*created); got != 3 {
+		t.Errorf("len(created) = %d, want 3 (warmup + failed-evict + fallback-grow)", got)
+	}
+}
+
+// TestMuxPool_BudgetExhaustedWithV2_UsesExistingCapacity guards against
+// the "hasV2 short-circuits to ErrMuxUnsupported even when an existing
+// v2 session has spare stream capacity" finding. After the per-call
+// eviction budget is exhausted (growth keeps landing on v1-only
+// listeners), the pool must give an existing v2 session with spare
+// capacity one last chance before falling back to v1 — otherwise
+// mixed-fleet rollouts route traffic to v1 unnecessarily.
+func TestMuxPool_BudgetExhaustedWithV2_UsesExistingCapacity(t *testing.T) {
+	// Session 0 is v2 with spare capacity (MaxStreamsPerSession=4).
+	// Sessions 1+ are v1-only: each first OpenStream returns
+	// ErrMuxUnsupported and the opener becomes sticky-unavailable.
+	factory, created := fakeFactory(t, func(id int, f *fakeOpener) {
+		if id >= 1 {
+			err := ErrMuxUnsupported
+			f.failOnce.Store(&err)
+			f.unavailable.Store(true)
+		}
+	})
+	pool := newTestPool(t,
+		MuxPoolOptions{MaxSessions: 2, MaxStreamsPerSession: 4},
+		factory)
+
+	// Warm up session 0 to inFlight=1 (still has 3 free slots).
+	s0, err := pool.OpenStream(context.Background())
+	if err != nil {
+		t.Fatalf("warmup OpenStream: %v", err)
+	}
+	defer s0.Close() //nolint:errcheck // test cleanup
+
+	// Drive the OpenStream retry loop into the budget-exhausted branch.
+	// Selector path: session 0 is non-idle (inFlight=1) so step 1 skips
+	// it; step 2 grows session 1 (v1-only, ErrMuxUnsupported), evict +
+	// retry; selector hits MaxSessions=2 non-draining, falls to
+	// pickLeastLoaded which reserves session 0 — and OpenStream on
+	// session 0 should succeed.
+	//
+	// Note: This test also covers the case where the "preferExisting"
+	// retry fails because the grown session is itself v1; the inline
+	// one-shot in the budget-exhausted branch is the safety net.
+	stream, err := pool.OpenStream(context.Background())
+	if err != nil {
+		t.Fatalf("OpenStream after budget exhaustion: got %v, want success via existing v2", err)
+	}
+	defer stream.Close() //nolint:errcheck // test cleanup
+
+	// Session 0 must have served the second stream too — assert its
+	// totalOpens is 2 (warmup + the budget-exhausted recovery).
+	if len(*created) < 1 {
+		t.Fatalf("len(created) = %d, want >=1", len(*created))
+	}
+	s0Opener := (*created)[0]
+	s0Opener.mu.Lock()
+	totalOpens := s0Opener.totalOpens
+	s0Opener.mu.Unlock()
+	if totalOpens != 2 {
+		t.Errorf("session 0 totalOpens = %d, want 2 (warmup + budget-exhausted one-shot)", totalOpens)
+	}
+
+	// The pool-wide sticky cache MUST NOT be set: session 0 is still
+	// v2 and usable. A follow-up OpenStream (after closing stream)
+	// should succeed without re-dialing.
+	_ = stream.Close()
+	s2, err := pool.OpenStream(context.Background())
+	if err != nil {
+		t.Fatalf("follow-up OpenStream: got %v, want success (sticky cache must be unset)", err)
+	}
+	_ = s2.Close()
+}
+
+// TestMuxPool_BudgetExhaustedV2_LastChanceFailureEvictsAndRecords guards
+// against the "broken existing v2 session lingers in the pool with no
+// metric signal after a failed lastChance open" finding. When the
+// one-shot pickLeastLoaded path hits a genuine session error (smux
+// setup, handshake parse, or a stale ErrMuxDialerClosed), the pool
+// must evict the session and record the rotation under
+// MuxRotationOpenFailed before returning ErrMuxUnsupported — otherwise
+// the broken session stays selectable for the next caller AND
+// operators have no signal in aztunnel_mux_rotations_total that v2
+// sessions are dying.
+func TestMuxPool_BudgetExhaustedV2_LastChanceFailureEvictsAndRecords(t *testing.T) {
+	failErr := errors.New("simulated mid-life v2 session failure")
+	m := metrics.New()
+	// Session 0 is v2 and survives the warmup. Sessions 1+ are v1-only
+	// (ErrMuxUnsupported + sticky-unavailable) so growth in the retry
+	// loop burns through the eviction budget and forces the hasV2
+	// branch.
+	factory, created := fakeFactory(t, func(id int, f *fakeOpener) {
+		if id >= 1 {
+			err := ErrMuxUnsupported
+			f.failOnce.Store(&err)
+			f.unavailable.Store(true)
+		}
+	})
+	pool := newTestPool(t,
+		MuxPoolOptions{MaxSessions: 2, MaxStreamsPerSession: 4, Metrics: m},
+		factory)
+
+	warmup, err := pool.OpenStream(context.Background())
+	if err != nil {
+		t.Fatalf("warmup OpenStream: %v", err)
+	}
+	defer warmup.Close() //nolint:errcheck // test cleanup
+
+	// Arm session 0 to fail on its next OpenStream — this is the
+	// lastChance call inside the budget-exhausted branch.
+	(*created)[0].failOnce.Store(&failErr)
+
+	// Drive the retry loop into budget exhaustion + hasV2 + lastChance
+	// failure. Expected outcome: caller gets ErrMuxUnsupported (v1
+	// fallback) AND session 0 is evicted AND mux_rotations_total{
+	// reason=open_failed} = 1.
+	_, err = pool.OpenStream(context.Background())
+	if !errors.Is(err, ErrMuxUnsupported) {
+		t.Fatalf("expected ErrMuxUnsupported (v1 fallback), got %v", err)
+	}
+
+	if !(*created)[0].closed.Load() {
+		t.Errorf("session 0 opener not closed; lastChance failure must evict the broken session")
+	}
+
+	if got := counterValue(t, m.Registry, "aztunnel_mux_rotations_total",
+		"role", "sender", "reason", metrics.MuxRotationOpenFailed); got != 1 {
+		t.Errorf("mux_rotations_total{role=sender, reason=%s} = %v, want 1 (lastChance failure must record rotation)",
+			metrics.MuxRotationOpenFailed, got)
+	}
+}
+
+// TestMuxPool_OpenStreamHonorsPrecancelledCtx guards the contract that
+// a caller whose ctx is already done at OpenStream entry receives
+// ctx.Err() and does NOT get a stream. Without the upfront ctx check,
+// the established-session fast path inside MuxDialer.OpenStream
+// (which only checks parentCtx) would silently hand the caller a
+// stream — weakening the timeout/cancellation guarantees the
+// port-forward and SOCKS5 admission paths rely on.
+func TestMuxPool_OpenStreamHonorsPrecancelledCtx(t *testing.T) {
+	factory, created := fakeFactory(t, nil)
+	m := metrics.New()
+	pool := newTestPool(t,
+		MuxPoolOptions{MaxSessions: 1, MaxStreamsPerSession: 4, Metrics: m},
+		factory)
+
+	// Warm session 0 so the fast path (established session, spare
+	// capacity) is what a precancelled caller would otherwise reach.
+	warmup, err := pool.OpenStream(context.Background())
+	if err != nil {
+		t.Fatalf("warmup OpenStream: %v", err)
+	}
+	defer warmup.Close() //nolint:errcheck // test cleanup
+
+	// Precancel the caller's ctx, then call OpenStream. Must return
+	// ctx.Canceled — not a stream.
+	cancelledCtx, cancel := context.WithCancel(context.Background())
+	cancel()
+	stream, err := pool.OpenStream(cancelledCtx)
+	if err == nil {
+		_ = stream.Close()
+		t.Fatalf("OpenStream returned a stream for precancelled ctx; want ctx.Canceled")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("OpenStream error = %v, want context.Canceled", err)
+	}
+
+	// Precancel handling must NOT increment the saturation counter —
+	// that's for callers that ctx-expired waiting on a full pool, not
+	// for callers who gave up before entering the wait.
+	if got := counterValue(t, m.Registry, "aztunnel_mux_pool_saturated_total", "role", "sender"); got != 0 {
+		t.Errorf("mux_pool_saturated_total{sender} = %v, want 0 for precancelled ctx", got)
+	}
+
+	// And the warmup-only session count must be unchanged — no extra
+	// session was dialed for the precancelled caller.
+	if got := len(*created); got != 1 {
+		t.Errorf("len(created) = %d, want 1 (precancelled caller must not dial)", got)
+	}
+}

--- a/internal/sender/portforward.go
+++ b/internal/sender/portforward.go
@@ -1,5 +1,22 @@
 // Package sender implements the relay-sender modes: port-forward,
 // socks5-proxy, and connect (stdin/stdout).
+//
+// The port-forward and socks5-proxy modes use a persistent multiplexed
+// session (smux over a single relay WebSocket) so that each new TCP session
+// becomes a cheap smux stream rather than a full Azure Relay rendezvous.
+// The mux session is dialed *lazily* on the first connection that needs
+// one — so the very first TCP session through the sender still pays the
+// full ~1-2 s rendezvous; subsequent connections that reuse an
+// already-established mux session drop to milliseconds. When MuxSessions
+// > 1 is configured and concurrent traffic forces the pool to grow, each
+// additional session is also dialed lazily on its first connection,
+// which pays a rendezvous too. Mux can be disabled per-config; the
+// listener-side accepts both protocols and the sender automatically
+// falls back to v1 if the listener it reaches doesn't speak v2
+// (mixed-version rolling deployments).
+//
+// The connect (stdin/stdout) mode is intentionally v1 only — it carries
+// exactly one connection, so multiplexing has no benefit.
 package sender
 
 import (
@@ -19,6 +36,17 @@ import (
 	"github.com/philsphicas/aztunnel/internal/relay"
 )
 
+// muxStreamAdmissionTimeout bounds the per-connection wait inside
+// MuxPool.OpenStream so a saturated pool cannot hang the goroutine
+// indefinitely on a process-level ctx (as used by the CLI port-forward
+// and socks5-proxy paths). Sized to give realistic burst traffic time
+// to land a slot while still surfacing genuine saturation through
+// aztunnel_mux_pool_saturated_total on caller-deadline expiry. The
+// envelope handshake and bridge phases run on the parent ctx so a
+// working stream lives as long as the client keeps the connection
+// open.
+const muxStreamAdmissionTimeout = 60 * time.Second
+
 // PortForwardConfig holds configuration for port-forward mode.
 type PortForwardConfig struct {
 	Endpoint      string
@@ -36,12 +64,47 @@ type PortForwardConfig struct {
 	// after the local app has closed its socket, producing ghost
 	// rendezvous when a listener eventually appears.
 	DialBudget time.Duration
+
 	// Ready, if non-nil, is invoked once after the local bind succeeds
 	// and before the accept loop starts. Tests use this to learn the
 	// chosen bind address (when BindAddress is :0) without having to
 	// probe with a real TCP dial that would consume a listener slot
 	// under MaxConnections. Production callers leave this nil.
 	Ready func(net.Addr)
+
+	// MaxProtocolVersion is the highest relay protocol version this
+	// sender is willing to attempt against a listener.
+	//
+	//   1 = legacy per-connection rendezvous. Every TCP session opens
+	//       a fresh relay WebSocket; no mux pool is built.
+	//   2 = stream multiplexing. Each TCP session becomes an smux
+	//       stream over a small pool of long-lived rendezvous
+	//       WebSockets (see MuxPool, MuxDialer).
+	//
+	// Zero is normalized to DefaultSenderMaxProtocolVersion at
+	// PortForward entry; values outside [1, protocol.MuxVersion] are
+	// clamped silently. A v2 sender against a v1-only listener falls
+	// back automatically (sticky muxUnavailableTTL), so requesting v2
+	// is always safe — this knob is a ceiling, not a floor.
+	MaxProtocolVersion int
+
+	// MuxSessions caps the number of persistent relay rendezvous
+	// WebSockets the sender holds open. Larger values may spread
+	// concurrent traffic across multiple HA listeners. Defaults to
+	// DefaultMuxSessions. Only effective when MaxProtocolVersion >= 2.
+	MuxSessions int
+
+	// MaxStreamsPerSession bounds in-flight streams per mux session;
+	// callers block (with ctx) when all sessions are at this cap and the
+	// pool is at MuxSessions. Defaults to DefaultMaxStreamsPerSession.
+	// Only effective when MaxProtocolVersion >= 2.
+	MaxStreamsPerSession int
+
+	// MuxStreamHandshakeTimeout caps the per-stream envelope+response
+	// exchange. Must exceed the listener's --connect-timeout because
+	// the listener dials the target before writing the response.
+	// Zero falls back to the package default (60s).
+	MuxStreamHandshakeTimeout time.Duration
 }
 
 // PortForward starts a local TCP listener and forwards each connection
@@ -59,9 +122,40 @@ func PortForward(ctx context.Context, cfg PortForwardConfig) error {
 		return fmt.Errorf("listen %s: %w", cfg.BindAddress, err)
 	}
 	defer ln.Close() //nolint:errcheck // best-effort cleanup
-	cfg.Logger.Info("port-forward listening", "bind", ln.Addr(), "target", cfg.Target)
+	cfg.MaxProtocolVersion = NormalizeSenderMaxProtocolVersion(cfg.MaxProtocolVersion)
+	muxEnabled := cfg.MaxProtocolVersion >= protocol.MuxVersion
+	muxSessions := cfg.MuxSessions
+	if muxSessions <= 0 {
+		muxSessions = DefaultMuxSessions
+	}
+	maxStreamsPerSession := cfg.MaxStreamsPerSession
+	if maxStreamsPerSession <= 0 {
+		maxStreamsPerSession = DefaultMaxStreamsPerSession
+	}
+	cfg.Logger.Info("port-forward listening",
+		"bind", ln.Addr(), "target", cfg.Target,
+		"maxProtocolVersion", cfg.MaxProtocolVersion,
+		"mux", muxEnabled,
+		"muxSessions", muxSessions,
+		"maxStreamsPerSession", maxStreamsPerSession,
+	)
 	if cfg.Ready != nil {
 		cfg.Ready(ln.Addr())
+	}
+
+	var pool *MuxPool
+	if muxEnabled {
+		pool = NewMuxPool(ctx, MuxPoolOptions{
+			Endpoint:             cfg.Endpoint,
+			EntityPath:           cfg.EntityPath,
+			TokenProvider:        cfg.TokenProvider,
+			ClientOptions:        cfg.ClientOptions,
+			Logger:               cfg.Logger,
+			Metrics:              cfg.Metrics,
+			MaxSessions:          cfg.MuxSessions,
+			MaxStreamsPerSession: cfg.MaxStreamsPerSession,
+		})
+		defer pool.Close()
 	}
 
 	go func() {
@@ -85,19 +179,119 @@ func PortForward(ctx context.Context, cfg PortForwardConfig) error {
 			// the bridge_id-bound logger; the returned error is
 			// surfaced for tests and metrics, not for top-level
 			// logging.
-			_ = forwardConnection(ctx, conn, cfg.Target, cfg)
+			_ = forwardConnection(ctx, conn, cfg.Target, cfg, pool)
 		}()
 	}
 }
 
-func forwardConnection(ctx context.Context, conn net.Conn, target string, cfg PortForwardConfig) error {
-	// Set TCP keepalive on the incoming connection.
+func forwardConnection(ctx context.Context, conn net.Conn, target string, cfg PortForwardConfig, pool *MuxPool) error {
 	relay.SetTCPKeepAlive(conn, cfg.TCPKeepAlive)
 
 	bridgeID := idgen.NewBridgeID()
 	logger := cfg.Logger.With("bridge_id", bridgeID)
 	logger.Info("connection requested", "target", target)
 
+	if pool != nil {
+		// Bound the mux open/admission wait so a saturated pool can't
+		// hang the goroutine indefinitely. The CLI passes the listener-
+		// loop ctx here (effectively process-level, no deadline), so
+		// without this an OpenStream blocked in the pool's
+		// notifyCh/select wait would never release if every session is
+		// at MaxStreamsPerSession AND the pool is at MaxSessions — and
+		// aztunnel_mux_pool_saturated_total would never fire because
+		// the ctx has no deadline. After OpenStream returns, the
+		// envelope handshake (capped by MuxStreamHandshakeTimeout) and
+		// the bridge use the parent ctx so a working stream lives as
+		// long as the client keeps it open.
+		admitCtx, admitCancel := context.WithTimeout(ctx, muxStreamAdmissionTimeout)
+		stream, err := pool.OpenStream(admitCtx)
+		// Capture the admission-ctx state BEFORE admitCancel() — once
+		// we cancel, admitCtx.Err() is always non-nil and useless for
+		// telling "admission expired / parent done" apart from
+		// "internal handshake/setup deadline fired on a sub-context".
+		admitDone := admitCtx.Err() != nil
+		admitCancel()
+		switch {
+		case err == nil:
+			defer stream.Close() //nolint:errcheck // best-effort cleanup
+			listenerID, err := sendEnvelopeOverStream(ctx, stream, target, bridgeID, cfg.MuxStreamHandshakeTimeout)
+			if err != nil {
+				logRejection(logger, target, listenerID, err)
+				cfg.Metrics.ConnectionError("sender", metrics.ReasonEnvelopeError)
+				return fmt.Errorf("mux envelope: %w", err)
+			}
+			logAccept(logger, target, listenerID)
+			result, bridgeErr := cfg.Metrics.TrackedStreamBridge(ctx, stream, conn, "sender", target)
+			attrs := []any{
+				"cause", result.EndCause,
+				"tcp_to_ws", result.Stats.TCPToWS,
+				"ws_to_tcp", result.Stats.WSToTCP,
+			}
+			if result.TCPToWS != nil {
+				attrs = append(attrs, "tcp_to_ws_err", result.TCPToWS)
+			}
+			if result.WSToTCP != nil {
+				attrs = append(attrs, "ws_to_tcp_err", result.WSToTCP)
+			}
+			if bridgeErr != nil {
+				errAttrs := append([]any{"error", bridgeErr}, attrs...)
+				logger.Warn("forward failed", errAttrs...)
+			} else {
+				logger.Debug("bridge ended", attrs...)
+			}
+			return bridgeErr
+		case errors.Is(err, ErrMuxUnsupported):
+			logger.Debug("mux unavailable, using v1 path", "target", target)
+			// fall through to v1
+		default:
+			// Filter what we record so we don't double-count or
+			// mislabel:
+			//   - context.Canceled/DeadlineExceeded BUT ONLY when
+			//     admitDone is true — admitCtx fired (admission
+			//     timeout) OR the parent ctx already cancelled
+			//     before we cancelled admitCtx ourselves. Either
+			//     way it's the caller giving up / real saturation,
+			//     not a connection error. (An *internal*
+			//     mux-handshake timeout also wraps
+			//     context.DeadlineExceeded but admitCtx was still
+			//     alive when OpenStream returned, so admitDone is
+			//     false and the error gets recorded.)
+			//   - ErrMuxPoolClosed (admitDone): the pool's
+			//     poolCtx fired during caller shutdown — same
+			//     class as ctx.Canceled, not a real failure.
+			//   - ErrMuxDialFailed: the underlying relay dial
+			//     failed and was already recorded by
+			//     MuxDialer.connectLocked (which calls
+			//     relay.DialWithRetry directly and emits
+			//     ConnectionError via DialReason itself, rather
+			//     than going through metrics.InstrumentedDial so
+			//     it can suppress parent-cancellation cases).
+			// Everything else is a genuine "we couldn't open a
+			// mux stream" (smux setup, handshake parse,
+			// listener rejection that isn't the v1-fallback
+			// marker, internal handshake timeout) — record as
+			// ReasonMuxOpenFailed.
+			callerCancelled := admitDone &&
+				(errors.Is(err, context.Canceled) ||
+					errors.Is(err, context.DeadlineExceeded) ||
+					errors.Is(err, ErrMuxPoolClosed))
+			if !callerCancelled && !errors.Is(err, ErrMuxDialFailed) {
+				cfg.Metrics.ConnectionError("sender", metrics.ReasonMuxOpenFailed)
+			}
+			logger.Warn("forward failed", "error", err)
+			return fmt.Errorf("open mux stream: %w", err)
+		}
+	}
+
+	return forwardConnectionV1(ctx, conn, target, cfg, bridgeID, logger)
+}
+
+// forwardConnectionV1 is the original per-connection rendezvous path. It
+// is used when mux is disabled by config or when the listener has been
+// observed to not support v2. The caller is expected to have already
+// minted a bridgeID and bound it on logger so logs from this path
+// share the same correlation key.
+func forwardConnectionV1(ctx context.Context, conn net.Conn, target string, cfg PortForwardConfig, bridgeID string, logger *slog.Logger) error {
 	// Per-connection dial budget caps retry duration so a stale
 	// local socket can't keep retrying indefinitely (issue #94).
 	// The bridge below intentionally uses the original ctx, not
@@ -148,7 +342,10 @@ func forwardConnection(ctx context.Context, conn net.Conn, target string, cfg Po
 	return bridgeErr
 }
 
-// sendEnvelopeAndCheck sends a ConnectEnvelope and reads the ConnectResponse.
+// sendEnvelopeAndCheck sends a v1 ConnectEnvelope as a WebSocket text
+// message and reads back the ConnectResponse. v1 uses WS message framing
+// (one envelope per message), so banner-overread is impossible.
+//
 // On a listener-side rejection (ConnectResponse.OK == false), the returned
 // error wraps a *connectRejected carrying both the human-readable message
 // and the machine-readable Code. Callers that need to surface the code to

--- a/internal/sender/protocol_version.go
+++ b/internal/sender/protocol_version.go
@@ -1,0 +1,55 @@
+package sender
+
+import "github.com/philsphicas/aztunnel/internal/protocol"
+
+// DefaultSenderMaxProtocolVersion is the default upper bound on the
+// relay protocol version this sender will attempt against a listener.
+//
+// In 0.4.0 this is 1: stream multiplexing (protocol v2) is an opt-in
+// capability; operators raise this to 2 via --max-protocol-version=2 or
+// AZTUNNEL_MAX_PROTOCOL_VERSION=2 to enable it. In 0.5.0 this constant
+// flips to 2 (i.e. protocol.MuxVersion) so mux becomes the default;
+// operators wanting to keep the legacy path use --max-protocol-version=1
+// to pin the sender to v1.
+//
+// The 0.5.0 flip is a single-line change to this constant. Every
+// downstream surface picks up the new value automatically:
+//
+//   - Library callers that construct a PortForwardConfig{}/SOCKS5Config{}
+//     with the zero value get the new default via
+//     NormalizeSenderMaxProtocolVersion(0).
+//   - The CLI default surfaced by kong reads this constant via the
+//     `${defaultSenderMaxProtocolVersion}` substitution wired in
+//     cmd/aztunnel/main.go (see TestKongDefault_MaxProtocolVersion_
+//     TracksConstants for the pin).
+//   - The protocol_version_test.go pin in this package and the kong
+//     pin in cmd/aztunnel will both fail if they aren't updated in
+//     the same commit as this constant.
+//
+// help.go and the README / docs/mux.md prose tables ARE NOT
+// automatically updated — they need a matching edit in the same
+// commit as the constant flip.
+const DefaultSenderMaxProtocolVersion = protocol.CurrentVersion
+
+// NormalizeSenderMaxProtocolVersion clamps a caller-supplied protocol
+// version ceiling into the supported range and substitutes the default
+// for the zero value (so library callers that never touch the field get
+// the same behaviour as a CLI invocation with no flag).
+//
+// Values below 1 are clamped up to 1 (the protocol's lowest version);
+// values above protocol.MuxVersion are clamped down to protocol.MuxVersion
+// (a user setting =99 to "future-proof" doesn't get silently broken
+// behaviour against a v3 sender we haven't written yet). A logger may
+// emit a warn line for either clamp; this helper itself is silent.
+func NormalizeSenderMaxProtocolVersion(v int) int {
+	if v == 0 {
+		return DefaultSenderMaxProtocolVersion
+	}
+	if v < 1 {
+		return 1
+	}
+	if v > protocol.MuxVersion {
+		return protocol.MuxVersion
+	}
+	return v
+}

--- a/internal/sender/protocol_version_test.go
+++ b/internal/sender/protocol_version_test.go
@@ -1,0 +1,41 @@
+package sender
+
+import (
+	"testing"
+
+	"github.com/philsphicas/aztunnel/internal/protocol"
+)
+
+// TestDefaultSenderMaxProtocolVersion_Is1 pins the 0.4.0 sender
+// default to v1 (mux opt-in). When this constant flips to
+// protocol.MuxVersion in 0.5.0, update this test in the SAME commit
+// — the test exists to make that flip a deliberate, single-line code
+// change rather than a silent default shift that goes through CI
+// unnoticed.
+func TestDefaultSenderMaxProtocolVersion_Is1(t *testing.T) {
+	if got, want := DefaultSenderMaxProtocolVersion, 1; got != want {
+		t.Errorf("DefaultSenderMaxProtocolVersion = %d, want %d (0.5.0 flip: bump together with cli/help/docs)", got, want)
+	}
+}
+
+func TestNormalizeSenderMaxProtocolVersion(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		in   int
+		want int
+	}{
+		{"zero takes the default", 0, DefaultSenderMaxProtocolVersion},
+		{"v1 passes through", 1, 1},
+		{"v2 passes through", protocol.MuxVersion, protocol.MuxVersion},
+		{"negative clamps up to 1", -3, 1},
+		{"above-max clamps down to MuxVersion", protocol.MuxVersion + 5, protocol.MuxVersion},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := NormalizeSenderMaxProtocolVersion(tt.in); got != tt.want {
+				t.Errorf("NormalizeSenderMaxProtocolVersion(%d) = %d, want %d", tt.in, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/sender/socks5proxy.go
+++ b/internal/sender/socks5proxy.go
@@ -31,11 +31,28 @@ type SOCKS5Config struct {
 	// after the local app has closed its socket, producing ghost
 	// rendezvous when a listener eventually appears.
 	DialBudget time.Duration
+
 	// Ready, if non-nil, is invoked once after the local bind succeeds
 	// and before the accept loop starts. Tests use this to learn the
 	// chosen bind address (when BindAddress is :0) without having to
 	// open a probe TCP connection. Production callers leave this nil.
 	Ready func(net.Addr)
+
+	// MaxProtocolVersion is the highest relay protocol version this
+	// sender is willing to attempt. See PortForwardConfig for full
+	// semantics and the version meanings.
+	MaxProtocolVersion int
+
+	// MuxSessions and MaxStreamsPerSession are the mux pool sizing knobs.
+	// See PortForwardConfig for semantics. Only effective when
+	// MaxProtocolVersion >= 2.
+	MuxSessions          int
+	MaxStreamsPerSession int
+
+	// MuxStreamHandshakeTimeout caps the per-stream envelope+response
+	// exchange. See PortForwardConfig.MuxStreamHandshakeTimeout for
+	// semantics.
+	MuxStreamHandshakeTimeout time.Duration
 }
 
 // SOCKS5Proxy starts a local SOCKS5 proxy and forwards each connection
@@ -54,9 +71,40 @@ func SOCKS5Proxy(ctx context.Context, cfg SOCKS5Config) error {
 		return fmt.Errorf("listen %s: %w", cfg.BindAddress, err)
 	}
 	defer ln.Close() //nolint:errcheck // best-effort cleanup
-	cfg.Logger.Info("socks5-proxy listening", "bind", ln.Addr())
+	cfg.MaxProtocolVersion = NormalizeSenderMaxProtocolVersion(cfg.MaxProtocolVersion)
+	muxEnabled := cfg.MaxProtocolVersion >= protocol.MuxVersion
+	muxSessions := cfg.MuxSessions
+	if muxSessions <= 0 {
+		muxSessions = DefaultMuxSessions
+	}
+	maxStreamsPerSession := cfg.MaxStreamsPerSession
+	if maxStreamsPerSession <= 0 {
+		maxStreamsPerSession = DefaultMaxStreamsPerSession
+	}
+	cfg.Logger.Info("socks5-proxy listening",
+		"bind", ln.Addr(),
+		"maxProtocolVersion", cfg.MaxProtocolVersion,
+		"mux", muxEnabled,
+		"muxSessions", muxSessions,
+		"maxStreamsPerSession", maxStreamsPerSession,
+	)
 	if cfg.Ready != nil {
 		cfg.Ready(ln.Addr())
+	}
+
+	var pool *MuxPool
+	if muxEnabled {
+		pool = NewMuxPool(ctx, MuxPoolOptions{
+			Endpoint:             cfg.Endpoint,
+			EntityPath:           cfg.EntityPath,
+			TokenProvider:        cfg.TokenProvider,
+			ClientOptions:        cfg.ClientOptions,
+			Logger:               cfg.Logger,
+			Metrics:              cfg.Metrics,
+			MaxSessions:          cfg.MuxSessions,
+			MaxStreamsPerSession: cfg.MaxStreamsPerSession,
+		})
+		defer pool.Close()
 	}
 
 	go func() {
@@ -81,16 +129,14 @@ func SOCKS5Proxy(ctx context.Context, cfg SOCKS5Config) error {
 			// failures that happen before the SOCKS5 handshake reveals
 			// a target). The returned error is surfaced for tests and
 			// metrics, not for top-level logging.
-			_ = handleSOCKS5(ctx, conn, cfg)
+			_ = handleSOCKS5(ctx, conn, cfg, pool)
 		}()
 	}
 }
 
-func handleSOCKS5(ctx context.Context, conn net.Conn, cfg SOCKS5Config) error {
-	// Set TCP keepalive.
+func handleSOCKS5(ctx context.Context, conn net.Conn, cfg SOCKS5Config, pool *MuxPool) error {
 	relay.SetTCPKeepAlive(conn, cfg.TCPKeepAlive)
 
-	// Set a deadline for the SOCKS5 handshake.
 	_ = conn.SetReadDeadline(time.Now().Add(30 * time.Second))
 
 	// Perform SOCKS5 handshake to get the target. No bridge_id is
@@ -103,7 +149,7 @@ func handleSOCKS5(ctx context.Context, conn net.Conn, cfg SOCKS5Config) error {
 		cfg.Logger.Warn("socks5 failed", "error", err)
 		return err
 	}
-	_ = conn.SetReadDeadline(time.Time{}) // clear deadline
+	_ = conn.SetReadDeadline(time.Time{})
 
 	// Mint the bridge_id once the target is known so the per-bridge
 	// logger carries both attributes from this point on.
@@ -111,6 +157,86 @@ func handleSOCKS5(ctx context.Context, conn net.Conn, cfg SOCKS5Config) error {
 	logger := cfg.Logger.With("bridge_id", bridgeID)
 	logger.Info("connection requested", "target", target)
 
+	if pool != nil {
+		// Bound the mux open/admission wait so a saturated pool can't
+		// hang the SOCKS5 goroutine indefinitely on a process-level
+		// ctx (the CLI socks5-proxy path uses the listener-loop ctx,
+		// which has no deadline). See the longer rationale in
+		// portforward.go's forwardConnection.
+		admitCtx, admitCancel := context.WithTimeout(ctx, muxStreamAdmissionTimeout)
+		stream, err := pool.OpenStream(admitCtx)
+		// Capture admit state before admitCancel() — see the matching
+		// note in portforward.go.
+		admitDone := admitCtx.Err() != nil
+		admitCancel()
+		switch {
+		case err == nil:
+			defer stream.Close() //nolint:errcheck // best-effort cleanup
+			listenerID, err := sendEnvelopeOverStream(ctx, stream, target, bridgeID, cfg.MuxStreamHandshakeTimeout)
+			if err != nil {
+				_ = socks5.SendReply(conn, socks5RepForError(err), nil)
+				logRejection(logger, target, listenerID, err)
+				cfg.Metrics.ConnectionError("sender", metrics.ReasonEnvelopeError)
+				return fmt.Errorf("mux envelope: %w", err)
+			}
+			logAccept(logger, target, listenerID)
+			tcpAddr, _ := conn.LocalAddr().(*net.TCPAddr)
+			_ = socks5.SendReply(conn, socks5.RepSuccess, tcpAddr)
+			result, bridgeErr := cfg.Metrics.TrackedStreamBridge(ctx, stream, conn, "sender", target)
+			attrs := []any{
+				"cause", result.EndCause,
+				"tcp_to_ws", result.Stats.TCPToWS,
+				"ws_to_tcp", result.Stats.WSToTCP,
+			}
+			if result.TCPToWS != nil {
+				attrs = append(attrs, "tcp_to_ws_err", result.TCPToWS)
+			}
+			if result.WSToTCP != nil {
+				attrs = append(attrs, "ws_to_tcp_err", result.WSToTCP)
+			}
+			if bridgeErr != nil {
+				errAttrs := append([]any{"error", bridgeErr}, attrs...)
+				logger.Warn("socks5 failed", errAttrs...)
+			} else {
+				logger.Debug("bridge ended", attrs...)
+			}
+			return bridgeErr
+		case errors.Is(err, ErrMuxUnsupported):
+			logger.Debug("mux unavailable, using v1 path", "target", target)
+			// fall through to v1
+		default:
+			_ = socks5.SendReply(conn, socks5.RepGeneralFailure, nil)
+			// Filter what we record so we don't double-count or
+			// mislabel — see the matching note in
+			// portforward.go's forwardConnection. The `admitDone`
+			// gate is critical: an *internal* mux-handshake
+			// timeout also wraps context.DeadlineExceeded, but
+			// admitCtx was still alive when OpenStream returned,
+			// so admitDone is false and the error gets recorded.
+			// ErrMuxPoolClosed is treated the same as a ctx
+			// cancellation when admitDone — it's the pool's
+			// poolCtx firing during caller shutdown, not a real
+			// connection failure.
+			callerCancelled := admitDone &&
+				(errors.Is(err, context.Canceled) ||
+					errors.Is(err, context.DeadlineExceeded) ||
+					errors.Is(err, ErrMuxPoolClosed))
+			if !callerCancelled && !errors.Is(err, ErrMuxDialFailed) {
+				cfg.Metrics.ConnectionError("sender", metrics.ReasonMuxOpenFailed)
+			}
+			logger.Warn("socks5 failed", "error", err)
+			return fmt.Errorf("open mux stream: %w", err)
+		}
+	}
+
+	return handleSOCKS5V1(ctx, conn, target, cfg, bridgeID, logger)
+}
+
+// handleSOCKS5V1 is the per-connection rendezvous path used when mux is
+// disabled or unsupported. The caller is expected to have already
+// minted a bridgeID and bound it on logger so logs from this path
+// share the same correlation key.
+func handleSOCKS5V1(ctx context.Context, conn net.Conn, target string, cfg SOCKS5Config, bridgeID string, logger *slog.Logger) error {
 	// Per-connection dial budget caps retry duration so a stale
 	// local socket can't keep retrying indefinitely (issue #94).
 	// The bridge below intentionally uses the original ctx, not
@@ -138,7 +264,6 @@ func handleSOCKS5(ctx context.Context, conn net.Conn, cfg SOCKS5Config) error {
 	}
 	logAccept(logger, target, listenerID)
 
-	// Tell the SOCKS5 client we're connected.
 	tcpAddr, _ := conn.LocalAddr().(*net.TCPAddr)
 	_ = socks5.SendReply(conn, socks5.RepSuccess, tcpAddr)
 


### PR DESCRIPTION
## Problem

Each new TCP session through aztunnel pays a full Azure Relay rendezvous: TLS handshake, WSS upgrade, control-channel signal to the listener, listener dials its own rendezvous WS back, pairing. End-to-end this costs ~1–2 s per connection, which is intolerable in SOCKS5 mode where browsers, `kubectl`, or `curl` open many short-lived sessions.

## Change

Introduce relay protocol v2: stream multiplexing over a small pool of persistent relay WebSockets using smux v2. Each TCP session becomes an smux stream with a single envelope round-trip on a persistent WebSocket — no Azure rendezvous per call.

This release (0.4.0) lands the capability as **opt-in**. The default sender ceiling is v1 (legacy per-connection rendezvous); a future release will flip the default to v2 once the wider fleet has had time to bake.

### Opt in (sender):

```sh
aztunnel relay-sender socks5-proxy --max-protocol-version=2 ...
# or
AZTUNNEL_MAX_PROTOCOL_VERSION=2 aztunnel ...
```

Listeners ship at v2 from day one (`DefaultListenerMaxProtocolVersion=2`) so a v2 sender works against any 0.4.0+ listener without operator coordination. An operator who needs an emergency v2 rollback on the listener side passes `--max-protocol-version=1`. The listener flag has no env binding — a workstation that exports `AZTUNNEL_MAX_PROTOCOL_VERSION` for its outbound sender must not silently disable v2 on a listener process it happens to launch as well.

## Wire shape

Sender's first WebSocket message is a `MuxHandshake` (text JSON, `version=2`, `mode="mux"`). Listener inspects via a forward-compatible `FirstMessage` type and dispatches to v2 mux or v1. Senders that hit a v1-only listener fall back to per-connection dial automatically with a sticky 60 s cache. The fallback trigger is a string-match against the v1 listener's rejection (`unsupported protocol version`, `missing target`, `invalid envelope`) so existing v1 listeners need no changes.

Per-stream envelopes use 2-byte length-prefixed framing so a stream-style `json.Decoder` can't swallow target banner bytes (SSH, SMTP, Postgres). Bridge does `CloseWrite()` on EOF so half-close-aware protocols work.

`relay-sender connect` (one-shot SSH ProxyCommand) stays on v1 regardless — no benefit to mux for a single stream.

## Real perf impact (Azure SAS, this branch)

`Serial_ConnPerRequestEcho_SOCKS5` — the canonical SOCKS5 short-session workload:

| metric                        | v1     | v2     | Δ     |
| ----------------------------- | ------ | ------ | ----- |
| cold p50                      | 503 ms | 191 ms | **−62 %** |
| wall (15 round-trips)         | 7.4 s  | 3.9 s  | −47 % |

`Parallel_ConnPerRequest_SOCKS5_DistinctTargets_N32` — 32-target fan-out:

| metric        | v1      | v2     | Δ     |
| ------------- | ------- | ------ | ----- |
| cold p95 tail | 1.23 s  | 896 ms | **−27 %** |
| wall          | 1.67 s  | 918 ms | **−45 %** |

Streaming fairness (`Stream_Trickle_SOCKS5_FanOut`) `maxgap_p95` essentially unchanged between v1 and v2 — no head-of-line blocking from the shared smux session.

## Resource control

- Listener-wide stream semaphore caps total in-flight target dials at `--max-connections` across v1 and v2 and across multiple concurrent mux sessions.
- Sessions rotate every 6 h with a 5-min drain (defence-in-depth; an empirical probe against a fresh namespace confirms Azure validates SAS at handshake only and the WS persists past `se=` as long as keepalives flow).
- smux config: Version=2, KeepAlive 30 s / timeout 90 s. After handshake smux owns the WS — nothing else reads/writes/pings it.

## CLI

| Flag                          | Default | Env                                       |
| ----------------------------- | ------- | ----------------------------------------- |
| sender `--max-protocol-version N`   | 1       | `AZTUNNEL_MAX_PROTOCOL_VERSION`           |
| listener `--max-protocol-version N` | 2       | (flag only, no env — see docs/mux.md)     |
| `--mux-sessions N`            | 2       | `AZTUNNEL_MUX_SESSIONS`                   |
| `--max-streams-per-session N` | 256     | `AZTUNNEL_MAX_STREAMS_PER_SESSION` (hidden) |

## Metrics

Sender exports: `aztunnel_mux_sessions_active`, `aztunnel_mux_stream_open_seconds`, `aztunnel_mux_session_age_seconds`, `aztunnel_mux_rotations_total{reason}`, `aztunnel_mux_pool_saturated_total`. See [`docs/mux.md`](docs/mux.md#metrics) for labels and meanings.

## Tests

- `go test ./... -race -count=1` — all packages pass.
- `make e2e-mock` — 28 scenarios × 2 auth × 2 mux versions on perf cells = ~80 sub-tests, 858 s wall, 0 failures.
- `make e2e-azure` — 61 sub-tests against a real Azure Relay namespace (SAS-only), 884 s wall, 0 failures.
- `make perf-matrix` — renders PERF MATRIX with paired v1/v2 rows; `perfreport --compare v1..v2 --compare-by mux` renders the head-to-head with no code changes.

## Docs

- `docs/mux.md` — protocol versions, opt-in semantics, framing, rotation, tuning, operator notes on `--max-connections` v2 semantics.
- `README.md` and `docs/guides/` — flag reference and SOCKS5 latency call-out qualified with `--max-protocol-version=2`.

## E2E + perf harness integration

`scenarios.RunPerformanceScenarios` is wrapped with `WithMuxAxis` so every perf cell produces paired v1/v2 PERF MATRIX rows tagged `axes:{auth, delay, mux}`. The existing `perfreport` tool pivots on the new axis with no code changes. Topology/observability scenarios that assert per-rendezvous semantics mux dissolves keep an explicit `SenderMaxProtocolVersion: 1` pin so they remain v1 forever — including after the 0.5.0 default flip.

Two new reliability scenarios (`ScenarioMuxFallback_V1Listener_{PortForward,SOCKS5}`) exercise sender-v2 against a listener pinned to v1 via `--max-protocol-version=1`, asserting the sticky 60 s cache holds across two back-to-back round-trips. A new observability scenario (`ScenarioMetrics_MuxSessionsActive`) asserts the v2 metrics surface lights up end-to-end.

## Out of scope

- Arc relay path (`internal/arc/`) — different token flow.
- Listener-side mux session metrics (sender-side only for now).
- `--mux-rotate-after` / `--mux-rotate-grace` flags (constants today).
- Real bidirectional protocol negotiation via `MuxCapabilities` — wire slot reserved (`MuxHandshake.Capabilities` + `ConnectResponse.Version` are already present) for a future v3 release.
- **0.5.0 default flip**: bumping `DefaultSenderMaxProtocolVersion` from 1 to 2 lands as a separate small PR after this one has baked. Wired so the flip is a single-constant change + matching docs/help update; `TestKongDefault_MaxProtocolVersion_TracksConstants` enforces the linkage.
