### PR TITLE
fix(e2e/azrelay): retry createRule on Azure Relay 40901 conflict

### DIFF
--- a/e2e/azrelay/provisioner.go
+++ b/e2e/azrelay/provisioner.go
@@ -18,11 +18,14 @@ package azrelay
 
 import (
 	"context"
-	"crypto/rand"
+	crand "crypto/rand"
 	"encoding/hex"
 	"errors"
 	"fmt"
+	mrand "math/rand/v2"
+	"net/http"
 	"regexp"
+	"strings"
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
@@ -54,6 +57,30 @@ const suffixLen = 12
 // under a second; we allow more to absorb the occasional regional blip
 // without forcing tests to handle the transient 404 themselves.
 const readinessMaxWait = 30 * time.Second
+
+// Bounds on the createRule / bestEffortDelete retry loop that absorbs the
+// transient 40901 MessagingGatewayTooManyRequests conflict produced when
+// Azure Relay's control plane serialises authorizationRule mutations per
+// hybrid connection: the ARM SDK returns 2xx for one mutation before the
+// backend has committed it, so a back-to-back mutation on the same hyco
+// (e.g. listener-rule then sender-rule, or delete-during-pending-create)
+// can race the per-hyco serialization gate and get rejected with 40901.
+// This is the same constraint that requires `@batchSize(1)` in Bicep on
+// Microsoft.Relay/namespaces/hybridConnections/authorizationRules.
+//
+// Six attempts with equal-jittered exponential backoff (500ms → 8s, cap)
+// is comfortably more than empirically observed convergence (sub-second)
+// while still bounded so a genuinely stuck control plane fails the run
+// rather than hanging. Note: the underlying azcore HTTP pipeline already
+// retries 429s a small number of times honouring Retry-After before
+// surfacing the error here, so the real cumulative wall time of a fully
+// exhausted createRule call is larger than ~15.5s of sleep alone — the
+// 30s ceiling in bestEffortDelete still dominates that path.
+const (
+	authRuleMaxAttempts  = 6
+	authRuleInitialDelay = 500 * time.Millisecond
+	authRuleMaxDelay     = 8 * time.Second
+)
 
 // dataPlaneSettleAfterKeys gives Relay's data plane a brief grace period
 // to propagate a newly-created SAS auth rule after the control plane
@@ -263,12 +290,14 @@ func (p *Provisioner) createHyco(ctx context.Context, name string) error {
 }
 
 func (p *Provisioner) createRule(ctx context.Context, hyco, ruleName string, right armrelay.AccessRights) error {
-	_, err := p.hycos.CreateOrUpdateAuthorizationRule(ctx, p.cfg.ResourceGroup, p.cfg.Namespace, hyco, ruleName, armrelay.AuthorizationRule{
-		Properties: &armrelay.AuthorizationRuleProperties{
-			Rights: []*armrelay.AccessRights{&right},
-		},
-	}, nil)
-	return err
+	return retryOnAuthRuleConflict(ctx, defaultAuthRuleRetry(), func() error {
+		_, err := p.hycos.CreateOrUpdateAuthorizationRule(ctx, p.cfg.ResourceGroup, p.cfg.Namespace, hyco, ruleName, armrelay.AuthorizationRule{
+			Properties: &armrelay.AuthorizationRuleProperties{
+				Rights: []*armrelay.AccessRights{&right},
+			},
+		}, nil)
+		return err
+	})
 }
 
 // readKey fetches the primary key for the given auth rule, retrying on
@@ -303,16 +332,114 @@ func (p *Provisioner) readKey(ctx context.Context, hyco, ruleName string) (strin
 func (p *Provisioner) bestEffortDelete(ctx context.Context, name string) {
 	ctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 30*time.Second)
 	defer cancel()
-	_, _ = p.hycos.Delete(ctx, p.cfg.ResourceGroup, p.cfg.Namespace, name, nil)
+	// Failure-path cleanup can race a not-yet-committed rule create on the
+	// same hyco; absorb the 40901 conflict the same way createRule does so
+	// we maximise cleanup success and reduce janitor load. Other errors
+	// (404, 403, ...) are swallowed by best-effort semantics.
+	_ = retryOnAuthRuleConflict(ctx, defaultAuthRuleRetry(), func() error {
+		_, err := p.hycos.Delete(ctx, p.cfg.ResourceGroup, p.cfg.Namespace, name, nil)
+		return err
+	})
 }
 
 // newSuffix returns a fresh suffixLen-character lowercase hex string.
 func newSuffix() (string, error) {
 	raw := make([]byte, suffixLen/2)
-	if _, err := rand.Read(raw); err != nil {
+	if _, err := crand.Read(raw); err != nil {
 		return "", err
 	}
 	return hex.EncodeToString(raw), nil
+}
+
+// authRuleRetry parameterises the bounded retry loop used to absorb the
+// transient 40901 MessagingGatewayTooManyRequests conflict on Relay
+// authorizationRule mutations. Kept as a struct so tests can drive the
+// loop with tiny delays without sleeping for real.
+type authRuleRetry struct {
+	maxAttempts  int
+	initialDelay time.Duration
+	maxDelay     time.Duration
+}
+
+func defaultAuthRuleRetry() authRuleRetry {
+	return authRuleRetry{
+		maxAttempts:  authRuleMaxAttempts,
+		initialDelay: authRuleInitialDelay,
+		maxDelay:     authRuleMaxDelay,
+	}
+}
+
+// retryOnAuthRuleConflict invokes fn, retrying with jittered exponential
+// backoff while fn returns a transient Azure Relay 40901 conflict (see
+// isAuthRuleConflict). Any other error — including generic 429s — is
+// returned to the caller immediately so we never paper over a real fault.
+// The function honours ctx cancellation between retries.
+func retryOnAuthRuleConflict(ctx context.Context, cfg authRuleRetry, fn func() error) error {
+	var lastErr error
+	delay := cfg.initialDelay
+	for attempt := 1; attempt <= cfg.maxAttempts; attempt++ {
+		err := fn()
+		if err == nil {
+			return nil
+		}
+		if !isAuthRuleConflict(err) {
+			return err
+		}
+		lastErr = err
+		if attempt == cfg.maxAttempts {
+			break
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(jitter(delay)):
+		}
+		if delay < cfg.maxDelay {
+			delay *= 2
+			if delay > cfg.maxDelay {
+				delay = cfg.maxDelay
+			}
+		}
+	}
+	return fmt.Errorf("after %d attempts: %w", cfg.maxAttempts, lastErr)
+}
+
+// isAuthRuleConflict reports whether err is the transient Azure Relay
+// 40901 MessagingGatewayTooManyRequests conflict produced when sequential
+// authorizationRule mutations race the per-hybrid-connection serialization
+// gate. Only this specific class is retried; generic 429s, other ARM
+// errors, and other SubCodes under the same ErrorCode (e.g. namespace-
+// level throttling that wouldn't benefit from short-window backoff
+// against a single hyco's commit window) are returned as-is.
+//
+// The SubCode marker is matched against ResponseError.Error() — azcore
+// embeds the raw response body in that string, and the body is the
+// authoritative carrier of the SubCode value in Service Bus / Relay
+// control-plane responses.
+func isAuthRuleConflict(err error) bool {
+	var respErr *azcore.ResponseError
+	if !errors.As(err, &respErr) {
+		return false
+	}
+	if respErr.StatusCode != http.StatusTooManyRequests ||
+		respErr.ErrorCode != "MessagingGatewayTooManyRequests" {
+		return false
+	}
+	return strings.Contains(respErr.Error(), "SubCode=40901")
+}
+
+// jitter returns a duration in the range [d/2, d]. Equal jitter is chosen
+// over full jitter so backoff still grows monotonically in expectation —
+// the race is a narrow per-hyco serialization window, not a thundering
+// herd against a shared fleet, so we want to keep growing the gap between
+// retries rather than risk re-firing near zero.
+func jitter(d time.Duration) time.Duration {
+	if d <= 0 {
+		return 0
+	}
+	half := d / 2
+	// #nosec G404 -- jitter is timing noise, not a security boundary.
+	return half + time.Duration(mrand.Int64N(int64(half)+1))
 }
 
 // isTransient classifies an error from ARM as retriable. Newly-created

--- a/e2e/azrelay/provisioner_test.go
+++ b/e2e/azrelay/provisioner_test.go
@@ -1,8 +1,17 @@
 package azrelay
 
 import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
 	"strings"
 	"testing"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 )
 
 func TestHycoNamePattern(t *testing.T) {
@@ -164,6 +173,260 @@ func TestProvisionerHycoNamesUsesSuffix(t *testing.T) {
 	for _, n := range []string{entra, sas} {
 		if !HycoNamePattern.MatchString(n) {
 			t.Errorf("generated name %q does not satisfy HycoNamePattern", n)
+		}
+	}
+}
+
+// fastAuthRuleRetry returns a retry config that runs the same number of
+// attempts as production but with near-zero delays so unit tests don't
+// pay the 500ms…8s backoff schedule. Behaviour-equivalent for the loop's
+// control flow (success/error/exhaust/cancel) and jitter is bounded by
+// initialDelay so even at full jitter the test budget is microseconds.
+func fastAuthRuleRetry() authRuleRetry {
+	return authRuleRetry{
+		maxAttempts:  authRuleMaxAttempts,
+		initialDelay: time.Microsecond,
+		maxDelay:     10 * time.Microsecond,
+	}
+}
+
+// newMessagingGatewayErr builds a *azcore.ResponseError that mirrors the
+// shape Azure Relay returns for a 429 MessagingGatewayTooManyRequests:
+// the StatusCode/ErrorCode fields plus a RawResponse whose body carries
+// the SubCode marker that azcore.Error() embeds in its rendered string.
+// The SubCode the caller specifies is what isAuthRuleConflict will see.
+func newMessagingGatewayErr(subCode int) error {
+	body := fmt.Sprintf(
+		`{"error":{"code":"MessagingGatewayTooManyRequests","message":"SubCode=%d. Another conflicting operation is in progress."}}`,
+		subCode,
+	)
+	req, _ := http.NewRequest(http.MethodPut, "http://example.com/rule", nil)
+	return &azcore.ResponseError{
+		StatusCode: http.StatusTooManyRequests,
+		ErrorCode:  "MessagingGatewayTooManyRequests",
+		RawResponse: &http.Response{
+			StatusCode: http.StatusTooManyRequests,
+			Status:     "429 Too Many Requests",
+			Body:       io.NopCloser(bytes.NewBufferString(body)),
+			Header:     http.Header{},
+			Request:    req,
+		},
+	}
+}
+
+// newConflictErr returns the 40901 SubCode shape isAuthRuleConflict
+// recognises (the exact failure mode the retry exists to absorb).
+func newConflictErr() error { return newMessagingGatewayErr(40901) }
+
+func TestIsAuthRuleConflict(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "nil",
+			err:  nil,
+			want: false,
+		},
+		{
+			name: "non-ResponseError",
+			err:  errors.New("plain error"),
+			want: false,
+		},
+		{
+			name: "matches 429 + MessagingGatewayTooManyRequests + SubCode=40901",
+			err:  newConflictErr(),
+			want: true,
+		},
+		{
+			name: "wrapped match still recognised",
+			err:  fmt.Errorf("create rule: %w", newConflictErr()),
+			want: true,
+		},
+		{
+			name: "same ErrorCode but different SubCode is not retried",
+			err:  newMessagingGatewayErr(40902),
+			want: false,
+		},
+		{
+			name: "same ErrorCode with no SubCode marker is not retried",
+			err: &azcore.ResponseError{
+				StatusCode: http.StatusTooManyRequests,
+				ErrorCode:  "MessagingGatewayTooManyRequests",
+			},
+			want: false,
+		},
+		{
+			name: "429 with different ErrorCode is not retried",
+			err: &azcore.ResponseError{
+				StatusCode: http.StatusTooManyRequests,
+				ErrorCode:  "SomeOtherThrottling",
+			},
+			want: false,
+		},
+		{
+			name: "429 with empty ErrorCode is not retried",
+			err: &azcore.ResponseError{
+				StatusCode: http.StatusTooManyRequests,
+			},
+			want: false,
+		},
+		{
+			name: "503 with matching ErrorCode + SubCode is not retried (wrong status)",
+			err: &azcore.ResponseError{
+				StatusCode: http.StatusServiceUnavailable,
+				ErrorCode:  "MessagingGatewayTooManyRequests",
+			},
+			want: false,
+		},
+		{
+			name: "401 is not retried",
+			err: &azcore.ResponseError{
+				StatusCode: http.StatusUnauthorized,
+				ErrorCode:  "MessagingGatewayTooManyRequests",
+			},
+			want: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isAuthRuleConflict(tc.err); got != tc.want {
+				t.Fatalf("isAuthRuleConflict(%v) = %v, want %v", tc.err, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestRetryOnAuthRuleConflict_SuccessFirstAttempt(t *testing.T) {
+	calls := 0
+	err := retryOnAuthRuleConflict(t.Context(), fastAuthRuleRetry(), func() error {
+		calls++
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if calls != 1 {
+		t.Fatalf("calls = %d, want 1", calls)
+	}
+}
+
+func TestRetryOnAuthRuleConflict_RetriesThenSucceeds(t *testing.T) {
+	calls := 0
+	const succeedOn = 4
+	err := retryOnAuthRuleConflict(t.Context(), fastAuthRuleRetry(), func() error {
+		calls++
+		if calls < succeedOn {
+			return newConflictErr()
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if calls != succeedOn {
+		t.Fatalf("calls = %d, want %d", calls, succeedOn)
+	}
+}
+
+func TestRetryOnAuthRuleConflict_NonConflictReturnsImmediately(t *testing.T) {
+	calls := 0
+	sentinel := errors.New("hard failure")
+	err := retryOnAuthRuleConflict(t.Context(), fastAuthRuleRetry(), func() error {
+		calls++
+		return sentinel
+	})
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("err = %v, want %v", err, sentinel)
+	}
+	if calls != 1 {
+		t.Fatalf("calls = %d, want 1 (non-conflict must not retry)", calls)
+	}
+}
+
+// A 429 with a different ErrorCode (e.g. SubscriptionThrottle) must not be
+// retried by this loop — the issue is explicit that we only retry the
+// specific 40901 class.
+func TestRetryOnAuthRuleConflict_Generic429NotRetried(t *testing.T) {
+	calls := 0
+	generic := &azcore.ResponseError{
+		StatusCode: http.StatusTooManyRequests,
+		ErrorCode:  "SubscriptionRequestThrottled",
+	}
+	err := retryOnAuthRuleConflict(t.Context(), fastAuthRuleRetry(), func() error {
+		calls++
+		return generic
+	})
+	if !errors.Is(err, generic) {
+		t.Fatalf("err = %v, want %v", err, generic)
+	}
+	if calls != 1 {
+		t.Fatalf("calls = %d, want 1 (generic 429 must not retry)", calls)
+	}
+}
+
+func TestRetryOnAuthRuleConflict_ExhaustWrapsLastErr(t *testing.T) {
+	calls := 0
+	last := newConflictErr()
+	err := retryOnAuthRuleConflict(t.Context(), fastAuthRuleRetry(), func() error {
+		calls++
+		return last
+	})
+	if err == nil {
+		t.Fatal("expected error after exhausting attempts, got nil")
+	}
+	if !errors.Is(err, last) {
+		t.Fatalf("err %v does not wrap last %v", err, last)
+	}
+	if !strings.Contains(err.Error(), "after") {
+		t.Fatalf("err %q does not mention attempts", err.Error())
+	}
+	if calls != authRuleMaxAttempts {
+		t.Fatalf("calls = %d, want %d", calls, authRuleMaxAttempts)
+	}
+}
+
+func TestRetryOnAuthRuleConflict_ContextCancelledBetweenAttempts(t *testing.T) {
+	// Drive the cancellation deterministically from inside fn so the test
+	// doesn't depend on scheduler wall-clock timing: the first attempt
+	// cancels ctx and returns a retriable conflict; the loop's select
+	// then observes ctx.Done immediately and returns context.Canceled
+	// without a second fn call.
+	cfg := authRuleRetry{
+		maxAttempts:  authRuleMaxAttempts,
+		initialDelay: time.Second, // never actually waited
+		maxDelay:     time.Second,
+	}
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	calls := 0
+	err := retryOnAuthRuleConflict(ctx, cfg, func() error {
+		calls++
+		cancel()
+		return newConflictErr()
+	})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("err = %v, want context.Canceled", err)
+	}
+	if calls != 1 {
+		t.Fatalf("calls = %d, want 1 (cancel must abort before second attempt)", calls)
+	}
+}
+
+func TestJitterBounds(t *testing.T) {
+	// jitter(d) must lie in [d/2, d] for positive d, and be 0 for d <= 0.
+	if got := jitter(0); got != 0 {
+		t.Fatalf("jitter(0) = %v, want 0", got)
+	}
+	if got := jitter(-time.Second); got != 0 {
+		t.Fatalf("jitter(-1s) = %v, want 0", got)
+	}
+	for range 256 {
+		d := 4 * time.Millisecond
+		got := jitter(d)
+		if got < d/2 || got > d {
+			t.Fatalf("jitter(%v) = %v outside [%v, %v]", d, got, d/2, d)
 		}
 	}
 }


### PR DESCRIPTION
## Summary

E2E provisioning intermittently fails when TestMain creates the second
`authorizationRule` (sender) on a hyco shortly after the first
(listener) succeeded:

```
RESPONSE 429: 429 Too Many Requests
ERROR CODE: MessagingGatewayTooManyRequests
{
  "code": "MessagingGatewayTooManyRequests",
  "message": "SubCode=40901. Another conflicting operation is in progress."
}
```

Azure Relay's control plane serialises `authorizationRule` mutations per
hybrid connection. The ARM SDK returns 2xx before the backend has
committed, so the second mutation lands inside the commit window and is
rejected with HTTP 429 / `MessagingGatewayTooManyRequests` / SubCode
40901. Same constraint that forces `@batchSize(1)` in Bicep on
`Microsoft.Relay/namespaces/hybridConnections/authorizationRules`.

## Behaviour change

`createRule` and `bestEffortDelete` now absorb the specific 40901
conflict with bounded jittered exponential backoff (6 attempts, 500ms →
8s cap, equal jitter `[d/2, d]`). The predicate requires all three of
StatusCode 429, ErrorCode `MessagingGatewayTooManyRequests`, **and**
the `SubCode=40901` marker in the response body — other subcodes under
the same ErrorCode (e.g. namespace-level throttling) and every other
ARM error are returned to the caller unchanged so real faults are not
masked.

`Teardown`'s `Delete` and `readKey`'s `isTransient` predicate are
deliberately untouched: rule mutations are committed by the time
`Teardown` runs, and `ListKeys` is read-only.

## Tests

Pure-Go unit tests in `e2e/azrelay/provisioner_test.go` cover:

- `isAuthRuleConflict`: positive on 429 + `MessagingGatewayTooManyRequests`
  + `SubCode=40901` (including wrapped errors). Negative on
  same-ErrorCode-different-SubCode, no-SubCode marker, other ErrorCode,
  empty ErrorCode, 503 + match, 401 + match, plain error, nil.
- `retryOnAuthRuleConflict`: success on first attempt, success on Nth,
  immediate return on non-conflict, generic 429 not retried, exhaust
  wraps last error, deterministic cancel between attempts.
- `jitter` bounds.

`go test -race ./...` and `golangci-lint run ./...` pass on both
modules. The e2e job exercises the real provisioning path against
Azure Relay.

Closes #57