### PR TITLE
fix(mockrelay): COPY e2e/infra/go.mod in Dockerfile build context

### DIFF
--- a/mockrelay/Dockerfile
+++ b/mockrelay/Dockerfile
@@ -16,6 +16,7 @@ WORKDIR /src
 COPY go.work ./
 COPY go.mod go.sum ./
 COPY mockrelay/go.mod mockrelay/go.sum ./mockrelay/
+COPY e2e/infra/go.mod e2e/infra/go.sum ./e2e/infra/
 RUN go mod download
 COPY . .
 ARG VERSION=dev


### PR DESCRIPTION
## Root cause

[PR #51](https://github.com/philsphicas/aztunnel/pull/51) added `./e2e/infra` to the root `go.work`:

```
use (
    .
    ./e2e/infra
    ./mockrelay
)
```

`mockrelay/Dockerfile` curates which module manifests it COPYs into the builder stage before `go mod download`. It copies the root and `mockrelay` modules but not `e2e/infra`. Once the new `use` entry hit `main`, the docker-relay matrix (both `bookworm` and `-alpine` variants) failed on the Release workflow:

```
go: cannot load module e2e/infra listed in go.work file:
    open e2e/infra/go.mod: no such file or directory
ERROR: process "/bin/sh -c go mod download" did not complete successfully: exit code: 1
```

Failed release run: https://github.com/philsphicas/aztunnel/actions/runs/25996603079

Only `aztunnel-relay:dev` and `aztunnel-relay:dev-alpine` on ghcr.io are stale; every other artifact in that run (Linux/Darwin/Windows binaries, production `aztunnel` images, mockrelay binaries, dev-release tagging) succeeded.

## Fix

Add a single `COPY` so the workspace's third module is present when `go mod download` runs:

```dockerfile
COPY mockrelay/go.mod mockrelay/go.sum ./mockrelay/
COPY e2e/infra/go.mod e2e/infra/go.sum ./e2e/infra/
RUN go mod download
```

## Verification

Built both variants locally against the fixed Dockerfile; both succeed:

```
docker build -f mockrelay/Dockerfile \
  --build-arg BUILDER_IMAGE=golang:1-bookworm \
  --build-arg RUNTIME_IMAGE=debian:bookworm-slim \
  -t aztunnel-relay:test-bookworm .

docker build -f mockrelay/Dockerfile \
  --build-arg BUILDER_IMAGE=golang:1-alpine \
  --build-arg RUNTIME_IMAGE=alpine \
  -t aztunnel-relay:test-alpine .
```

Once this lands on `main`, the next Release run will publish the `aztunnel-relay:dev` and `aztunnel-relay:dev-alpine` images.