### PR TITLE
feat: N×M×1 relay parity topology and leak gates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ fmt-check: ## Check formatting (same as CI)
 	npx --yes prettier --check .
 
 e2e: build ## Run end-to-end tests (requires Azure Relay credentials)
-	go test -tags=e2e -timeout=10m -v ./e2e/...
+	go test -tags=e2e -timeout=20m -v ./e2e/...
 
 e2e-docker: ## Run container-to-container e2e tests
 	@status=0; \

--- a/e2e/azure_backend_test.go
+++ b/e2e/azure_backend_test.go
@@ -18,10 +18,13 @@ import (
 //
 // Each instance is bound to a single authConfig (Entra or SAS) so the
 // caller can run the same scenario suite once per available auth.
-// All listeners and the sender are real aztunnel subprocesses driven
-// by the existing helpers (startListener, startPortForwardSender,
+// All listeners and senders are real aztunnel subprocesses driven by
+// the existing helpers (startListener, startPortForwardSender,
 // startSOCKS5Sender), so they exercise the same code paths that
-// production users hit.
+// production users hit. Each subprocess exposes its own Prometheus
+// /metrics endpoint via --metrics-addr 127.0.0.1:0, which the
+// Listener / Sender accessor closures scrape on demand to satisfy
+// Completed() / Active() reads.
 type azureBackend struct {
 	env  *relayEnv
 	auth authConfig
@@ -31,17 +34,23 @@ type azureBackend struct {
 // "azure-entra" or "azure-sas".
 func (b *azureBackend) Name() string { return "azure-" + b.auth.name }
 
-// Setup brings up the requested topology and blocks until every
-// listener has logged "control channel connected" and the sender has
-// logged its bind address. All subprocesses are torn down via the
-// existing t.Cleanup wiring inside startAztunnelWithSAS.
+// Setup brings up the requested topology (NumListeners listeners and
+// max(NumSenders,1) senders), waits until every listener has logged
+// "control channel connected" and every sender has logged its bind
+// address, then attaches metrics-scrape closures and returns the
+// Tunnel handle. All subprocesses are torn down via the existing
+// t.Cleanup wiring inside startAztunnelWithSAS.
 func (b *azureBackend) Setup(t *testing.T, opts relayparity.SetupOptions) *relayparity.Tunnel {
 	t.Helper()
 	if opts.NumListeners < 1 {
 		t.Fatalf("NumListeners must be >= 1, got %d", opts.NumListeners)
 	}
+	numSenders := opts.NumSenders
+	if numSenders < 1 {
+		numSenders = 1
+	}
 
-	listenerArgs := []string{}
+	listenerArgs := []string{"--metrics-addr", "127.0.0.1:0"}
 	for _, target := range opts.AllowedTargets {
 		listenerArgs = append(listenerArgs, "--allow", target)
 	}
@@ -50,22 +59,85 @@ func (b *azureBackend) Setup(t *testing.T, opts relayparity.SetupOptions) *relay
 			strconv.Itoa(opts.MaxConnections))
 	}
 
-	for i := 0; i < opts.NumListeners; i++ {
+	spawnListener := func(t *testing.T) *relayparity.Listener {
+		t.Helper()
 		lst := startListener(t, b.env, b.auth, listenerArgs...)
 		waitForLog(t, lst, "control channel connected", 30*time.Second)
+		metricsAddr := lst.MetricsAddr(t, 15*time.Second)
+		return &relayparity.Listener{
+			Addr:      metricsAddr,
+			Completed: scrapeCounter(metricsAddr, "aztunnel_connections_total"),
+			Active:    scrapeGauge(metricsAddr, "aztunnel_active_connections"),
+			Stop:      func() { lst.Stop(t) },
+		}
 	}
 
-	var senderAddr string
-	switch opts.SenderMode {
-	case relayparity.ModePortForward:
-		s := startPortForwardSender(t, b.env, b.auth, opts.Target)
-		senderAddr = waitForLogAddr(t, s, "port-forward listening", 15*time.Second)
-	case relayparity.ModeSOCKS5:
-		s := startSOCKS5Sender(t, b.env, b.auth)
-		senderAddr = waitForLogAddr(t, s, "socks5-proxy listening", 15*time.Second)
-	default:
-		t.Fatalf("unknown SenderMode %v", opts.SenderMode)
+	senderArgs := []string{"--metrics-addr", "127.0.0.1:0"}
+
+	listeners := make([]*relayparity.Listener, 0, opts.NumListeners)
+	for i := 0; i < opts.NumListeners; i++ {
+		listeners = append(listeners, spawnListener(t))
 	}
 
-	return &relayparity.Tunnel{SenderAddr: senderAddr}
+	senderAddrs := make([]string, 0, numSenders)
+	senders := make([]*relayparity.Sender, 0, numSenders)
+	for i := 0; i < numSenders; i++ {
+		var proc *aztunnelProcess
+		var logMsg string
+		switch opts.SenderMode {
+		case relayparity.ModePortForward:
+			proc = startPortForwardSender(t, b.env, b.auth, opts.Target, senderArgs...)
+			logMsg = "port-forward listening"
+		case relayparity.ModeSOCKS5:
+			proc = startSOCKS5Sender(t, b.env, b.auth, senderArgs...)
+			logMsg = "socks5-proxy listening"
+		default:
+			t.Fatalf("unknown SenderMode %v", opts.SenderMode)
+		}
+		bindAddr := waitForLogAddr(t, proc, logMsg, 15*time.Second)
+		metricsAddr := proc.MetricsAddr(t, 15*time.Second)
+		senderAddrs = append(senderAddrs, bindAddr)
+		senders = append(senders, &relayparity.Sender{
+			Addr:      bindAddr,
+			Completed: scrapeCounter(metricsAddr, "aztunnel_connections_total"),
+			Active:    scrapeGauge(metricsAddr, "aztunnel_active_connections"),
+			Stop:      func() { proc.Stop(t) },
+		})
+	}
+
+	tun := &relayparity.Tunnel{
+		SenderAddr:  senderAddrs[0],
+		SenderAddrs: senderAddrs,
+		Senders:     senders,
+		Listeners:   listeners,
+	}
+	tun.AddListener = func(t *testing.T) *relayparity.Listener {
+		t.Helper()
+		l := spawnListener(t)
+		tun.Listeners = append(tun.Listeners, l)
+		return l
+	}
+	return tun
+}
+
+// scrapeCounter returns a closure that scrapes /metrics on addr and
+// returns the sum of metric `name` (as int64) across all label
+// combinations. Used for `aztunnel_connections_total` — bridges that
+// have completed (Done()).
+func scrapeCounter(addr, name string) func() int64 {
+	return func() int64 {
+		text := scrapeMetricsBest(addr)
+		return int64(sumMetric(text, name))
+	}
+}
+
+// scrapeGauge returns a closure that scrapes /metrics on addr and
+// returns the sum of metric `name` (as int64) across all label
+// combinations. Used for `aztunnel_active_connections` — in-flight
+// bridges.
+func scrapeGauge(addr, name string) func() int64 {
+	return func() int64 {
+		text := scrapeMetricsBest(addr)
+		return int64(sumMetric(text, name))
+	}
 }

--- a/e2e/parity_test.go
+++ b/e2e/parity_test.go
@@ -20,6 +20,7 @@ func TestParity_Azure(t *testing.T) {
 		t.Run(auth.name, func(t *testing.T) {
 			b := &azureBackend{env: env, auth: auth}
 			relayparity.RunCoreSuite(t, b)
+			relayparity.RunTopologySuite(t, b)
 		})
 	}
 }

--- a/internal/relayparity/backend.go
+++ b/internal/relayparity/backend.go
@@ -43,11 +43,13 @@ type Backend interface {
 	// subprocesses, listeners, sockets) are registered for cleanup on
 	// t via t.Cleanup; the scenario does not have to release them.
 	//
-	// Setup must block until the topology is ready: the sender's bind
-	// address is accepting connections and every requested listener is
-	// reachable (control channel established for subprocess backends;
-	// goroutine running for in-process). Scenarios assume the tunnel
-	// is fully connected on return.
+	// Setup must block until the topology is ready: every sender's
+	// bind address is accepting connections and every requested
+	// listener has its control channel attached to the relay (for
+	// subprocess backends, the "control channel connected" log; for
+	// the in-process backend, the aztunnel_control_channel_connected
+	// gauge). Scenarios assume the tunnel is fully connected on
+	// return.
 	Setup(t *testing.T, opts SetupOptions) *Tunnel
 }
 
@@ -56,6 +58,13 @@ type SetupOptions struct {
 	// NumListeners is the count of listener processes/goroutines to
 	// start against the same entity. Must be >= 1.
 	NumListeners int
+
+	// NumSenders is the count of sender processes/goroutines to start
+	// against the same entity. 0 or 1 means a single sender (current
+	// single-sender behaviour, for back-compat with the original four
+	// scenarios). 2+ means N senders; each gets its own free bind and
+	// is exposed via Tunnel.Senders / Tunnel.SenderAddrs.
+	NumSenders int
 
 	// SenderMode picks port-forward vs SOCKS5.
 	SenderMode SenderMode
@@ -76,16 +85,96 @@ type SetupOptions struct {
 	MaxConnections int
 }
 
-// Tunnel is a running listener/sender/relay topology returned by
-// Backend.Setup. Scenarios drive it by dialing SenderAddr from client
-// goroutines.
+// Listener is a handle to a single listener in a Tunnel. Backends
+// populate Tunnel.Listeners with one entry per running listener.
 //
-// Per-listener handles (for distribution, hot-drop, hot-add scenarios)
-// will be added when the topology suite that needs them lands.
+// All accessor closures (Completed, Active) are safe to call
+// concurrently and return monotonically-updating values without
+// blocking on the listener.
+type Listener struct {
+	// Addr is the listener's metrics-scrape address for subprocess
+	// backends; it is left empty for in-process backends that expose
+	// counters directly via the Completed/Active closures.
+	Addr string
+
+	// Completed returns the number of bridged connections this
+	// listener has handled to completion (aztunnel_connections_total
+	// summed across all label combinations on this listener's
+	// metrics surface). Increments only after the bridge ends, so it
+	// is suitable for distribution-after-the-fact assertions but not
+	// for "is a connection currently in flight" checks — use Active
+	// for that.
+	Completed func() int64
+
+	// Active returns the number of bridges currently in flight on
+	// this listener (aztunnel_active_connections summed across all
+	// label combinations).
+	Active func() int64
+
+	// Stop drops this listener: in-process backends cancel the
+	// listener's context and wait for the goroutine to exit;
+	// subprocess backends kill and reap the listener process.
+	// Idempotent; safe to call from a scenario goroutine.
+	Stop func()
+}
+
+// Sender is a handle to a single sender in a Tunnel. Backends populate
+// Tunnel.Senders with one entry per running sender. Tunnel.SenderAddrs
+// holds the same Addr values in the same order for convenience.
+type Sender struct {
+	// Addr is the local bind clients dial. For ModePortForward it is
+	// a plain TCP target that forwards to SetupOptions.Target. For
+	// ModeSOCKS5 it is a SOCKS5 proxy.
+	Addr string
+
+	// Completed returns the number of bridged connections this
+	// sender has handled to completion. See Listener.Completed for
+	// caveats; the same metric semantics apply with role="sender".
+	Completed func() int64
+
+	// Active returns the number of bridges currently in flight on
+	// this sender.
+	Active func() int64
+
+	// Stop drops this sender. Idempotent.
+	Stop func()
+}
+
+// Tunnel is a running listener/sender/relay topology returned by
+// Backend.Setup. Scenarios drive it by dialing into SenderAddrs from
+// client goroutines.
+//
+// Back-compat with the four original scenarios is preserved: SenderAddr
+// remains the field they read and always equals SenderAddrs[0]. New
+// multi-sender scenarios index SenderAddrs directly.
 type Tunnel struct {
-	// SenderAddr is the host:port clients dial. For ModePortForward
-	// this is a plain TCP target that forwards to SetupOptions.Target.
-	// For ModeSOCKS5 this is a SOCKS5 proxy that accepts any allowed
-	// target via the SOCKS5 handshake.
+	// SenderAddr is the host:port clients dial for the first (or
+	// only) sender. Always equal to SenderAddrs[0]. Kept as a top-
+	// level field so the four #50 scenarios compile unchanged.
 	SenderAddr string
+
+	// SenderAddrs holds every sender's bind address in the order
+	// they were spawned. len(SenderAddrs) == len(Senders) ==
+	// max(NumSenders, 1).
+	SenderAddrs []string
+
+	// Senders is the per-sender handle slice, in the same order as
+	// SenderAddrs. Topology scenarios reach for Senders[i].Completed
+	// to verify per-sender distribution.
+	Senders []*Sender
+
+	// Listeners is the per-listener handle slice. len(Listeners) ==
+	// initial NumListeners; AddListener appends.
+	Listeners []*Listener
+
+	// AddListener spawns an additional listener against the same
+	// entity with the same SetupOptions used at Setup time, blocks
+	// until its control channel is attached, appends the handle to
+	// Listeners, and returns the new handle. The caller's t.Cleanup
+	// is already wired up; scenarios do not need to call Stop unless
+	// they want to drop the listener mid-scenario.
+	//
+	// May be nil for backends that haven't wired hot-add yet; the
+	// hot-add scenario calls t.Skip when it is.
+	AddListener func(t *testing.T) *Listener
 }

--- a/internal/relayparity/leak.go
+++ b/internal/relayparity/leak.go
@@ -1,0 +1,103 @@
+package relayparity
+
+import (
+	"os"
+	"runtime"
+	"testing"
+	"time"
+)
+
+// leakTolerance is the slack we allow between the before/after samples
+// of goroutines and open file descriptors. A single scenario brings
+// many transient resources to life (mock-relay http test server,
+// metrics scrape pools, subprocess pipe copy goroutines on the e2e
+// backend, ephemeral connection-close goroutines from net/http) that
+// take a beat to settle once cleanup completes. Anything above this
+// tolerance is treated as a leak. Holding ±10 across both backends
+// has been validated empirically; tightening it later is fine.
+const leakTolerance = 10
+
+// leakSettleDeadline bounds how long AssertNoLeaks polls for the
+// goroutine count to come back inside leakTolerance before declaring
+// a leak. Cleanups (cancel + WaitGroup drains + subprocess Wait()) are
+// synchronous, but Go-runtime bookkeeping for closed connections /
+// timer goroutines can take a few ms to reflect in NumGoroutine.
+const leakSettleDeadline = 2 * time.Second
+
+// AssertNoLeaks samples the test process's goroutine count and (on
+// Linux) open FD count before the scenario runs, then registers a
+// t.Cleanup that re-samples after every other cleanup has finished
+// and fails the test if either delta exceeds leakTolerance.
+//
+// Call AssertNoLeaks at the very top of a scenario, BEFORE invoking
+// Backend.Setup. Because t.Cleanup runs in LIFO order, the leak
+// cleanup we register here runs LAST, after the backend's cleanup
+// chain has cancelled contexts, drained waitgroups, and reaped
+// subprocesses — so by the time we re-sample, all the scenario's
+// resources should have been released.
+//
+// FD checks rely on /proc/self/fd, which only exists on Linux. On
+// other operating systems we skip the FD check and only assert on
+// goroutines; the mock backend runs on every platform but the
+// goroutine half is still a useful signal.
+func AssertNoLeaks(t *testing.T) {
+	t.Helper()
+
+	// Two GC cycles before sampling let the runtime sweep any
+	// "almost dead" goroutines that finished in the moments leading
+	// up to the scenario starting — the first GC marks them, the
+	// second collects. Without this, the baseline can be inflated
+	// by a finalizer goroutine that exits inside the scenario,
+	// producing a *negative* delta that we'd nonetheless treat as
+	// noise. Two cycles is the standard cure.
+	runtime.GC()
+	runtime.GC()
+
+	beforeGo := runtime.NumGoroutine()
+	beforeFD, fdSupported := readFDCount()
+
+	t.Cleanup(func() {
+		// Poll for the goroutine count to drop back inside tolerance.
+		// We sample every 50 ms; the loop exits as soon as the deltas
+		// are within bounds, or after the settle deadline, whichever
+		// is sooner. Don't sleep before the first sample — fast
+		// backends (mock) frequently settle within microseconds.
+		deadline := time.Now().Add(leakSettleDeadline)
+		var afterGo int
+		var afterFD int
+		for {
+			runtime.GC()
+			afterGo = runtime.NumGoroutine()
+			afterFD, _ = readFDCount()
+			goLeak := afterGo-beforeGo > leakTolerance
+			fdLeak := fdSupported && afterFD-beforeFD > leakTolerance
+			if !goLeak && !fdLeak {
+				return
+			}
+			if time.Now().After(deadline) {
+				break
+			}
+			time.Sleep(50 * time.Millisecond)
+		}
+
+		if afterGo-beforeGo > leakTolerance {
+			t.Errorf("goroutine leak: before=%d after=%d delta=%d (tolerance %d)",
+				beforeGo, afterGo, afterGo-beforeGo, leakTolerance)
+		}
+		if fdSupported && afterFD-beforeFD > leakTolerance {
+			t.Errorf("file-descriptor leak: before=%d after=%d delta=%d (tolerance %d)",
+				beforeFD, afterFD, afterFD-beforeFD, leakTolerance)
+		}
+	})
+}
+
+// readFDCount returns the count of entries in /proc/self/fd. The
+// second return is false if the file is unavailable (non-Linux); in
+// that case the FD check is skipped without failing the test.
+func readFDCount() (int, bool) {
+	entries, err := os.ReadDir("/proc/self/fd")
+	if err != nil {
+		return 0, false
+	}
+	return len(entries), true
+}

--- a/internal/relayparity/scenarios.go
+++ b/internal/relayparity/scenarios.go
@@ -47,6 +47,7 @@ func RunCoreSuite(t *testing.T, b Backend) {
 // tunnel routes bytes end-to-end.
 func ScenarioEcho_PortForward(t *testing.T, b Backend) {
 	t.Helper()
+	AssertNoLeaks(t)
 	echo := StartPlainEcho(t)
 	tun := b.Setup(t, SetupOptions{
 		NumListeners:   1,
@@ -71,6 +72,7 @@ func ScenarioEcho_PortForward(t *testing.T, b Backend) {
 // trips bytes correctly.
 func ScenarioEcho_SOCKS5(t *testing.T, b Backend) {
 	t.Helper()
+	AssertNoLeaks(t)
 	echo := StartPlainEcho(t)
 	tun := b.Setup(t, SetupOptions{
 		NumListeners:   1,
@@ -100,6 +102,7 @@ func ScenarioEcho_SOCKS5(t *testing.T, b Backend) {
 // Catches reordering or interleaving inside the bridge / future mux.
 func ScenarioOrdering_PortForward(t *testing.T, b Backend) {
 	t.Helper()
+	AssertNoLeaks(t)
 	echo := StartPlainEcho(t)
 	tun := b.Setup(t, SetupOptions{
 		NumListeners:   1,
@@ -168,6 +171,7 @@ func ScenarioOrdering_PortForward(t *testing.T, b Backend) {
 // "echo passes but bytes got rearranged" failure mode).
 func ScenarioBidirectional_PortForward(t *testing.T, b Backend) {
 	t.Helper()
+	AssertNoLeaks(t)
 	echo := StartPlainEcho(t)
 	tun := b.Setup(t, SetupOptions{
 		NumListeners:   1,

--- a/internal/relayparity/topology.go
+++ b/internal/relayparity/topology.go
@@ -1,0 +1,795 @@
+package relayparity
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// RunTopologySuite runs the multi-listener / multi-sender / single-target
+// parity scenarios against b. Each scenario fires at a curated set of
+// (N, M) matrix cells; cells that don't meet a scenario's minimum
+// requirements are simply not emitted (no t.Skip noise in output).
+//
+// Cells are conservative — we cover the four corners of the {1,2}×{1,2}
+// matrix only where they add information. Scaling K up at high cells
+// burns mock-CI budget without adding new failure modes.
+func RunTopologySuite(t *testing.T, b Backend) {
+	t.Helper()
+
+	type cell struct{ n, m int }
+	all := []cell{{1, 1}, {1, 2}, {2, 1}, {2, 2}}
+	withMultiListener := []cell{{1, 2}, {2, 2}}
+	withMultiSender := []cell{{2, 1}, {2, 2}}
+
+	scenarios := []struct {
+		name  string
+		cells []cell
+		run   func(*testing.T, Backend, int, int)
+	}{
+		{"NSenderMListener_Echo", all, scenarioNMEcho},
+		{"Distribution_PerListener", withMultiListener, scenarioDistributionPerListener},
+		{"Distribution_PerSender", withMultiSender, scenarioDistributionPerSender},
+		{"HotDropListener", withMultiListener, scenarioHotDropListener},
+		// Hot-add starts at M=1 and grows; running it across multiple
+		// (N) cells doesn't add a new failure mode, so it gets just
+		// one representative cell.
+		{"HotAddListener", []cell{{1, 1}}, scenarioHotAddListener},
+		// Back-pressure only needs M=2 with MaxConnections=2 to
+		// exercise the slot logic; a second sender doesn't change
+		// the semaphore behaviour.
+		{"MaxConn_BackPressure", []cell{{1, 2}}, scenarioMaxConnBackPressure},
+	}
+
+	for _, sc := range scenarios {
+		t.Run(sc.name, func(t *testing.T) {
+			for _, c := range sc.cells {
+				name := fmt.Sprintf("N%dM%d", c.n, c.m)
+				t.Run(name, func(t *testing.T) {
+					sc.run(t, b, c.n, c.m)
+				})
+			}
+		})
+	}
+}
+
+// scenarioNMEcho drives K parallel TCP echo flows distributed round-
+// robin across SenderAddrs, all targeting a single backend echo
+// server. Asserts every flow's payload round-trips intact. This is
+// the workhorse correctness check for the topology slice; everything
+// downstream assumes it holds.
+func scenarioNMEcho(t *testing.T, b Backend, n, m int) {
+	t.Helper()
+	AssertNoLeaks(t)
+	echo := StartPlainEcho(t)
+	tun := b.Setup(t, SetupOptions{
+		NumListeners:   m,
+		NumSenders:     n,
+		SenderMode:     ModePortForward,
+		Target:         echo.Addr(),
+		AllowedTargets: []string{echo.Addr()},
+	})
+
+	const k = 8
+	var wg sync.WaitGroup
+	errs := make(chan error, k)
+	for i := 0; i < k; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			addr := tun.SenderAddrs[i%len(tun.SenderAddrs)]
+			if err := runEchoOnce(addr, fmt.Sprintf("hello %d\n", i), 15*time.Second); err != nil {
+				errs <- fmt.Errorf("flow %d via %s: %w", i, addr, err)
+			}
+		}(i)
+	}
+	wg.Wait()
+	close(errs)
+	if firstErr := drainErrors(errs); firstErr != nil {
+		t.Fatalf("%v", firstErr)
+	}
+}
+
+// scenarioDistributionPerListener drives short echoes round-robin
+// across senders until every listener has handled at least one
+// bridge to completion, or a bounded budget is exhausted. Azure
+// Relay's listener selection is explicitly non-uniform at small
+// sample sizes (e2e/multi_test.go documents observed ratios up to
+// 1:7 at K=8), so a fixed-K "then assert" approach would have a
+// non-trivial spurious-failure rate. The convergence loop here gives
+// the relay as many sequential rendezvous as it needs to cover every
+// listener while still bounding total wall-clock and total dials —
+// failing only when the distribution genuinely never converged.
+func scenarioDistributionPerListener(t *testing.T, b Backend, n, m int) {
+	t.Helper()
+	AssertNoLeaks(t)
+	echo := StartPlainEcho(t)
+	tun := b.Setup(t, SetupOptions{
+		NumListeners:   m,
+		NumSenders:     n,
+		SenderMode:     ModePortForward,
+		Target:         echo.Addr(),
+		AllowedTargets: []string{echo.Addr()},
+	})
+
+	const (
+		kInit  = 20
+		kBatch = 10
+		kMax   = 100
+	)
+	overallDeadline := time.Now().Add(90 * time.Second)
+	sent := 0
+
+	issue := func(count int) {
+		for i := 0; i < count && sent < kMax; i++ {
+			if time.Now().After(overallDeadline) {
+				t.Fatalf("convergence deadline exceeded after %d echoes", sent)
+			}
+			addr := tun.SenderAddrs[sent%len(tun.SenderAddrs)]
+			payload := fmt.Sprintf("ser-%d\n", sent)
+			if err := runEchoOnce(addr, payload, 10*time.Second); err != nil {
+				t.Fatalf("echo %d via %s: %v", sent, addr, err)
+			}
+			sent++
+		}
+	}
+
+	converged := func() bool {
+		for _, l := range tun.Listeners {
+			if l.Completed() <= 0 {
+				return false
+			}
+		}
+		return true
+	}
+
+	issue(kInit)
+	waitForListenerSum(t, tun, int64(sent), 5*time.Second)
+	for !converged() && sent < kMax && time.Now().Before(overallDeadline) {
+		issue(kBatch)
+		waitForListenerSum(t, tun, int64(sent), 5*time.Second)
+	}
+
+	for i, l := range tun.Listeners {
+		c := l.Completed()
+		t.Logf("listener[%d] completed=%d (after %d echoes)", i, c, sent)
+		if c <= 0 {
+			t.Errorf("listener[%d] completed=%d after %d echoes, want > 0", i, c, sent)
+		}
+	}
+}
+
+// scenarioDistributionPerSender mirrors scenarioDistributionPerListener
+// for senders. With echoes dialed round-robin across N senders, every
+// sender is exercised by construction for the dial count; the metric
+// assertion proves each sender actually bridged the dial to a relay
+// rendezvous (vs. accepted the TCP and failed before forwarding).
+//
+// The convergence loop is here primarily for symmetry with the
+// listener variant. Per-sender distribution converges much faster
+// because round-robin is enforced by this test, but the same shape
+// keeps both scenarios easy to reason about.
+func scenarioDistributionPerSender(t *testing.T, b Backend, n, m int) {
+	t.Helper()
+	AssertNoLeaks(t)
+	echo := StartPlainEcho(t)
+	tun := b.Setup(t, SetupOptions{
+		NumListeners:   m,
+		NumSenders:     n,
+		SenderMode:     ModePortForward,
+		Target:         echo.Addr(),
+		AllowedTargets: []string{echo.Addr()},
+	})
+
+	const (
+		kInit  = 20
+		kBatch = 10
+		kMax   = 100
+	)
+	overallDeadline := time.Now().Add(90 * time.Second)
+	sent := 0
+
+	issue := func(count int) {
+		for i := 0; i < count && sent < kMax; i++ {
+			if time.Now().After(overallDeadline) {
+				t.Fatalf("convergence deadline exceeded after %d echoes", sent)
+			}
+			addr := tun.SenderAddrs[sent%len(tun.SenderAddrs)]
+			payload := fmt.Sprintf("ser-%d\n", sent)
+			if err := runEchoOnce(addr, payload, 10*time.Second); err != nil {
+				t.Fatalf("echo %d via %s: %v", sent, addr, err)
+			}
+			sent++
+		}
+	}
+
+	converged := func() bool {
+		for _, s := range tun.Senders {
+			if s.Completed() <= 0 {
+				return false
+			}
+		}
+		return true
+	}
+
+	issue(kInit)
+	waitForSenderSum(t, tun, int64(sent), 5*time.Second)
+	for !converged() && sent < kMax && time.Now().Before(overallDeadline) {
+		issue(kBatch)
+		waitForSenderSum(t, tun, int64(sent), 5*time.Second)
+	}
+
+	for i, s := range tun.Senders {
+		c := s.Completed()
+		t.Logf("sender[%d] completed=%d (after %d echoes)", i, c, sent)
+		if c <= 0 {
+			t.Errorf("sender[%d] completed=%d after %d echoes, want > 0", i, c, sent)
+		}
+	}
+}
+
+// scenarioHotDropListener verifies the surviving-listener path. It
+// opens enough long-running flows for at least one to land on
+// listener[0], snapshots A0 = listener[0].Active(), stops
+// listener[0], and asserts:
+//
+//   - at least A0 flows fail/EOF within bounded time;
+//   - the surviving K-A0 flows keep echoing;
+//   - a fresh dial after drop succeeds and echoes.
+//
+// Azure Relay distributes connections nonuniformly across listeners
+// (observed ratios up to 1:7 with K=8), so we open in batches of
+// kBatch=8 up to a hard cap of kMax=40 flows until A0 > 0. If we
+// can't get any flow onto listener[0] after kMax attempts, the
+// backend distribution is degenerate and the test fails — silently
+// skipping would let a real hot-drop regression slip through.
+func scenarioHotDropListener(t *testing.T, b Backend, n, m int) {
+	t.Helper()
+	AssertNoLeaks(t)
+	echo := StartPlainEcho(t)
+	tun := b.Setup(t, SetupOptions{
+		NumListeners:   m,
+		NumSenders:     n,
+		SenderMode:     ModePortForward,
+		Target:         echo.Addr(),
+		AllowedTargets: []string{echo.Addr()},
+	})
+
+	const (
+		kBatch = 8
+		kMax   = 40
+	)
+	var flows []*longFlow
+	var a0 int64
+	for len(flows) < kMax {
+		// Open one batch.
+		batchStart := len(flows)
+		for i := 0; i < kBatch && len(flows) < kMax; i++ {
+			addr := tun.SenderAddrs[len(flows)%len(tun.SenderAddrs)]
+			f, err := startLongFlow(addr, 15*time.Second)
+			if err != nil {
+				t.Fatalf("start long flow %d: %v", len(flows), err)
+			}
+			flows = append(flows, f)
+			t.Cleanup(f.Close)
+		}
+		// Wait until every long-flow opened so far is bridged.
+		if !waitForSumActive(tun, int64(len(flows)), 10*time.Second) {
+			t.Fatalf("sum of listener Active() never reached %d after batch starting at %d",
+				len(flows), batchStart)
+		}
+		a0 = tun.Listeners[0].Active()
+		if a0 > 0 {
+			break
+		}
+	}
+	if a0 == 0 {
+		t.Fatalf("after %d long flows, listener[0] Active()=0; backend distribution is degenerate", len(flows))
+	}
+	k := len(flows)
+	for i, l := range tun.Listeners {
+		t.Logf("pre-drop: listener[%d] Active()=%d", i, l.Active())
+	}
+	// Re-read a0 immediately before Stop() so the snapshot is as
+	// fresh as possible — any per-listener scrape skew from the
+	// logging loop above is bounded by the time between this read
+	// and Stop() (microseconds).
+	a0 = tun.Listeners[0].Active()
+	t.Logf("pre-drop: %d flows open, listener[0] Active()=%d", k, a0)
+
+	// Drop listener[0]. New rendezvous attempts will only land on
+	// remaining listeners thereafter.
+	tun.Listeners[0].Stop()
+
+	// Count flows that have gone dead (write or read fails) within the
+	// bounded window. The scenario contract is exactly A0 broken: the
+	// flows that were on listener[0]. Fewer would mean the drop did
+	// not propagate; more would mean a surviving listener silently
+	// tore down in-flight bridges, which is the regression we want to
+	// catch. Wait up to 15 s for the lower bound, then settle for 5 s
+	// before re-counting so any async surviving-listener-side
+	// breakages (e.g. timer-driven cleanup) have time to manifest.
+	deadline := time.Now().Add(15 * time.Second)
+	var dead int
+	for time.Now().Before(deadline) {
+		dead = 0
+		for _, f := range flows {
+			if f.broken() {
+				dead++
+			}
+		}
+		if int64(dead) >= a0 {
+			break
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	time.Sleep(5 * time.Second)
+	dead = 0
+	for _, f := range flows {
+		if f.broken() {
+			dead++
+		}
+	}
+	if int64(dead) < a0 {
+		t.Errorf("after dropping listener[0]: %d/%d flows broken, want >= %d (A0)", dead, k, a0)
+	}
+	if int64(dead) > a0 {
+		t.Errorf("after dropping listener[0]: %d/%d flows broken, want <= %d (A0); surviving listener(s) silently tore down %d in-flight bridge(s)", dead, k, a0, int64(dead)-a0)
+	}
+
+	// Verify every surviving flow still echoes. If A0 happened to
+	// equal K (all flows on the dropped listener), all flows are
+	// broken and we skip the survivor check; otherwise we exercise
+	// every non-broken flow — a regression where the surviving
+	// listener silently dropped some bridges but left others healthy
+	// would slip through if we only probed one.
+	if a0 < int64(k) {
+		survivors := 0
+		for i, f := range flows {
+			if f.broken() {
+				continue
+			}
+			if err := f.exchange(fmt.Sprintf("survivor-%d\n", i), 5*time.Second); err != nil {
+				t.Errorf("survivor flow %d exchange failed: %v", i, err)
+				continue
+			}
+			survivors++
+		}
+		if survivors == 0 {
+			t.Fatalf("expected at least one surviving flow but all are broken")
+		}
+		t.Logf("post-drop: %d/%d surviving flows still echo", survivors, k)
+	}
+
+	// A fresh dial after drop must succeed via the surviving listener.
+	if err := runEchoOnce(tun.SenderAddr, "after-drop\n", 15*time.Second); err != nil {
+		t.Errorf("post-drop fresh dial: %v", err)
+	}
+}
+
+// scenarioHotAddListener verifies that adding a listener mid-flight
+// converges: existing flows keep echoing, and new flows reach the new
+// listener within a bounded window. Because Azure Relay's listener
+// selection is non-uniform at small sample sizes (e2e/multi_test.go
+// documents observed ratios up to 1:7 at K=8), a fixed-K probe count
+// would have a non-trivial spurious-failure rate when no flow lands
+// on the freshly-added listener. Instead we drive short echoes in
+// batches until newListener.Completed() > 0, capped at a hard probe
+// budget — that bounds the test runtime while making a true
+// "no traffic ever reaches the new listener" regression observable.
+func scenarioHotAddListener(t *testing.T, b Backend, n, m int) {
+	t.Helper()
+	AssertNoLeaks(t)
+	echo := StartPlainEcho(t)
+	tun := b.Setup(t, SetupOptions{
+		NumListeners:   m,
+		NumSenders:     n,
+		SenderMode:     ModePortForward,
+		Target:         echo.Addr(),
+		AllowedTargets: []string{echo.Addr()},
+	})
+	if tun.AddListener == nil {
+		t.Skip("backend does not implement hot-add (Tunnel.AddListener is nil)")
+	}
+
+	const kActive = 4
+	flows := make([]*longFlow, kActive)
+	for i := 0; i < kActive; i++ {
+		addr := tun.SenderAddrs[i%len(tun.SenderAddrs)]
+		f, err := startLongFlow(addr, 15*time.Second)
+		if err != nil {
+			t.Fatalf("start long flow %d: %v", i, err)
+		}
+		flows[i] = f
+		t.Cleanup(f.Close)
+	}
+
+	newListener := tun.AddListener(t)
+	if newListener == nil {
+		t.Fatalf("AddListener returned nil")
+	}
+
+	// Drive short echoes in batches until the new listener completes
+	// at least one bridge, or we exhaust the probe budget. We need
+	// the listener to be the chosen destination at least once;
+	// Azure's selection is non-uniform but biased toward freshly-
+	// attached listeners in practice, so this typically converges
+	// within the first batch.
+	const (
+		kBatch      = 8
+		kMax        = 60
+		probeBudget = 60 * time.Second
+	)
+	probeDeadline := time.Now().Add(probeBudget)
+	sent := 0
+	for newListener.Completed() == 0 && sent < kMax && time.Now().Before(probeDeadline) {
+		for i := 0; i < kBatch && sent < kMax && time.Now().Before(probeDeadline); i++ {
+			addr := tun.SenderAddrs[sent%len(tun.SenderAddrs)]
+			payload := fmt.Sprintf("probe-%d\n", sent)
+			if err := runEchoOnce(addr, payload, 10*time.Second); err != nil {
+				t.Fatalf("probe %d via %s: %v", sent, addr, err)
+			}
+			sent++
+		}
+		// Brief settle for Completed() to update.
+		settle := time.Now().Add(2 * time.Second)
+		for newListener.Completed() == 0 && time.Now().Before(settle) {
+			time.Sleep(50 * time.Millisecond)
+		}
+	}
+	if c := newListener.Completed(); c <= 0 {
+		t.Errorf("new listener completed=%d after %d probes, want > 0", c, sent)
+	} else {
+		t.Logf("hot-add converged: new listener completed=%d after %d probes", c, sent)
+	}
+
+	// Existing flows must still be alive.
+	for i, f := range flows {
+		if f.broken() {
+			t.Errorf("existing flow %d broken after hot-add", i)
+			continue
+		}
+		if err := f.exchange(fmt.Sprintf("existing-%d\n", i), 5*time.Second); err != nil {
+			t.Errorf("existing flow %d exchange failed: %v", i, err)
+		}
+	}
+}
+
+// scenarioMaxConnBackPressure verifies the per-listener semaphore
+// holds: with MaxConnections=2 on each of M=2 listeners, no more than
+// 4 bridges may be active at any sampled moment, and all K=8 dial
+// attempts ultimately succeed via client-side retry. The current
+// listener implementation drops overflow accepts (non-blocking
+// tryAcquire) — so clients see EOF / closed connection and must
+// retry. This scenario asserts both invariants.
+//
+// Each successful client holds its bridge open for holdDur after the
+// initial echo so the metric sampler (20 ms ticker) reliably catches
+// the steady-state concurrent count. Without the hold, short echoes
+// complete in single-digit milliseconds and the sampler races them.
+func scenarioMaxConnBackPressure(t *testing.T, b Backend, n, m int) {
+	t.Helper()
+	AssertNoLeaks(t)
+	echo := StartPlainEcho(t)
+	const maxConn = 2
+	tun := b.Setup(t, SetupOptions{
+		NumListeners:   m,
+		NumSenders:     n,
+		SenderMode:     ModePortForward,
+		Target:         echo.Addr(),
+		AllowedTargets: []string{echo.Addr()},
+		MaxConnections: maxConn,
+	})
+
+	const k = 8
+	const holdDur = 300 * time.Millisecond
+	const overall = 90 * time.Second
+	const limit = int64(maxConn) * 2 // M=2 listeners
+
+	var maxObserved int64
+	samplerCtx, samplerCancel := context.WithCancel(context.Background())
+	defer samplerCancel()
+	samplerDone := make(chan struct{})
+	go func() {
+		defer close(samplerDone)
+		ticker := time.NewTicker(20 * time.Millisecond)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-samplerCtx.Done():
+				return
+			case <-ticker.C:
+				var sum int64
+				for _, l := range tun.Listeners {
+					sum += l.Active()
+				}
+				if sum > atomic.LoadInt64(&maxObserved) {
+					atomic.StoreInt64(&maxObserved, sum)
+				}
+			}
+		}
+	}()
+
+	var wg sync.WaitGroup
+	errs := make(chan error, k)
+	for i := 0; i < k; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			addr := tun.SenderAddrs[i%len(tun.SenderAddrs)]
+			payload := fmt.Sprintf("mc-%d\n", i)
+			deadline := time.Now().Add(overall)
+			var lastErr error
+			for time.Now().Before(deadline) {
+				err := echoWithHold(addr, payload, holdDur, 5*time.Second)
+				if err == nil {
+					return
+				}
+				lastErr = err
+				// Brief jitter so the retries don't all crash the
+				// gate at once. 50–150 ms keeps the test responsive
+				// while letting saturated listeners free a slot.
+				time.Sleep(50*time.Millisecond + time.Duration(i%3)*30*time.Millisecond)
+			}
+			errs <- fmt.Errorf("flow %d via %s: %w", i, addr, lastErr)
+		}(i)
+	}
+	wg.Wait()
+	close(errs)
+
+	samplerCancel()
+	<-samplerDone
+
+	if firstErr := drainErrors(errs); firstErr != nil {
+		t.Errorf("%v", firstErr)
+	}
+	if observed := atomic.LoadInt64(&maxObserved); observed > limit {
+		t.Errorf("max concurrent Active() observed=%d, want <= %d (M=%d * MaxConn=%d)",
+			observed, limit, m, maxConn)
+	} else {
+		t.Logf("max concurrent Active() observed=%d (limit %d)", observed, limit)
+	}
+}
+
+// echoWithHold dials addr, exchanges payload once, holds the bridge
+// open for hold (no I/O during the hold so the sender's bridge sits
+// idle), then closes. Used by scenarioMaxConnBackPressure to give the
+// 20 ms metric sampler a chance to observe the steady-state Active
+// count across all listeners — short echoes that complete in single-
+// digit milliseconds race the sampler and produce observed=0
+// spuriously.
+func echoWithHold(addr, payload string, hold, timeout time.Duration) error {
+	conn, err := net.DialTimeout("tcp", addr, timeout)
+	if err != nil {
+		return fmt.Errorf("dial: %w", err)
+	}
+	defer conn.Close() //nolint:errcheck // best-effort
+	_ = conn.SetDeadline(time.Now().Add(timeout + hold))
+
+	if err := writeFull(conn, []byte(payload)); err != nil {
+		return fmt.Errorf("write: %w", err)
+	}
+	buf := make([]byte, len(payload))
+	if _, err := io.ReadFull(conn, buf); err != nil {
+		return fmt.Errorf("read: %w", err)
+	}
+	if !bytes.Equal(buf, []byte(payload)) {
+		return fmt.Errorf("echo mismatch: got %q want %q", buf, payload)
+	}
+	time.Sleep(hold)
+	return nil
+}
+
+// --- helpers --------------------------------------------------------
+
+// runEchoOnce opens one connection, writes payload, reads it back,
+// and closes. Returns an error if any step fails or if the echo does
+// not round-trip exactly.
+func runEchoOnce(addr, payload string, timeout time.Duration) error {
+	conn, err := net.DialTimeout("tcp", addr, timeout)
+	if err != nil {
+		return fmt.Errorf("dial: %w", err)
+	}
+	defer conn.Close() //nolint:errcheck // best-effort
+	_ = conn.SetDeadline(time.Now().Add(timeout))
+
+	if err := writeFull(conn, []byte(payload)); err != nil {
+		return fmt.Errorf("write: %w", err)
+	}
+	buf := make([]byte, len(payload))
+	if _, err := io.ReadFull(conn, buf); err != nil {
+		return fmt.Errorf("read: %w", err)
+	}
+	if !bytes.Equal(buf, []byte(payload)) {
+		return fmt.Errorf("echo mismatch: got %q want %q", buf, payload)
+	}
+	return nil
+}
+
+// drainErrors returns the first error from a closed channel, with a
+// summary mention of how many additional errors followed.
+func drainErrors(errs <-chan error) error {
+	first, ok := <-errs
+	if !ok {
+		return nil
+	}
+	count := 1
+	for range errs {
+		count++
+	}
+	if count == 1 {
+		return first
+	}
+	return fmt.Errorf("%w (+%d more errors)", first, count-1)
+}
+
+// waitForListenerSum polls Tunnel.Listeners for sum-of-Completed to
+// reach want. Used after a burst of short echoes where the last few
+// Done() callbacks may still be in flight when the sender goroutine
+// returns. Fails the test on deadline.
+func waitForListenerSum(t *testing.T, tun *Tunnel, want int64, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		var sum int64
+		for _, l := range tun.Listeners {
+			sum += l.Completed()
+		}
+		if sum >= want {
+			return
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	var sum int64
+	for _, l := range tun.Listeners {
+		sum += l.Completed()
+	}
+	t.Fatalf("listener-completed sum reached %d after %v, want >= %d", sum, timeout, want)
+}
+
+func waitForSenderSum(t *testing.T, tun *Tunnel, want int64, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		var sum int64
+		for _, s := range tun.Senders {
+			sum += s.Completed()
+		}
+		if sum >= want {
+			return
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	var sum int64
+	for _, s := range tun.Senders {
+		sum += s.Completed()
+	}
+	t.Fatalf("sender-completed sum reached %d after %v, want >= %d", sum, timeout, want)
+}
+
+// waitForSumActive polls until the sum of Active() across all
+// listeners reaches want. Returns true on success, false on deadline.
+func waitForSumActive(tun *Tunnel, want int64, timeout time.Duration) bool {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		var sum int64
+		for _, l := range tun.Listeners {
+			sum += l.Active()
+		}
+		if sum >= want {
+			return true
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	return false
+}
+
+// longFlow is a holds-open echo connection used by hot-drop and hot-
+// add scenarios that need to observe in-flight bridges.
+type longFlow struct {
+	conn net.Conn
+	mu   sync.Mutex
+	bad  bool
+}
+
+func startLongFlow(addr string, dialTimeout time.Duration) (*longFlow, error) {
+	c, err := net.DialTimeout("tcp", addr, dialTimeout)
+	if err != nil {
+		return nil, err
+	}
+	// Sanity exchange so we know the bridge is established before
+	// callers move on to topology changes. Without this, race-y
+	// behaviour where the bridge hasn't yet bumped Active() can give
+	// false A0=0 readings in hot-drop.
+	f := &longFlow{conn: c}
+	if err := f.exchange("init\n", 10*time.Second); err != nil {
+		_ = c.Close()
+		return nil, fmt.Errorf("init: %w", err)
+	}
+	return f, nil
+}
+
+// exchange writes payload and reads it back; returns an error if
+// either side fails. On any error, the flow is marked broken so
+// future broken() calls return true.
+func (f *longFlow) exchange(payload string, timeout time.Duration) error {
+	if f == nil {
+		return errors.New("nil flow")
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.bad {
+		return errors.New("flow already broken")
+	}
+	_ = f.conn.SetDeadline(time.Now().Add(timeout))
+	defer func() { _ = f.conn.SetDeadline(time.Time{}) }()
+
+	if err := writeFull(f.conn, []byte(payload)); err != nil {
+		f.bad = true
+		return fmt.Errorf("write: %w", err)
+	}
+	buf := make([]byte, len(payload))
+	if _, err := io.ReadFull(f.conn, buf); err != nil {
+		f.bad = true
+		return fmt.Errorf("read: %w", err)
+	}
+	if !bytes.Equal(buf, []byte(payload)) {
+		f.bad = true
+		return fmt.Errorf("mismatch: got %q want %q", buf, payload)
+	}
+	return nil
+}
+
+// broken probes the flow with a tiny non-destructive read deadline.
+// If the underlying TCP has been torn down (peer closed), Read
+// returns EOF / RST immediately and we mark the flow broken.
+//
+// We intentionally do NOT call broken() in parallel with exchange()
+// from the same flow — the mutex serialises both, but the broken
+// check sets a 1 ms read deadline that would race a concurrent
+// exchange.
+func (f *longFlow) broken() bool {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.bad {
+		return true
+	}
+	_ = f.conn.SetReadDeadline(time.Now().Add(1 * time.Millisecond))
+	buf := make([]byte, 1)
+	_, err := f.conn.Read(buf)
+	_ = f.conn.SetReadDeadline(time.Time{})
+	if err == nil {
+		// Got a byte unexpectedly. Treat as broken (echo is full-
+		// duplex; a stray byte means something is wrong).
+		f.bad = true
+		return true
+	}
+	var ne net.Error
+	if errors.As(err, &ne) && ne.Timeout() {
+		// No data; still alive.
+		return false
+	}
+	// Any other error means EOF / RST / closed.
+	f.bad = true
+	return true
+}
+
+// Close closes the underlying connection. Safe to call multiple times.
+func (f *longFlow) Close() {
+	if f == nil {
+		return
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.conn != nil {
+		_ = f.conn.Close()
+		f.conn = nil
+	}
+}

--- a/internal/sender/portforward.go
+++ b/internal/sender/portforward.go
@@ -29,6 +29,12 @@ type PortForwardConfig struct {
 	TCPKeepAlive  time.Duration
 	Logger        *slog.Logger
 	Metrics       *metrics.Metrics // optional; nil disables metrics
+	// Ready, if non-nil, is invoked once after the local bind succeeds
+	// and before the accept loop starts. Tests use this to learn the
+	// chosen bind address (when BindAddress is :0) without having to
+	// probe with a real TCP dial that would consume a listener slot
+	// under MaxConnections. Production callers leave this nil.
+	Ready func(net.Addr)
 }
 
 // PortForward starts a local TCP listener and forwards each connection
@@ -47,6 +53,9 @@ func PortForward(ctx context.Context, cfg PortForwardConfig) error {
 	}
 	defer ln.Close() //nolint:errcheck // best-effort cleanup
 	cfg.Logger.Info("port-forward listening", "bind", ln.Addr(), "target", cfg.Target)
+	if cfg.Ready != nil {
+		cfg.Ready(ln.Addr())
+	}
 
 	go func() {
 		<-ctx.Done()

--- a/internal/sender/socks5proxy.go
+++ b/internal/sender/socks5proxy.go
@@ -22,6 +22,11 @@ type SOCKS5Config struct {
 	TCPKeepAlive  time.Duration
 	Logger        *slog.Logger
 	Metrics       *metrics.Metrics // optional; nil disables metrics
+	// Ready, if non-nil, is invoked once after the local bind succeeds
+	// and before the accept loop starts. Tests use this to learn the
+	// chosen bind address (when BindAddress is :0) without having to
+	// open a probe TCP connection. Production callers leave this nil.
+	Ready func(net.Addr)
 }
 
 // SOCKS5Proxy starts a local SOCKS5 proxy and forwards each connection
@@ -41,6 +46,9 @@ func SOCKS5Proxy(ctx context.Context, cfg SOCKS5Config) error {
 	}
 	defer ln.Close() //nolint:errcheck // best-effort cleanup
 	cfg.Logger.Info("socks5-proxy listening", "bind", ln.Addr())
+	if cfg.Ready != nil {
+		cfg.Ready(ln.Addr())
+	}
 
 	go func() {
 		<-ctx.Done()

--- a/mockrelay/parity/mock_backend.go
+++ b/mockrelay/parity/mock_backend.go
@@ -1,12 +1,11 @@
 // Package parity wires the shared relay-parity scenario suite
 // (internal/relayparity) up against an in-process mock relay.
 //
-// MockBackend is intended for use inside the mockrelay module's test
-// binary; it brings up a real aztunnel listener + sender (the same
+// MockBackend brings up a real aztunnel listener + sender (the same
 // code paths exercised against Azure Relay) talking to a mock relay
 // server in-process. Tests written against the relayparity.Backend
 // interface run unmodified against this backend, and the e2e module's
-// AzureBackend, so any behavioural divergence between mock and Azure
+// azureBackend, so any behavioural divergence between mock and Azure
 // shows up as a failing scenario in one but not the other.
 package parity
 
@@ -18,7 +17,6 @@ import (
 	"io"
 	"log/slog"
 	"net"
-	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"strings"
@@ -27,6 +25,7 @@ import (
 	"time"
 
 	"github.com/philsphicas/aztunnel/internal/listener"
+	"github.com/philsphicas/aztunnel/internal/metrics"
 	"github.com/philsphicas/aztunnel/internal/relay"
 	"github.com/philsphicas/aztunnel/internal/relayparity"
 	"github.com/philsphicas/aztunnel/internal/sender"
@@ -34,7 +33,7 @@ import (
 )
 
 // MockBackend implements relayparity.Backend by standing up a mock
-// relay server + aztunnel listener(s) + aztunnel sender all in the
+// relay server + aztunnel listener(s) + aztunnel sender(s) all in the
 // same process. It is the fast, deterministic side of the parity
 // matrix and runs in the default `go test ./mockrelay/...` job.
 type MockBackend struct{}
@@ -42,229 +41,231 @@ type MockBackend struct{}
 // Name returns the backend identifier used in test sub-paths.
 func (*MockBackend) Name() string { return "mock" }
 
-// Setup brings up the in-process topology described by opts and
-// blocks until every listener has registered with the mock relay and
-// the sender's local bind is accepting TCP. All goroutines, the mock
-// HTTP server, and the sender bind are released via t.Cleanup.
+// Setup brings up the in-process topology described by opts and blocks
+// until every listener's control channel is attached and every sender
+// bind is accepting TCP. All goroutines, the mock HTTP server, and
+// the sender binds are released via t.Cleanup.
 func (*MockBackend) Setup(t *testing.T, opts relayparity.SetupOptions) *relayparity.Tunnel {
 	t.Helper()
 	if opts.NumListeners < 1 {
 		t.Fatalf("NumListeners must be >= 1, got %d", opts.NumListeners)
 	}
+	switch opts.SenderMode {
+	case relayparity.ModePortForward, relayparity.ModeSOCKS5:
+	default:
+		t.Fatalf("unknown SenderMode %v", opts.SenderMode)
+	}
+	numSenders := opts.NumSenders
+	if numSenders < 1 {
+		numSenders = 1
+	}
 
+	host, clientOpts := startMockRelay(t)
+	// Cleanup ordering carry-over from PR #50 review: startMockRelay's
+	// own t.Cleanup registers srv.Close. Register cancel+wg.Wait AFTER
+	// it so LIFO teardown runs cancel first → drains the listener /
+	// sender goroutines → THEN closes the mock relay. This stops the
+	// "listener exited: <error>" log lines that fired when the relay
+	// disappeared while listeners were still running.
 	ctx, cancel := context.WithCancel(context.Background())
-	// Register cleanup BEFORE spawning any goroutines so an early
-	// t.Fatalf in a readiness gate still drains anything we managed to
-	// start. wg.Wait() on a zero-counter wg returns immediately, so
-	// this is safe when Setup fails before any goroutine launches.
 	var wg sync.WaitGroup
 	t.Cleanup(func() {
 		cancel()
 		wg.Wait()
 	})
 
-	host, clientOpts, srv := startMockRelay(t)
-	// Entity name is unique per scenario so concurrent t.Parallel
-	// sub-tests cannot bleed into each other if they ever land on the
-	// same mock-relay instance — and gives test failure messages a
-	// useful breadcrumb to the originating scenario.
 	entity := mustEntityName(t)
-
 	tokenProvider := &relay.SASTokenProvider{
 		KeyName: server.DefaultSASKeyName,
 		Key:     server.DefaultSASKey,
 	}
 	silentLogger := slog.New(slog.NewTextHandler(io.Discard, nil))
 
-	for i := 0; i < opts.NumListeners; i++ {
+	tun := &relayparity.Tunnel{}
+
+	// startListener brings up a single listener goroutine and returns
+	// its relayparity handle. Each listener owns a private metrics
+	// surface so Completed() / Active() report only that listener's
+	// bridges.
+	startListener := func(t *testing.T) *relayparity.Listener {
+		t.Helper()
+		m := metrics.New()
+		lctx, lcancel := context.WithCancel(ctx)
+		done := make(chan struct{})
+
+		cfg := listener.Config{
+			Endpoint:       host,
+			EntityPath:     entity,
+			TokenProvider:  tokenProvider,
+			ClientOptions:  clientOpts,
+			AllowList:      opts.AllowedTargets,
+			MaxConnections: opts.MaxConnections,
+			Logger:         silentLogger,
+			Metrics:        m,
+		}
+
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			err := listener.ListenAndServe(ctx, listener.Config{
-				Endpoint:       host,
-				EntityPath:     entity,
-				TokenProvider:  tokenProvider,
-				ClientOptions:  clientOpts,
-				AllowList:      opts.AllowedTargets,
-				MaxConnections: opts.MaxConnections,
-				Logger:         silentLogger,
-			})
-			if err != nil && ctx.Err() == nil {
+			defer close(done)
+			err := listener.ListenAndServe(lctx, cfg)
+			if err != nil && lctx.Err() == nil && ctx.Err() == nil {
 				t.Logf("listener exited: %v", err)
 			}
 		}()
-	}
-	// Wait for *all* listeners to register their accept side with the
-	// mock so scenarios that happen to land on a not-yet-attached
-	// listener don't see a transient 404. The mock's probe transitions
-	// from 404 -> 400 once any listener is registered; we don't have a
-	// strict per-listener probe, so a small extra settle after the
-	// first ready signal covers the others.
-	waitForControl(t, srv, entity, 3*time.Second)
-	if opts.NumListeners > 1 {
-		// One additional poll cycle is enough on the mock: every
-		// listener registers in a single tick of its dial loop.
-		time.Sleep(100 * time.Millisecond)
-	}
 
-	// Validate SenderMode synchronously so an unknown mode fails the
-	// test immediately instead of being caught by the waitForTCP
-	// timeout below — the timeout would mask the real cause and add
-	// ~3 s of avoidable delay per misconfigured scenario.
-	switch opts.SenderMode {
-	case relayparity.ModePortForward, relayparity.ModeSOCKS5:
-	default:
-		t.Fatalf("unknown SenderMode %v", opts.SenderMode)
-	}
+		// Wait for the control_channel_connected gauge to flip to 1:
+		// it is set inside relay.ListenAndServe's OnConnect, which is
+		// the canonical "control channel attached" signal — the same
+		// log line the Azure backend waits for. Polling the gauge
+		// avoids any need to scrape /metrics over HTTP.
+		if !waitForGauge(m, "aztunnel_control_channel_connected", 1, 15*time.Second) {
+			lcancel()
+			<-done
+			t.Fatalf("listener never reported control_channel_connected")
+		}
 
-	bind := pickFreePort(t)
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		var err error
-		switch opts.SenderMode {
-		case relayparity.ModePortForward:
-			err = sender.PortForward(ctx, sender.PortForwardConfig{
-				Endpoint:      host,
-				EntityPath:    entity,
-				TokenProvider: tokenProvider,
-				ClientOptions: clientOpts,
-				Target:        opts.Target,
-				BindAddress:   bind,
-				Logger:        silentLogger,
-			})
-		case relayparity.ModeSOCKS5:
-			err = sender.SOCKS5Proxy(ctx, sender.SOCKS5Config{
-				Endpoint:      host,
-				EntityPath:    entity,
-				TokenProvider: tokenProvider,
-				ClientOptions: clientOpts,
-				BindAddress:   bind,
-				Logger:        silentLogger,
+		var stopOnce sync.Once
+		stop := func() {
+			stopOnce.Do(func() {
+				lcancel()
+				<-done
 			})
 		}
-		if err != nil && ctx.Err() == nil {
-			t.Logf("sender exited: %v", err)
-		}
-	}()
 
-	if !waitForTCP(bind, 3*time.Second) {
-		t.Fatalf("sender bind %s never became reachable", bind)
+		return &relayparity.Listener{
+			Addr:      "",
+			Completed: counterReader(m, "aztunnel_connections_total"),
+			Active:    gaugeReader(m, "aztunnel_active_connections"),
+			Stop:      stop,
+		}
 	}
 
-	return &relayparity.Tunnel{SenderAddr: bind}
+	for i := 0; i < opts.NumListeners; i++ {
+		tun.Listeners = append(tun.Listeners, startListener(t))
+	}
+
+	// Each sender goroutine has its own free :0 bind and its own
+	// metrics surface. Ready is signalled via the
+	// PortForwardConfig.Ready / SOCKS5Config.Ready callback, which
+	// fires immediately after net.Listen — there is no probe TCP
+	// connection that would consume a listener slot under
+	// MaxConnections.
+	startOneSender := func() *relayparity.Sender {
+		m := metrics.New()
+		sctx, scancel := context.WithCancel(ctx)
+		done := make(chan struct{})
+		addrCh := make(chan net.Addr, 1)
+		ready := func(a net.Addr) {
+			select {
+			case addrCh <- a:
+			default:
+			}
+		}
+
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			defer close(done)
+			var err error
+			switch opts.SenderMode {
+			case relayparity.ModePortForward:
+				err = sender.PortForward(sctx, sender.PortForwardConfig{
+					Endpoint:      host,
+					EntityPath:    entity,
+					TokenProvider: tokenProvider,
+					ClientOptions: clientOpts,
+					Target:        opts.Target,
+					BindAddress:   "127.0.0.1:0",
+					Logger:        silentLogger,
+					Metrics:       m,
+					Ready:         ready,
+				})
+			case relayparity.ModeSOCKS5:
+				err = sender.SOCKS5Proxy(sctx, sender.SOCKS5Config{
+					Endpoint:      host,
+					EntityPath:    entity,
+					TokenProvider: tokenProvider,
+					ClientOptions: clientOpts,
+					BindAddress:   "127.0.0.1:0",
+					Logger:        silentLogger,
+					Metrics:       m,
+					Ready:         ready,
+				})
+			}
+			if err != nil && sctx.Err() == nil && ctx.Err() == nil {
+				t.Logf("sender exited: %v", err)
+			}
+		}()
+
+		var addr net.Addr
+		select {
+		case addr = <-addrCh:
+		case <-time.After(15 * time.Second):
+			scancel()
+			<-done
+			t.Fatalf("sender Ready callback never fired")
+		}
+
+		var stopOnce sync.Once
+		stop := func() {
+			stopOnce.Do(func() {
+				scancel()
+				<-done
+			})
+		}
+
+		return &relayparity.Sender{
+			Addr:      addr.String(),
+			Completed: counterReader(m, "aztunnel_connections_total"),
+			Active:    gaugeReader(m, "aztunnel_active_connections"),
+			Stop:      stop,
+		}
+	}
+
+	for i := 0; i < numSenders; i++ {
+		s := startOneSender()
+		tun.Senders = append(tun.Senders, s)
+		tun.SenderAddrs = append(tun.SenderAddrs, s.Addr)
+	}
+	tun.SenderAddr = tun.SenderAddrs[0]
+	tun.AddListener = func(t *testing.T) *relayparity.Listener {
+		t.Helper()
+		l := startListener(t)
+		tun.Listeners = append(tun.Listeners, l)
+		return l
+	}
+
+	return tun
 }
 
 // startMockRelay starts a server.Server backed by httptest.NewTLSServer
 // (aztunnel only dials TLS-protected relays) and returns the host:port
 // plus a ClientOptions whose TLSConfig skips verification of the test
-// certificate. Mirrors the helper in mockrelay/server/integration_test.go
-// so behaviour is identical.
-func startMockRelay(t *testing.T) (host string, opts relay.ClientOptions, srv *httptest.Server) {
+// certificate.
+//
+// RendezvousTimeout is deliberately short so MaxConn back-pressure
+// scenarios — which intentionally provoke listeners to drop accept
+// messages and rely on the rendezvous timing out — fail-fast on each
+// retry instead of waiting the default. 1s is plenty for in-process
+// rendezvous round-trips.
+func startMockRelay(t *testing.T) (host string, opts relay.ClientOptions) {
 	t.Helper()
 	rs, err := server.NewServer(server.Config{
 		Logger:            slog.New(slog.NewTextHandler(io.Discard, nil)),
-		RendezvousTimeout: 5 * time.Second,
+		RendezvousTimeout: 1 * time.Second,
 	})
 	if err != nil {
 		t.Fatalf("new mock relay: %v", err)
 	}
-	srv = httptest.NewTLSServer(rs.Handler())
+	srv := httptest.NewTLSServer(rs.Handler())
 	u, _ := url.Parse(srv.URL)
 	host = u.Host
 	opts = relay.ClientOptions{
 		TLSConfig: &tls.Config{InsecureSkipVerify: true}, //nolint:gosec // test cert
 	}
 	t.Cleanup(srv.Close)
-	return host, opts, srv
-}
-
-// pickFreePort returns a localhost host:port that was free at the
-// moment of the call. There is an unavoidable TOCTOU window between
-// this Listen+Close pair and the sender's own net.Listen on the same
-// addr: another process can grab the port in between. If it loses
-// the race, the sender returns immediately with a bind error (the
-// senders do not retry), the sender goroutine exits, and Setup's
-// downstream waitForTCP times out after 3 s with a "never became
-// reachable" failure. In practice the window is microseconds-long
-// on a quiet test host, so this has not flaked, but the failure
-// mode is loud rather than retried.
-func pickFreePort(t *testing.T) string {
-	t.Helper()
-	ln, err := net.Listen("tcp", "127.0.0.1:0")
-	if err != nil {
-		t.Fatalf("pick port: %v", err)
-	}
-	addr := ln.Addr().String()
-	ln.Close() //nolint:errcheck // best-effort cleanup
-	return addr
-}
-
-// waitForTCP polls until a TCP connection to addr succeeds or the
-// timeout elapses. Used to make Backend.Setup block until the sender
-// is actually accepting.
-//
-// TODO(slice-2B): in ModePortForward, every accepted TCP connection
-// triggers a forward attempt through the relay. The probe socket
-// immediately closes, so the bridge tears down — but it does briefly
-// occupy a slot. Once MaxConnections=N scenarios land, the probe will
-// consume the only available slot and the scenario's real dial will
-// be rejected on the mock backend (azureBackend uses log-gated
-// readiness and is unaffected). Replace this probe with a non-
-// forwarding readiness signal (custom logger handler that captures
-// the "port-forward listening" log line, or a sender-side ready
-// channel) before MaxConnections scenarios merge.
-func waitForTCP(addr string, timeout time.Duration) bool {
-	deadline := time.Now().Add(timeout)
-	for time.Now().Before(deadline) {
-		c, err := net.DialTimeout("tcp", addr, 200*time.Millisecond)
-		if err == nil {
-			c.Close() //nolint:errcheck // best-effort cleanup
-			return true
-		}
-		time.Sleep(10 * time.Millisecond)
-	}
-	return false
-}
-
-// waitForControl polls the mock relay until at least one listener has
-// registered for the given entity. The sb-hc-action=connect probe
-// without an Upgrade header returns 404 when no listener is attached
-// and 400-ish once one is, so we watch for the transition away from
-// 404. Copy of the helper in mockrelay/server/integration_test.go.
-func waitForControl(t *testing.T, srv *httptest.Server, entity string, timeout time.Duration) {
-	t.Helper()
-	// Build our own client over the test server's TLS transport
-	// rather than mutating srv.Client(), which is shared and could
-	// surprise other code paths that reach for the default timeout.
-	httpClient := &http.Client{
-		Transport: srv.Client().Transport,
-		Timeout:   1 * time.Second,
-	}
-	host := strings.TrimPrefix(srv.URL, "https://")
-	tok, err := relay.GenerateSASToken(
-		relay.ResourceURI(host, entity),
-		server.DefaultSASKeyName,
-		server.DefaultSASKey,
-		1*time.Minute,
-	)
-	if err != nil {
-		t.Fatalf("mint probe token: %v", err)
-	}
-	probeURL := srv.URL + "/$hc/" + entity + "?sb-hc-action=connect&sb-hc-token=" + url.QueryEscape(tok)
-	deadline := time.Now().Add(timeout)
-	for time.Now().Before(deadline) {
-		resp, err := httpClient.Get(probeURL)
-		if err == nil {
-			status := resp.StatusCode
-			resp.Body.Close() //nolint:errcheck // best-effort cleanup
-			if status != http.StatusNotFound {
-				return
-			}
-		}
-		time.Sleep(50 * time.Millisecond)
-	}
-	t.Fatalf("timed out waiting for listener on %s/%s", host, entity)
+	return host, opts
 }
 
 // mustEntityName returns a short random suffix appended to the
@@ -275,7 +276,91 @@ func mustEntityName(t *testing.T) string {
 	if _, err := rand.Read(b[:]); err != nil {
 		t.Fatalf("rand: %v", err)
 	}
-	// Sanitize the test name into something safe for a URL path.
 	safe := strings.NewReplacer("/", "-", " ", "-", "#", "-").Replace(t.Name())
 	return safe + "-" + hex.EncodeToString(b[:])
+}
+
+// waitForGauge polls m's registry for a gauge to reach at least want
+// before timeout. Returns true on success, false on deadline.
+func waitForGauge(m *metrics.Metrics, name string, want float64, timeout time.Duration) bool {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if gaugeValue(m, name) >= want {
+			return true
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	return false
+}
+
+// counterReader returns a closure that sums every sample for the given
+// counter name across all label combinations on m's registry. Used to
+// expose listener / sender connection counters as Completed() closures.
+//
+// Summing across labels (target, status) is deliberate: each per-
+// listener / per-sender metrics surface only sees its own connections,
+// so there is no risk of cross-listener bleed in the sum.
+func counterReader(m *metrics.Metrics, name string) func() int64 {
+	return func() int64 {
+		families, err := m.Registry.Gather()
+		if err != nil {
+			return 0
+		}
+		var total float64
+		for _, f := range families {
+			if f.GetName() != name {
+				continue
+			}
+			for _, sample := range f.GetMetric() {
+				if c := sample.GetCounter(); c != nil {
+					total += c.GetValue()
+				}
+			}
+		}
+		return int64(total)
+	}
+}
+
+// gaugeReader returns a closure that sums every sample for the given
+// gauge name across all label combinations on m's registry.
+func gaugeReader(m *metrics.Metrics, name string) func() int64 {
+	return func() int64 {
+		families, err := m.Registry.Gather()
+		if err != nil {
+			return 0
+		}
+		var total float64
+		for _, f := range families {
+			if f.GetName() != name {
+				continue
+			}
+			for _, sample := range f.GetMetric() {
+				if g := sample.GetGauge(); g != nil {
+					total += g.GetValue()
+				}
+			}
+		}
+		return int64(total)
+	}
+}
+
+// gaugeValue returns the single-sample value of a gauge by name. Used
+// for the control_channel_connected readiness probe, which has no
+// labels.
+func gaugeValue(m *metrics.Metrics, name string) float64 {
+	families, err := m.Registry.Gather()
+	if err != nil {
+		return 0
+	}
+	for _, f := range families {
+		if f.GetName() != name {
+			continue
+		}
+		for _, sample := range f.GetMetric() {
+			if g := sample.GetGauge(); g != nil {
+				return g.GetValue()
+			}
+		}
+	}
+	return 0
 }

--- a/mockrelay/parity/parity_test.go
+++ b/mockrelay/parity/parity_test.go
@@ -7,13 +7,14 @@ import (
 	"github.com/philsphicas/aztunnel/mockrelay/parity"
 )
 
-// TestParity_Mock runs the shared core parity suite against the
-// in-process MockBackend. This is the always-on side of the parity
-// matrix; it runs in `go test ./mockrelay/...` and is what the CI
-// `test` job enforces.
+// TestParity_Mock runs the shared parity suites against the in-process
+// MockBackend. This is the always-on side of the parity matrix; it
+// runs in `go test ./mockrelay/...` and is what the CI `test` job
+// enforces.
 func TestParity_Mock(t *testing.T) {
 	var b parity.MockBackend
 	t.Run(b.Name(), func(t *testing.T) {
 		relayparity.RunCoreSuite(t, &b)
+		relayparity.RunTopologySuite(t, &b)
 	})
 }


### PR DESCRIPTION
Extend the relay parity harness with a single-target multi-component
topology: N senders × M listeners × 1 target server, per-listener and
per-sender metrics handles, hot-drop / hot-add of listeners,
max-connection back-pressure, and goroutine + FD leak gates.

## What this gives us

- A common test surface for both the in-process mock relay and a real
  Azure Relay namespace, exercised by the same scenarios so any
  divergence between mock and Azure is mechanically caught.
- Per-listener and per-sender `Completed()` / `Active()` counters that
  scenarios can sum across labels — distribution assertions, hot-drop
  in-flight failure counts, and max-conn steady-state sampling all
  read the same handle shape on both backends.
- Hot-drop and hot-add of listeners while bridged traffic is in
  flight, with a fresh-dial check post-mutation to verify the surviving
  topology still serves new clients.
- A back-pressure scenario that asserts the per-listener semaphore
  bounds concurrent bridges across M listeners even when K > M·max
  clients all dial in parallel, with retry-on-EOF for overflow.
- Goroutine + FD leak gates that catch a goroutine leak per scenario
  iteration as small as ~5 goroutines and any FD leak on Linux.

## New scenarios (RunTopologySuite)

- `NSenderMListener_Echo` — sanity check across the (N, M) ∈ {(1,1),
  (1,2), (2,1), (2,2)} matrix.
- `Distribution_PerListener` / `Distribution_PerSender` — convergence
  loops: 20 initial sequential echoes then batches of 10 until every
  listener (or sender) has `Completed() > 0`, capped at 100 echoes or
  90 s. Catches zero-coverage regressions without flaking on Azure
  Relay's non-uniform listener selection at small sample sizes.
- `HotDropListener` — opens long flows in batches until listener[0]
  has at least one bridge, drops it, and asserts `dead == A0` exactly
  after a 5 s settle so a surviving listener silently tearing down
  in-flight bridges is observable; every non-broken flow is then
  exchanged to verify continuity, and a fresh dial still succeeds via
  the surviving listener.
- `HotAddListener` — adds a listener mid-flight, asserts existing
  flows keep echoing and the new listener observes at least one
  `Completed()` within a bounded probe budget (8-probe batches up to
  60 probes / 60 s).
- `MaxConn_BackPressure` — K=8 clients on M=2 listeners with
  MaxConnections=2 each; max observed in-flight ≤ 4, all 8 succeed
  via client retry.

## Backwards compatibility

The four single-flow core scenarios (Echo / Ordering / Bidirectional)
continue to use `Tunnel.SenderAddr`, which now aliases
`Tunnel.SenderAddrs[0]`. Backends that haven't wired hot-add yet may
leave `Tunnel.AddListener` nil; the hot-add scenario skips when it is.

Closes #53
