### PR TITLE
test: relay parity foundation (mock + Azure share one scenario suite)

### DIFF
--- a/e2e/azure_backend_test.go
+++ b/e2e/azure_backend_test.go
@@ -1,0 +1,71 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/philsphicas/aztunnel/internal/relayparity"
+)
+
+// azureBackend implements relayparity.Backend against a real Azure
+// Relay namespace. It is the source-of-truth side of the parity
+// matrix: any scenario divergence between this backend and the
+// in-process MockBackend (mockrelay/parity) is a behavioural gap in
+// the mock that we have to either fix or document.
+//
+// Each instance is bound to a single authConfig (Entra or SAS) so the
+// caller can run the same scenario suite once per available auth.
+// All listeners and the sender are real aztunnel subprocesses driven
+// by the existing helpers (startListener, startPortForwardSender,
+// startSOCKS5Sender), so they exercise the same code paths that
+// production users hit.
+type azureBackend struct {
+	env  *relayEnv
+	auth authConfig
+}
+
+// Name returns the backend identifier used in test sub-paths, e.g.
+// "azure-entra" or "azure-sas".
+func (b *azureBackend) Name() string { return "azure-" + b.auth.name }
+
+// Setup brings up the requested topology and blocks until every
+// listener has logged "control channel connected" and the sender has
+// logged its bind address. All subprocesses are torn down via the
+// existing t.Cleanup wiring inside startAztunnelWithSAS.
+func (b *azureBackend) Setup(t *testing.T, opts relayparity.SetupOptions) *relayparity.Tunnel {
+	t.Helper()
+	if opts.NumListeners < 1 {
+		t.Fatalf("NumListeners must be >= 1, got %d", opts.NumListeners)
+	}
+
+	listenerArgs := []string{}
+	for _, target := range opts.AllowedTargets {
+		listenerArgs = append(listenerArgs, "--allow", target)
+	}
+	if opts.MaxConnections > 0 {
+		listenerArgs = append(listenerArgs, "--max-connections",
+			strconv.Itoa(opts.MaxConnections))
+	}
+
+	for i := 0; i < opts.NumListeners; i++ {
+		lst := startListener(t, b.env, b.auth, listenerArgs...)
+		waitForLog(t, lst, "control channel connected", 30*time.Second)
+	}
+
+	var senderAddr string
+	switch opts.SenderMode {
+	case relayparity.ModePortForward:
+		s := startPortForwardSender(t, b.env, b.auth, opts.Target)
+		senderAddr = waitForLogAddr(t, s, "port-forward listening", 15*time.Second)
+	case relayparity.ModeSOCKS5:
+		s := startSOCKS5Sender(t, b.env, b.auth)
+		senderAddr = waitForLogAddr(t, s, "socks5-proxy listening", 15*time.Second)
+	default:
+		t.Fatalf("unknown SenderMode %v", opts.SenderMode)
+	}
+
+	return &relayparity.Tunnel{SenderAddr: senderAddr}
+}

--- a/e2e/parity_test.go
+++ b/e2e/parity_test.go
@@ -1,0 +1,25 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"testing"
+
+	"github.com/philsphicas/aztunnel/internal/relayparity"
+)
+
+// TestParity_Azure runs the shared core parity suite against a real
+// Azure Relay namespace, once per configured auth method (Entra,
+// SAS). The same scenarios run against the in-process MockBackend in
+// mockrelay/parity — any divergence between this test and that one is
+// a behavioural gap to fix in the mock.
+func TestParity_Azure(t *testing.T) {
+	env := requireRelayEnv(t)
+	for _, auth := range availableAuths(t, env) {
+		auth := auth
+		t.Run(auth.name, func(t *testing.T) {
+			b := &azureBackend{env: env, auth: auth}
+			relayparity.RunCoreSuite(t, b)
+		})
+	}
+}

--- a/internal/relayparity/backend.go
+++ b/internal/relayparity/backend.go
@@ -1,0 +1,91 @@
+package relayparity
+
+import (
+	"testing"
+)
+
+// SenderMode selects which aztunnel sender to bring up.
+type SenderMode int
+
+const (
+	// ModePortForward starts a relay-sender port-forward bound to
+	// SetupOptions.Target. Dialing the resulting SenderAddr is
+	// equivalent to dialing Target directly through the tunnel.
+	ModePortForward SenderMode = iota
+	// ModeSOCKS5 starts a relay-sender socks5-proxy. The resulting
+	// SenderAddr speaks SOCKS5; each client connection chooses its own
+	// target via the SOCKS5 handshake.
+	ModeSOCKS5
+)
+
+func (m SenderMode) String() string {
+	switch m {
+	case ModePortForward:
+		return "port-forward"
+	case ModeSOCKS5:
+		return "socks5"
+	default:
+		return "unknown"
+	}
+}
+
+// Backend is the abstraction parity scenarios run against. Each
+// implementation knows how to bring up a topology that satisfies
+// SetupOptions and to tear it down cleanly via t.Cleanup.
+type Backend interface {
+	// Name identifies the backend in test output (e.g. "mock",
+	// "azure-entra", "azure-sas"). Used to make sub-test paths
+	// readable.
+	Name() string
+
+	// Setup brings up a relay topology described by opts and returns a
+	// Tunnel handle the scenario can drive. All resources (goroutines,
+	// subprocesses, listeners, sockets) are registered for cleanup on
+	// t via t.Cleanup; the scenario does not have to release them.
+	//
+	// Setup must block until the topology is ready: the sender's bind
+	// address is accepting connections and every requested listener is
+	// reachable (control channel established for subprocess backends;
+	// goroutine running for in-process). Scenarios assume the tunnel
+	// is fully connected on return.
+	Setup(t *testing.T, opts SetupOptions) *Tunnel
+}
+
+// SetupOptions configures the topology a backend should create.
+type SetupOptions struct {
+	// NumListeners is the count of listener processes/goroutines to
+	// start against the same entity. Must be >= 1.
+	NumListeners int
+
+	// SenderMode picks port-forward vs SOCKS5.
+	SenderMode SenderMode
+
+	// Target is the dial target for port-forward mode. Ignored for
+	// SOCKS5 (clients choose their own target via the SOCKS5
+	// handshake).
+	Target string
+
+	// AllowedTargets is the listener --allow value(s). Empty means
+	// allow all; tests usually pass the addresses of the target
+	// servers they started. Slice order is not significant.
+	AllowedTargets []string
+
+	// MaxConnections caps concurrent target dials on each listener
+	// (`aztunnel relay-listener --max-connections=N`). 0 means
+	// unlimited.
+	MaxConnections int
+}
+
+// Tunnel is a running listener/sender/relay topology returned by
+// Backend.Setup. Scenarios drive it by dialing SenderAddr from client
+// goroutines.
+//
+// Per-listener handles (for distribution, hot-drop, hot-add scenarios)
+// will be added when the topology suite that needs them lands.
+type Tunnel struct {
+	// SenderAddr is the host:port clients dial. For ModePortForward
+	// this is a plain TCP target that forwards to SetupOptions.Target.
+	// For ModeSOCKS5 this is a SOCKS5 proxy that accepts any allowed
+	// target via the SOCKS5 handshake.
+	SenderAddr string
+}

--- a/internal/relayparity/doc.go
+++ b/internal/relayparity/doc.go
@@ -1,0 +1,22 @@
+// Package relayparity defines a backend abstraction for running the
+// same end-to-end test scenarios against multiple relay implementations.
+//
+// Two implementations exist:
+//
+//   - github.com/philsphicas/aztunnel/mockrelay/parity.MockBackend
+//     runs the mock relay server (mockrelay/server) and the aztunnel
+//     listener and sender in-process. Fast, deterministic, no external
+//     dependencies. Lives in the mockrelay module so the in-process
+//     server import does not leak into the main aztunnel binary's
+//     dependency graph.
+//
+//   - e2e/azure_backend_test.go (azureBackend, build tag e2e) drives
+//     subprocess aztunnel listeners and senders against a real Azure
+//     Relay namespace. Runs in the e2e CI job and requires Azure
+//     credentials.
+//
+// Scenarios in this package describe observable behavior of the
+// tunnel and are written once. They run against both backends so any
+// divergence is surfaced as a test failure (or documented contract
+// gap).
+package relayparity

--- a/internal/relayparity/echo.go
+++ b/internal/relayparity/echo.go
@@ -1,0 +1,71 @@
+package relayparity
+
+import (
+	"io"
+	"net"
+	"sync"
+	"sync/atomic"
+	"testing"
+)
+
+// PlainEcho is a TCP server that echoes every byte it receives back
+// to the sender, unmodified. Used by scenarios that verify byte-level
+// transparency (ordering, integrity, bidirectional throughput).
+//
+// Lifetimes are tracked separately: serveDone signals when the accept
+// loop has exited (and therefore no further connection-goroutine
+// spawns can happen), and connWg tracks the connection goroutines
+// themselves. Stop waits on serveDone before draining connWg so the
+// connection counter never receives a fresh Add concurrent with its
+// own Wait.
+type PlainEcho struct {
+	ln        net.Listener
+	serveDone chan struct{}
+	connWg    sync.WaitGroup
+	done      atomic.Bool
+}
+
+// StartPlainEcho starts a plain echo server on a free localhost port.
+// It is stopped by t.Cleanup.
+func StartPlainEcho(t *testing.T) *PlainEcho {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("plain echo listen: %v", err)
+	}
+	pe := &PlainEcho{ln: ln, serveDone: make(chan struct{})}
+	go pe.serve()
+	t.Cleanup(pe.Stop)
+	return pe
+}
+
+// Addr returns the host:port the echo server is listening on.
+func (pe *PlainEcho) Addr() string { return pe.ln.Addr().String() }
+
+// Stop closes the listener, waits for the accept loop to exit so no
+// further connection goroutines can be spawned, then drains the
+// outstanding connections.
+func (pe *PlainEcho) Stop() {
+	if pe.done.Swap(true) {
+		return
+	}
+	pe.ln.Close()  //nolint:errcheck // best-effort cleanup
+	<-pe.serveDone // accept loop has exited; connWg is now stable
+	pe.connWg.Wait()
+}
+
+func (pe *PlainEcho) serve() {
+	defer close(pe.serveDone)
+	for {
+		conn, err := pe.ln.Accept()
+		if err != nil {
+			return
+		}
+		pe.connWg.Add(1)
+		go func(c net.Conn) {
+			defer pe.connWg.Done()
+			defer c.Close() //nolint:errcheck // best-effort cleanup
+			_, _ = io.Copy(c, c)
+		}(conn)
+	}
+}

--- a/internal/relayparity/scenarios.go
+++ b/internal/relayparity/scenarios.go
@@ -1,0 +1,348 @@
+package relayparity
+
+import (
+	"bytes"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"testing"
+	"time"
+)
+
+// RunCoreSuite runs every single-flow parity scenario against b as a
+// set of sub-tests under the caller's t. New scenarios get added here.
+//
+// The scenarios run sequentially, each in its own t.Run; backends
+// register their own t.Cleanup, so each sub-test gets a freshly built
+// topology and tears it down before the next starts.
+//
+// Scenarios in the core suite are required to pass on current main.
+// Behaviors that PR #47 (mux) is expected to change (e.g. half-close
+// propagation) live outside the core suite so this gate stays green
+// pre- and post-#47.
+func RunCoreSuite(t *testing.T, b Backend) {
+	t.Helper()
+	scenarios := []struct {
+		name string
+		run  func(*testing.T, Backend)
+	}{
+		{"Echo_PortForward", ScenarioEcho_PortForward},
+		{"Echo_SOCKS5", ScenarioEcho_SOCKS5},
+		{"Ordering_PortForward", ScenarioOrdering_PortForward},
+		{"Bidirectional_PortForward", ScenarioBidirectional_PortForward},
+	}
+	for _, sc := range scenarios {
+		t.Run(sc.name, func(t *testing.T) {
+			sc.run(t, b)
+		})
+	}
+}
+
+// ScenarioEcho_PortForward: open one port-forward connection, write a
+// short payload, read it back unchanged. The minimum proof that the
+// tunnel routes bytes end-to-end.
+func ScenarioEcho_PortForward(t *testing.T, b Backend) {
+	t.Helper()
+	echo := StartPlainEcho(t)
+	tun := b.Setup(t, SetupOptions{
+		NumListeners:   1,
+		SenderMode:     ModePortForward,
+		Target:         echo.Addr(),
+		AllowedTargets: []string{echo.Addr()},
+	})
+
+	conn := dialWithRetry(t, tun.SenderAddr, 5*time.Second)
+	defer conn.Close() //nolint:errcheck // best-effort cleanup
+
+	want := []byte("hello aztunnel parity\n")
+	writeAll(t, conn, want)
+	got := readN(t, conn, len(want), 10*time.Second)
+	if !bytes.Equal(got, want) {
+		t.Fatalf("echo mismatch\n got=%q\nwant=%q", got, want)
+	}
+}
+
+// ScenarioEcho_SOCKS5: same as ScenarioEcho_PortForward but the
+// sender is a SOCKS5 proxy. Verifies the SOCKS5 CONNECT path round-
+// trips bytes correctly.
+func ScenarioEcho_SOCKS5(t *testing.T, b Backend) {
+	t.Helper()
+	echo := StartPlainEcho(t)
+	tun := b.Setup(t, SetupOptions{
+		NumListeners:   1,
+		SenderMode:     ModeSOCKS5,
+		AllowedTargets: []string{echo.Addr()},
+	})
+
+	conn, err := dialSOCKS5WithRetry(tun.SenderAddr, echo.Addr(), 5*time.Second)
+	if err != nil {
+		t.Fatalf("socks5 dial: %v", err)
+	}
+	defer conn.Close() //nolint:errcheck // best-effort cleanup
+
+	want := []byte("hello aztunnel socks5 parity\n")
+	writeAll(t, conn, want)
+	got := readN(t, conn, len(want), 10*time.Second)
+	if !bytes.Equal(got, want) {
+		t.Fatalf("echo mismatch\n got=%q\nwant=%q", got, want)
+	}
+}
+
+// ScenarioOrdering_PortForward sends 1024 sequenced 1 KB chunks
+// through one connection. Each chunk's first 4 bytes are the chunk
+// index in big-endian; the remaining 1020 bytes are deterministic
+// filler. Read-back must arrive in the same order, identical bytes.
+//
+// Catches reordering or interleaving inside the bridge / future mux.
+func ScenarioOrdering_PortForward(t *testing.T, b Backend) {
+	t.Helper()
+	echo := StartPlainEcho(t)
+	tun := b.Setup(t, SetupOptions{
+		NumListeners:   1,
+		SenderMode:     ModePortForward,
+		Target:         echo.Addr(),
+		AllowedTargets: []string{echo.Addr()},
+	})
+
+	const nChunks = 1024
+	const chunkSize = 1024
+	total := nChunks * chunkSize
+
+	conn := dialWithRetry(t, tun.SenderAddr, 5*time.Second)
+	defer conn.Close() //nolint:errcheck // best-effort cleanup
+	_ = conn.SetDeadline(time.Now().Add(60 * time.Second))
+
+	// Writer goroutine.
+	writeErr := make(chan error, 1)
+	go func() {
+		buf := make([]byte, chunkSize)
+		for i := uint32(0); i < nChunks; i++ {
+			binary.BigEndian.PutUint32(buf[:4], i)
+			for j := 4; j < chunkSize; j++ {
+				buf[j] = byte(i + uint32(j))
+			}
+			if err := writeFull(conn, buf); err != nil {
+				writeErr <- fmt.Errorf("write chunk %d: %w", i, err)
+				return
+			}
+		}
+		writeErr <- nil
+	}()
+
+	// Reader on main goroutine.
+	got := make([]byte, total)
+	if _, err := io.ReadFull(conn, got); err != nil {
+		t.Fatalf("read full %d bytes: %v", total, err)
+	}
+	if err := <-writeErr; err != nil {
+		t.Fatalf("writer: %v", err)
+	}
+
+	for i := uint32(0); i < nChunks; i++ {
+		off := int(i) * chunkSize
+		seen := binary.BigEndian.Uint32(got[off : off+4])
+		if seen != i {
+			t.Fatalf("chunk %d header mismatch: got %d at offset %d", i, seen, off)
+		}
+		for j := 4; j < chunkSize; j++ {
+			want := byte(i + uint32(j))
+			if got[off+j] != want {
+				t.Fatalf("chunk %d byte %d: got %#x want %#x", i, j, got[off+j], want)
+			}
+		}
+	}
+}
+
+// ScenarioBidirectional_PortForward writes 256 KB upstream while
+// reading 256 KB downstream simultaneously, comparing both sides
+// against an in-memory random body via SHA256. The target is a plain
+// (full-duplex) echo, so what the client reads is exactly what it
+// wrote — a SHA256 match in both directions, end-to-end.
+//
+// Catches half-duplex bugs, back-pressure deadlocks, and silent body
+// corruption (random body + hash + exact length defends against the
+// "echo passes but bytes got rearranged" failure mode).
+func ScenarioBidirectional_PortForward(t *testing.T, b Backend) {
+	t.Helper()
+	echo := StartPlainEcho(t)
+	tun := b.Setup(t, SetupOptions{
+		NumListeners:   1,
+		SenderMode:     ModePortForward,
+		Target:         echo.Addr(),
+		AllowedTargets: []string{echo.Addr()},
+	})
+
+	const size = 256 * 1024
+	body := make([]byte, size)
+	if _, err := rand.Read(body); err != nil {
+		t.Fatalf("rand: %v", err)
+	}
+	want := sha256.Sum256(body)
+
+	conn := dialWithRetry(t, tun.SenderAddr, 5*time.Second)
+	defer conn.Close() //nolint:errcheck // best-effort cleanup
+	_ = conn.SetDeadline(time.Now().Add(60 * time.Second))
+
+	// Each goroutine reports its result on its own channel; the main
+	// goroutine drains both before asserting. This keeps the
+	// happens-before story explicit (channel send → channel receive)
+	// rather than relying on WaitGroup memory ordering around shared
+	// variables.
+	type readResult struct {
+		err error
+		sum [32]byte
+		n   int
+	}
+	wErr := make(chan error, 1)
+	rRes := make(chan readResult, 1)
+
+	go func() {
+		if err := writeFull(conn, body); err != nil {
+			wErr <- fmt.Errorf("write: %w", err)
+			return
+		}
+		wErr <- nil
+	}()
+	go func() {
+		got := make([]byte, size)
+		if _, err := io.ReadFull(conn, got); err != nil {
+			rRes <- readResult{err: fmt.Errorf("read: %w", err)}
+			return
+		}
+		rRes <- readResult{sum: sha256.Sum256(got), n: size}
+	}()
+
+	if err := <-wErr; err != nil {
+		t.Fatalf("%v", err)
+	}
+	res := <-rRes
+	if res.err != nil {
+		t.Fatalf("%v", res.err)
+	}
+	if res.n != size {
+		t.Fatalf("length mismatch: got %d want %d", res.n, size)
+	}
+	if res.sum != want {
+		t.Fatalf("body sha256 mismatch:\n got=%x\nwant=%x", res.sum, want)
+	}
+}
+
+// dialWithRetry dials addr with a short backoff so the sender's bind
+// has time to come up after Setup returns. Setup blocks until ready,
+// but tests still see occasional ECONNREFUSED races on slow runners;
+// 200 ms of backoff makes the test deterministic.
+//
+// Each attempt is bounded by the remaining budget against a single
+// absolute deadline (computed at entry), so the helper respects its
+// timeout parameter precisely — no stacked per-attempt timeouts.
+func dialWithRetry(t *testing.T, addr string, timeout time.Duration) net.Conn {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	var lastErr error
+	for {
+		remaining := time.Until(deadline)
+		if remaining <= 0 {
+			break
+		}
+		attemptTimeout := remaining
+		if attemptTimeout > 1*time.Second {
+			attemptTimeout = 1 * time.Second
+		}
+		conn, err := net.DialTimeout("tcp", addr, attemptTimeout)
+		if err == nil {
+			return conn
+		}
+		lastErr = err
+		const backoff = 25 * time.Millisecond
+		if time.Until(deadline) <= backoff {
+			break
+		}
+		time.Sleep(backoff)
+	}
+	t.Fatalf("dial %s after %v: %v", addr, timeout, lastErr)
+	return nil
+}
+
+// dialSOCKS5WithRetry is the SOCKS5 analogue of dialWithRetry.
+// SOCKS5 negotiation can transiently fail if the listener's control
+// channel has not yet attached on the relay side; retry until the
+// timeout. Each attempt is bounded by the remaining budget so a
+// stalled SOCKS5 handshake cannot block past the overall deadline.
+//
+// A SOCKS5-level reply (any *SOCKS5Error — e.g. REP=0x02
+// "not allowed by ruleset", REP=0x07 "command not supported") is a
+// definitive answer from the proxy, not a transient race, so it
+// short-circuits the retry loop and is returned immediately. Only
+// dial/IO errors are retried.
+func dialSOCKS5WithRetry(proxyAddr, target string, timeout time.Duration) (net.Conn, error) {
+	deadline := time.Now().Add(timeout)
+	var lastErr error
+	for {
+		remaining := time.Until(deadline)
+		if remaining <= 0 {
+			break
+		}
+		attemptTimeout := remaining
+		if attemptTimeout > 2*time.Second {
+			attemptTimeout = 2 * time.Second
+		}
+		conn, err := DialSOCKS5(proxyAddr, target, attemptTimeout)
+		if err == nil {
+			return conn, nil
+		}
+		var sErr *SOCKS5Error
+		if errors.As(err, &sErr) {
+			return nil, err
+		}
+		lastErr = err
+		// Cap the inter-attempt backoff to whatever budget is left so
+		// the wrapper never overshoots its overall deadline. If less
+		// than the full backoff remains, there's no time for another
+		// attempt anyway, so break out instead of sleeping into the
+		// final break check.
+		const backoff = 50 * time.Millisecond
+		if time.Until(deadline) <= backoff {
+			break
+		}
+		time.Sleep(backoff)
+	}
+	return nil, fmt.Errorf("socks5 dial %s via %s after %v: %w", target, proxyAddr, timeout, lastErr)
+}
+
+func writeAll(t *testing.T, w io.Writer, b []byte) {
+	t.Helper()
+	if err := writeFull(w, b); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+}
+
+// writeFull is the goroutine-safe counterpart to writeAll: it writes
+// all of buf to w and returns an explicit error on short write. Per
+// the io.Writer contract a short write must come with a non-nil
+// error, but checking n explicitly surfaces contract violations as a
+// clear failure rather than a deadlocked reader.
+func writeFull(w io.Writer, buf []byte) error {
+	n, err := w.Write(buf)
+	if err != nil {
+		return err
+	}
+	if n != len(buf) {
+		return io.ErrShortWrite
+	}
+	return nil
+}
+
+func readN(t *testing.T, c net.Conn, n int, timeout time.Duration) []byte {
+	t.Helper()
+	_ = c.SetReadDeadline(time.Now().Add(timeout))
+	defer func() { _ = c.SetReadDeadline(time.Time{}) }()
+	buf := make([]byte, n)
+	if _, err := io.ReadFull(c, buf); err != nil {
+		t.Fatalf("read %d bytes: %v", n, err)
+	}
+	return buf
+}

--- a/internal/relayparity/socks5.go
+++ b/internal/relayparity/socks5.go
@@ -1,0 +1,169 @@
+package relayparity
+
+import (
+	"encoding/binary"
+	"fmt"
+	"io"
+	"net"
+	"strconv"
+	"time"
+)
+
+// DialSOCKS5 performs a no-auth SOCKS5 CONNECT through proxyAddr to
+// target ("host:port"). On success it returns a net.Conn already
+// addressed to target. On a SOCKS5-level failure (non-zero REP byte)
+// it returns an error containing the REP value so error-propagation
+// scenarios can distinguish refused vs unreachable vs other.
+//
+// timeout bounds the entire operation (TCP dial + SOCKS5 negotiation)
+// against a single absolute deadline computed at entry. A stalled
+// proxy that accepts TCP but never replies to method negotiation,
+// and a slow DNS resolution that eats most of the budget, both fail
+// inside the same overall deadline rather than each getting a fresh
+// timeout. The conn deadline is cleared on successful return; on
+// error the conn is closed.
+//
+// This is a minimal SOCKS5 client suitable for parity tests; it does
+// not support auth methods, BIND, or UDP ASSOCIATE.
+func DialSOCKS5(proxyAddr, target string, timeout time.Duration) (net.Conn, error) {
+	deadline := time.Now().Add(timeout)
+	dialer := net.Dialer{Deadline: deadline}
+	conn, err := dialer.Dial("tcp", proxyAddr)
+	if err != nil {
+		return nil, fmt.Errorf("dial proxy: %w", err)
+	}
+	if err := conn.SetDeadline(deadline); err != nil {
+		conn.Close() //nolint:errcheck // best-effort cleanup on error
+		return nil, fmt.Errorf("set deadline: %w", err)
+	}
+	if err := socks5Negotiate(conn, target); err != nil {
+		conn.Close() //nolint:errcheck // best-effort cleanup on error
+		return nil, err
+	}
+	if err := conn.SetDeadline(time.Time{}); err != nil {
+		conn.Close() //nolint:errcheck // best-effort cleanup on error
+		return nil, fmt.Errorf("clear deadline: %w", err)
+	}
+	return conn, nil
+}
+
+func socks5Negotiate(conn net.Conn, target string) error {
+	host, portStr, err := net.SplitHostPort(target)
+	if err != nil {
+		return fmt.Errorf("parse target %q: %w", target, err)
+	}
+	portInt, err := strconv.Atoi(portStr)
+	if err != nil || portInt <= 0 || portInt > 65535 {
+		return fmt.Errorf("parse port %q: invalid", portStr)
+	}
+	port := uint16(portInt)
+
+	// Method negotiation: VER=5, NMETHODS=1, NO-AUTH(0x00).
+	if err := writeFull(conn, []byte{0x05, 0x01, 0x00}); err != nil {
+		return fmt.Errorf("socks5 method write: %w", err)
+	}
+	resp := make([]byte, 2)
+	if _, err := io.ReadFull(conn, resp); err != nil {
+		return fmt.Errorf("socks5 method response: %w", err)
+	}
+	if resp[0] != 0x05 || resp[1] != 0x00 {
+		return fmt.Errorf("socks5 method rejected: %v", resp)
+	}
+
+	// CONNECT request: VER=5, CMD=CONNECT(0x01), RSV=0, ATYP+ADDR+PORT.
+	req := []byte{0x05, 0x01, 0x00}
+	if ip := net.ParseIP(host); ip != nil {
+		if ip4 := ip.To4(); ip4 != nil {
+			req = append(req, 0x01)
+			req = append(req, ip4...)
+		} else {
+			req = append(req, 0x04)
+			req = append(req, ip...)
+		}
+	} else {
+		if len(host) > 255 {
+			return fmt.Errorf("socks5 hostname too long: %d", len(host))
+		}
+		req = append(req, 0x03, byte(len(host)))
+		req = append(req, []byte(host)...)
+	}
+	portBytes := make([]byte, 2)
+	binary.BigEndian.PutUint16(portBytes, port)
+	req = append(req, portBytes...)
+
+	if err := writeFull(conn, req); err != nil {
+		return fmt.Errorf("socks5 connect write: %w", err)
+	}
+
+	// Reply: VER, REP, RSV, ATYP, BND.ADDR, BND.PORT.
+	head := make([]byte, 4)
+	if _, err := io.ReadFull(conn, head); err != nil {
+		return fmt.Errorf("socks5 connect response: %w", err)
+	}
+	if head[0] != 0x05 {
+		return fmt.Errorf("socks5 reply VER=%#x, want 0x05", head[0])
+	}
+	if head[2] != 0x00 {
+		return fmt.Errorf("socks5 reply RSV=%#x, want 0x00", head[2])
+	}
+	// Drain the bound address regardless of REP so the conn is
+	// positioned at the start of the data stream.
+	switch head[3] {
+	case 0x01:
+		_, err = io.ReadFull(conn, make([]byte, 4+2))
+	case 0x04:
+		_, err = io.ReadFull(conn, make([]byte, 16+2))
+	case 0x03:
+		ln := make([]byte, 1)
+		if _, err = io.ReadFull(conn, ln); err == nil {
+			_, err = io.ReadFull(conn, make([]byte, int(ln[0])+2))
+		}
+	default:
+		return fmt.Errorf("socks5 unknown ATYP %#x", head[3])
+	}
+	if err != nil {
+		return fmt.Errorf("socks5 read bnd addr: %w", err)
+	}
+
+	if head[1] != 0x00 {
+		return &SOCKS5Error{Rep: head[1]}
+	}
+	return nil
+}
+
+// SOCKS5Error is returned by DialSOCKS5 when the proxy replies with a
+// non-success REP code. Scenarios that test error propagation
+// (T17 in the plan) inspect Rep directly.
+type SOCKS5Error struct {
+	Rep byte
+}
+
+func (e *SOCKS5Error) Error() string {
+	return fmt.Sprintf("socks5 reply rejected: REP=%#x (%s)", e.Rep, socks5RepName(e.Rep))
+}
+
+// socks5RepName returns the RFC 1928 name for a SOCKS5 reply code.
+func socks5RepName(rep byte) string {
+	switch rep {
+	case 0x00:
+		return "succeeded"
+	case 0x01:
+		return "general SOCKS server failure"
+	case 0x02:
+		return "connection not allowed by ruleset"
+	case 0x03:
+		return "network unreachable"
+	case 0x04:
+		return "host unreachable"
+	case 0x05:
+		return "connection refused"
+	case 0x06:
+		return "TTL expired"
+	case 0x07:
+		return "command not supported"
+	case 0x08:
+		return "address type not supported"
+	default:
+		return "unknown"
+	}
+}

--- a/mockrelay/parity/mock_backend.go
+++ b/mockrelay/parity/mock_backend.go
@@ -1,0 +1,281 @@
+// Package parity wires the shared relay-parity scenario suite
+// (internal/relayparity) up against an in-process mock relay.
+//
+// MockBackend is intended for use inside the mockrelay module's test
+// binary; it brings up a real aztunnel listener + sender (the same
+// code paths exercised against Azure Relay) talking to a mock relay
+// server in-process. Tests written against the relayparity.Backend
+// interface run unmodified against this backend, and the e2e module's
+// AzureBackend, so any behavioural divergence between mock and Azure
+// shows up as a failing scenario in one but not the other.
+package parity
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/tls"
+	"encoding/hex"
+	"io"
+	"log/slog"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/philsphicas/aztunnel/internal/listener"
+	"github.com/philsphicas/aztunnel/internal/relay"
+	"github.com/philsphicas/aztunnel/internal/relayparity"
+	"github.com/philsphicas/aztunnel/internal/sender"
+	"github.com/philsphicas/aztunnel/mockrelay/server"
+)
+
+// MockBackend implements relayparity.Backend by standing up a mock
+// relay server + aztunnel listener(s) + aztunnel sender all in the
+// same process. It is the fast, deterministic side of the parity
+// matrix and runs in the default `go test ./mockrelay/...` job.
+type MockBackend struct{}
+
+// Name returns the backend identifier used in test sub-paths.
+func (*MockBackend) Name() string { return "mock" }
+
+// Setup brings up the in-process topology described by opts and
+// blocks until every listener has registered with the mock relay and
+// the sender's local bind is accepting TCP. All goroutines, the mock
+// HTTP server, and the sender bind are released via t.Cleanup.
+func (*MockBackend) Setup(t *testing.T, opts relayparity.SetupOptions) *relayparity.Tunnel {
+	t.Helper()
+	if opts.NumListeners < 1 {
+		t.Fatalf("NumListeners must be >= 1, got %d", opts.NumListeners)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	// Register cleanup BEFORE spawning any goroutines so an early
+	// t.Fatalf in a readiness gate still drains anything we managed to
+	// start. wg.Wait() on a zero-counter wg returns immediately, so
+	// this is safe when Setup fails before any goroutine launches.
+	var wg sync.WaitGroup
+	t.Cleanup(func() {
+		cancel()
+		wg.Wait()
+	})
+
+	host, clientOpts, srv := startMockRelay(t)
+	// Entity name is unique per scenario so concurrent t.Parallel
+	// sub-tests cannot bleed into each other if they ever land on the
+	// same mock-relay instance — and gives test failure messages a
+	// useful breadcrumb to the originating scenario.
+	entity := mustEntityName(t)
+
+	tokenProvider := &relay.SASTokenProvider{
+		KeyName: server.DefaultSASKeyName,
+		Key:     server.DefaultSASKey,
+	}
+	silentLogger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	for i := 0; i < opts.NumListeners; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			err := listener.ListenAndServe(ctx, listener.Config{
+				Endpoint:       host,
+				EntityPath:     entity,
+				TokenProvider:  tokenProvider,
+				ClientOptions:  clientOpts,
+				AllowList:      opts.AllowedTargets,
+				MaxConnections: opts.MaxConnections,
+				Logger:         silentLogger,
+			})
+			if err != nil && ctx.Err() == nil {
+				t.Logf("listener exited: %v", err)
+			}
+		}()
+	}
+	// Wait for *all* listeners to register their accept side with the
+	// mock so scenarios that happen to land on a not-yet-attached
+	// listener don't see a transient 404. The mock's probe transitions
+	// from 404 -> 400 once any listener is registered; we don't have a
+	// strict per-listener probe, so a small extra settle after the
+	// first ready signal covers the others.
+	waitForControl(t, srv, entity, 3*time.Second)
+	if opts.NumListeners > 1 {
+		// One additional poll cycle is enough on the mock: every
+		// listener registers in a single tick of its dial loop.
+		time.Sleep(100 * time.Millisecond)
+	}
+
+	// Validate SenderMode synchronously so an unknown mode fails the
+	// test immediately instead of being caught by the waitForTCP
+	// timeout below — the timeout would mask the real cause and add
+	// ~3 s of avoidable delay per misconfigured scenario.
+	switch opts.SenderMode {
+	case relayparity.ModePortForward, relayparity.ModeSOCKS5:
+	default:
+		t.Fatalf("unknown SenderMode %v", opts.SenderMode)
+	}
+
+	bind := pickFreePort(t)
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		var err error
+		switch opts.SenderMode {
+		case relayparity.ModePortForward:
+			err = sender.PortForward(ctx, sender.PortForwardConfig{
+				Endpoint:      host,
+				EntityPath:    entity,
+				TokenProvider: tokenProvider,
+				ClientOptions: clientOpts,
+				Target:        opts.Target,
+				BindAddress:   bind,
+				Logger:        silentLogger,
+			})
+		case relayparity.ModeSOCKS5:
+			err = sender.SOCKS5Proxy(ctx, sender.SOCKS5Config{
+				Endpoint:      host,
+				EntityPath:    entity,
+				TokenProvider: tokenProvider,
+				ClientOptions: clientOpts,
+				BindAddress:   bind,
+				Logger:        silentLogger,
+			})
+		}
+		if err != nil && ctx.Err() == nil {
+			t.Logf("sender exited: %v", err)
+		}
+	}()
+
+	if !waitForTCP(bind, 3*time.Second) {
+		t.Fatalf("sender bind %s never became reachable", bind)
+	}
+
+	return &relayparity.Tunnel{SenderAddr: bind}
+}
+
+// startMockRelay starts a server.Server backed by httptest.NewTLSServer
+// (aztunnel only dials TLS-protected relays) and returns the host:port
+// plus a ClientOptions whose TLSConfig skips verification of the test
+// certificate. Mirrors the helper in mockrelay/server/integration_test.go
+// so behaviour is identical.
+func startMockRelay(t *testing.T) (host string, opts relay.ClientOptions, srv *httptest.Server) {
+	t.Helper()
+	rs, err := server.NewServer(server.Config{
+		Logger:            slog.New(slog.NewTextHandler(io.Discard, nil)),
+		RendezvousTimeout: 5 * time.Second,
+	})
+	if err != nil {
+		t.Fatalf("new mock relay: %v", err)
+	}
+	srv = httptest.NewTLSServer(rs.Handler())
+	u, _ := url.Parse(srv.URL)
+	host = u.Host
+	opts = relay.ClientOptions{
+		TLSConfig: &tls.Config{InsecureSkipVerify: true}, //nolint:gosec // test cert
+	}
+	t.Cleanup(srv.Close)
+	return host, opts, srv
+}
+
+// pickFreePort returns a localhost host:port that was free at the
+// moment of the call. There is an unavoidable TOCTOU window between
+// this Listen+Close pair and the sender's own net.Listen on the same
+// addr: another process can grab the port in between. If it loses
+// the race, the sender returns immediately with a bind error (the
+// senders do not retry), the sender goroutine exits, and Setup's
+// downstream waitForTCP times out after 3 s with a "never became
+// reachable" failure. In practice the window is microseconds-long
+// on a quiet test host, so this has not flaked, but the failure
+// mode is loud rather than retried.
+func pickFreePort(t *testing.T) string {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("pick port: %v", err)
+	}
+	addr := ln.Addr().String()
+	ln.Close() //nolint:errcheck // best-effort cleanup
+	return addr
+}
+
+// waitForTCP polls until a TCP connection to addr succeeds or the
+// timeout elapses. Used to make Backend.Setup block until the sender
+// is actually accepting.
+//
+// TODO(slice-2B): in ModePortForward, every accepted TCP connection
+// triggers a forward attempt through the relay. The probe socket
+// immediately closes, so the bridge tears down — but it does briefly
+// occupy a slot. Once MaxConnections=N scenarios land, the probe will
+// consume the only available slot and the scenario's real dial will
+// be rejected on the mock backend (azureBackend uses log-gated
+// readiness and is unaffected). Replace this probe with a non-
+// forwarding readiness signal (custom logger handler that captures
+// the "port-forward listening" log line, or a sender-side ready
+// channel) before MaxConnections scenarios merge.
+func waitForTCP(addr string, timeout time.Duration) bool {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		c, err := net.DialTimeout("tcp", addr, 200*time.Millisecond)
+		if err == nil {
+			c.Close() //nolint:errcheck // best-effort cleanup
+			return true
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	return false
+}
+
+// waitForControl polls the mock relay until at least one listener has
+// registered for the given entity. The sb-hc-action=connect probe
+// without an Upgrade header returns 404 when no listener is attached
+// and 400-ish once one is, so we watch for the transition away from
+// 404. Copy of the helper in mockrelay/server/integration_test.go.
+func waitForControl(t *testing.T, srv *httptest.Server, entity string, timeout time.Duration) {
+	t.Helper()
+	// Build our own client over the test server's TLS transport
+	// rather than mutating srv.Client(), which is shared and could
+	// surprise other code paths that reach for the default timeout.
+	httpClient := &http.Client{
+		Transport: srv.Client().Transport,
+		Timeout:   1 * time.Second,
+	}
+	host := strings.TrimPrefix(srv.URL, "https://")
+	tok, err := relay.GenerateSASToken(
+		relay.ResourceURI(host, entity),
+		server.DefaultSASKeyName,
+		server.DefaultSASKey,
+		1*time.Minute,
+	)
+	if err != nil {
+		t.Fatalf("mint probe token: %v", err)
+	}
+	probeURL := srv.URL + "/$hc/" + entity + "?sb-hc-action=connect&sb-hc-token=" + url.QueryEscape(tok)
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		resp, err := httpClient.Get(probeURL)
+		if err == nil {
+			status := resp.StatusCode
+			resp.Body.Close() //nolint:errcheck // best-effort cleanup
+			if status != http.StatusNotFound {
+				return
+			}
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for listener on %s/%s", host, entity)
+}
+
+// mustEntityName returns a short random suffix appended to the
+// caller's test name. Keeps entities unique across scenarios.
+func mustEntityName(t *testing.T) string {
+	t.Helper()
+	var b [4]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		t.Fatalf("rand: %v", err)
+	}
+	// Sanitize the test name into something safe for a URL path.
+	safe := strings.NewReplacer("/", "-", " ", "-", "#", "-").Replace(t.Name())
+	return safe + "-" + hex.EncodeToString(b[:])
+}

--- a/mockrelay/parity/parity_test.go
+++ b/mockrelay/parity/parity_test.go
@@ -1,0 +1,19 @@
+package parity_test
+
+import (
+	"testing"
+
+	"github.com/philsphicas/aztunnel/internal/relayparity"
+	"github.com/philsphicas/aztunnel/mockrelay/parity"
+)
+
+// TestParity_Mock runs the shared core parity suite against the
+// in-process MockBackend. This is the always-on side of the parity
+// matrix; it runs in `go test ./mockrelay/...` and is what the CI
+// `test` job enforces.
+func TestParity_Mock(t *testing.T) {
+	var b parity.MockBackend
+	t.Run(b.Name(), func(t *testing.T) {
+		relayparity.RunCoreSuite(t, &b)
+	})
+}


### PR DESCRIPTION
## Why

Today the mock relay and Azure Relay are tested in isolation. Behavioural drift between them is invisible until it surfaces as a flake in one suite and not the other — and we have no way to *quantify* what a relay-side change (mux, retries, anything) actually changes about end-to-end behaviour.

This PR introduces a parity test harness so a single set of scenarios runs unmodified against both backends.

## What you get

- **`TestParity_Mock`** in `mockrelay/parity/` — runs in the default `go test ./mockrelay/...` job. Brings up an in-process mock relay + real aztunnel listener and sender, all in the same process. Sub-second per run.
- **`TestParity_Azure`** in `e2e/parity_test.go` (build tag `e2e`) — same scenarios against a real Azure Relay namespace, once per available auth method (Entra ID, SAS). Subprocess-driven via the existing e2e helpers.
- **Shared scenarios** in `internal/relayparity/` — backend-agnostic; new scenarios get added in one place and automatically run on both backends.

When the two suites disagree, the divergence is the headline finding.

## Scenarios in this slice

| Scenario | What it proves |
| --- | --- |
| `Echo_PortForward` | Bytes round-trip end-to-end through a port-forward tunnel. |
| `Echo_SOCKS5` | Same, but through the SOCKS5 sender (CONNECT path). |
| `Ordering_PortForward` | 1024 sequenced 1 KB chunks arrive in order, no interleaving or reordering inside the bridge. |
| `Bidirectional_PortForward` | 256 KB random payload + SHA256 verify in both directions concurrently — catches half-duplex bugs, back-pressure deadlocks, and silent body corruption. |

All four pass with the race detector on current `main`.

## What's deliberately not here

- Multi-listener / multi-sender / multi-target topology — comes in 2B.
- Benchmarks and quantitative characterisation — 2C.
- Stress, edge cases, half-close-aware protocols — 2D. Half-close in particular is out of scope: the current bridge tears down both directions on EOF, so half-close-aware tests would fail on `main` today. They become useful regression checks once that behaviour changes.

## How to run locally

```
go test -race ./mockrelay/parity/...                      # mock backend, ~1.4s
go test -tags=e2e -count=1 ./e2e/ -run TestParity_Azure   # Azure backend, requires E2E_* env
```