### PR TITLE
feat: relay parity characterization benchmarks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ LDFLAGS  := -ldflags "-X main.version=$(VERSION)"
 CGO    := $(shell go env CGO_ENABLED)
 RACE   := $(if $(filter 1,$(CGO)),-race,)
 
-.PHONY: build test cover lint clean install docker docker-alpine docker-bookworm fmt fmt-check e2e e2e-docker e2e-infra-setup e2e-infra-ci e2e-infra-clean e2e-infra-env e2e-infra-janitor vulncheck help
+.PHONY: build test cover lint clean install docker docker-alpine docker-bookworm fmt fmt-check e2e e2e-docker e2e-infra-setup e2e-infra-ci e2e-infra-clean e2e-infra-env e2e-infra-janitor vulncheck bench bench-compare help
 
 .DEFAULT_GOAL := help
 
@@ -89,6 +89,19 @@ e2e-infra-janitor: ## Delete orphaned per-invocation hybrid connections older th
 
 vulncheck: ## Check Go dependencies for known vulnerabilities
 	go run golang.org/x/vuln/cmd/govulncheck@latest ./...
+
+bench: ## Run mock parity benchmarks once (override BENCH=, COUNT=, BENCHTIME=)
+	cd mockrelay && go test -run='^$$' -bench='$(or $(BENCH),.)' -benchmem \
+		-count='$(or $(COUNT),1)' -benchtime='$(or $(BENCHTIME),1s)' \
+		./testharness/parity/...
+
+bench-compare: ## Compare parity benchmarks across two refs: BASE=<sha> [HEAD=<sha>]
+	@if [ -z "$(BASE)" ]; then \
+		echo "usage: make bench-compare BASE=<sha> [HEAD=<sha>] [BACKEND=mock|azure] [COUNT=N] [BENCHTIME=...]" >&2; \
+		exit 2; \
+	fi
+	BACKEND='$(or $(BACKEND),mock)' COUNT='$(or $(COUNT),5)' BENCHTIME='$(BENCHTIME)' \
+		scripts/bench-compare.sh '$(BASE)' '$(HEAD)'
 
 help: ## Show this help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | \

--- a/e2e/azure_backend_test.go
+++ b/e2e/azure_backend_test.go
@@ -40,7 +40,7 @@ func (b *azureBackend) Name() string { return "azure-" + b.auth.name }
 // address, then attaches metrics-scrape closures and returns the
 // Tunnel handle. All subprocesses are torn down via the existing
 // t.Cleanup wiring inside startAztunnelWithSAS.
-func (b *azureBackend) Setup(t *testing.T, opts relayparity.SetupOptions) *relayparity.Tunnel {
+func (b *azureBackend) Setup(t testing.TB, opts relayparity.SetupOptions) *relayparity.Tunnel {
 	t.Helper()
 	if opts.NumListeners < 1 {
 		t.Fatalf("NumListeners must be >= 1, got %d", opts.NumListeners)
@@ -59,7 +59,7 @@ func (b *azureBackend) Setup(t *testing.T, opts relayparity.SetupOptions) *relay
 			strconv.Itoa(opts.MaxConnections))
 	}
 
-	spawnListener := func(t *testing.T) *relayparity.Listener {
+	spawnListener := func(t testing.TB) *relayparity.Listener {
 		t.Helper()
 		lst := startListener(t, b.env, b.auth, listenerArgs...)
 		waitForLog(t, lst, "control channel connected", 30*time.Second)

--- a/e2e/helpers_test.go
+++ b/e2e/helpers_test.go
@@ -38,7 +38,7 @@ type authConfig struct {
 }
 
 // requireRelayEnv reads config from env vars and skips if nothing is configured.
-func requireRelayEnv(t *testing.T) *relayEnv {
+func requireRelayEnv(t testing.TB) *relayEnv {
 	t.Helper()
 	relay := os.Getenv("E2E_RELAY_NAME")
 	if relay == "" {
@@ -63,7 +63,7 @@ func requireRelayEnv(t *testing.T) *relayEnv {
 // availableAuths returns auth configurations for each available method.
 // Tests can iterate over these to run against both Entra and SAS.
 // Set E2E_AUTH=entra or E2E_AUTH=sas to restrict to a single method.
-func availableAuths(t *testing.T, env *relayEnv) []authConfig {
+func availableAuths(t testing.TB, env *relayEnv) []authConfig {
 	t.Helper()
 	filter := os.Getenv("E2E_AUTH") // "", "entra", "sas"
 	switch filter {
@@ -94,7 +94,7 @@ func availableAuths(t *testing.T, env *relayEnv) []authConfig {
 }
 
 // startListener starts an aztunnel relay-listener with the given auth config.
-func startListener(t *testing.T, env *relayEnv, auth authConfig, extraArgs ...string) *aztunnelProcess {
+func startListener(t testing.TB, env *relayEnv, auth authConfig, extraArgs ...string) *aztunnelProcess {
 	t.Helper()
 	args := append([]string{
 		"relay-listener",
@@ -105,7 +105,7 @@ func startListener(t *testing.T, env *relayEnv, auth authConfig, extraArgs ...st
 }
 
 // startPortForwardSender starts an aztunnel relay-sender port-forward with the given auth config.
-func startPortForwardSender(t *testing.T, env *relayEnv, auth authConfig, target string, extraArgs ...string) *aztunnelProcess {
+func startPortForwardSender(t testing.TB, env *relayEnv, auth authConfig, target string, extraArgs ...string) *aztunnelProcess {
 	t.Helper()
 	args := append([]string{
 		"relay-sender", "port-forward", target,
@@ -117,7 +117,7 @@ func startPortForwardSender(t *testing.T, env *relayEnv, auth authConfig, target
 }
 
 // startSOCKS5Sender starts an aztunnel relay-sender socks5-proxy with the given auth config.
-func startSOCKS5Sender(t *testing.T, env *relayEnv, auth authConfig, extraArgs ...string) *aztunnelProcess {
+func startSOCKS5Sender(t testing.TB, env *relayEnv, auth authConfig, extraArgs ...string) *aztunnelProcess {
 	t.Helper()
 	args := append([]string{
 		"relay-sender", "socks5-proxy",
@@ -135,7 +135,7 @@ var (
 )
 
 // aztunnelBinary builds the aztunnel binary once and returns its path.
-func aztunnelBinary(t *testing.T) string {
+func aztunnelBinary(t testing.TB) string {
 	t.Helper()
 	buildOnce.Do(func() {
 		// Find the repo root (parent of e2e/).
@@ -171,7 +171,7 @@ type aztunnelProcess struct {
 // the second and subsequent calls are no-ops. The Cleanup hook registered by
 // startAztunnelWithSAS calls Stop too, so tests only need to call this when
 // they want to terminate a process mid-test (e.g. listener restart scenarios).
-func (p *aztunnelProcess) Stop(t *testing.T) {
+func (p *aztunnelProcess) Stop(t testing.TB) {
 	t.Helper()
 	p.stopOnce.Do(func() {
 		if p.cmd.Process != nil {
@@ -183,7 +183,7 @@ func (p *aztunnelProcess) Stop(t *testing.T) {
 
 // MetricsAddr waits for the "metrics server listening addr=…" log line and
 // returns the address. Use this in tests that pass --metrics-addr 127.0.0.1:0.
-func (p *aztunnelProcess) MetricsAddr(t *testing.T, timeout time.Duration) string {
+func (p *aztunnelProcess) MetricsAddr(t testing.TB, timeout time.Duration) string {
 	t.Helper()
 	return waitForLogAddr(t, p, "metrics server listening", timeout)
 }
@@ -275,12 +275,12 @@ func (lb *logBuffer) waitFor(substr string, timeout time.Duration) (string, bool
 
 // startAztunnel starts an aztunnel process with the given args and returns
 // a handle. The process is killed on test cleanup.
-func startAztunnel(t *testing.T, env *relayEnv, args ...string) *aztunnelProcess {
+func startAztunnel(t testing.TB, env *relayEnv, args ...string) *aztunnelProcess {
 	return startAztunnelWithSAS(t, env, nil, args...)
 }
 
 // startAztunnelWithSAS starts an aztunnel process with explicit SAS credentials.
-func startAztunnelWithSAS(t *testing.T, env *relayEnv, sas *sasCredentials, args ...string) *aztunnelProcess {
+func startAztunnelWithSAS(t testing.TB, env *relayEnv, sas *sasCredentials, args ...string) *aztunnelProcess {
 	t.Helper()
 	binary := aztunnelBinary(t)
 
@@ -388,7 +388,7 @@ func setAztunnelEnv(cmd *exec.Cmd, env *relayEnv, sas *sasCredentials) {
 }
 
 // waitForLog waits for a log line containing the given substring.
-func waitForLog(t *testing.T, proc *aztunnelProcess, substr string, timeout time.Duration) string {
+func waitForLog(t testing.TB, proc *aztunnelProcess, substr string, timeout time.Duration) string {
 	t.Helper()
 	line, ok := proc.logs.waitFor(substr, timeout)
 	if !ok {
@@ -401,7 +401,7 @@ func waitForLog(t *testing.T, proc *aztunnelProcess, substr string, timeout time
 var addrRe = regexp.MustCompile(`addr=([^\s]+)`)
 
 // waitForLogAddr waits for a log line and extracts the addr= value.
-func waitForLogAddr(t *testing.T, proc *aztunnelProcess, substr string, timeout time.Duration) string {
+func waitForLogAddr(t testing.TB, proc *aztunnelProcess, substr string, timeout time.Duration) string {
 	t.Helper()
 	line := waitForLog(t, proc, substr, timeout)
 	m := addrRe.FindStringSubmatch(line)

--- a/e2e/parity_bench_test.go
+++ b/e2e/parity_bench_test.go
@@ -1,0 +1,36 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"testing"
+
+	"github.com/philsphicas/aztunnel/internal/testharness/relayparity"
+)
+
+// BenchmarkParity_Azure runs the shared parity benchmark suite
+// against a real Azure Relay namespace. Pair with the mock variant
+// (BenchmarkParity_Mock in mockrelay/testharness/parity) for fast
+// iteration; the Azure variant produces source-of-truth numbers for
+// characterising PR #47.
+//
+// Only one auth method is exercised — whichever availableAuths
+// returns first — to keep the run time bounded. Run with E2E_AUTH=sas
+// or E2E_AUTH=entra to pin the method, which is important for
+// benchstat name-matching across BASE and HEAD invocations of
+// scripts/bench-compare.sh.
+//
+// Standard invocation (each iteration involves real relay round-
+// trips, so -benchtime=10x usually beats the default -benchtime=1s):
+//
+//	go test -tags=e2e -run='^$' -bench=. -benchmem -count=5 \
+//	    -benchtime=10x -timeout=60m ./e2e/...
+func BenchmarkParity_Azure(b *testing.B) {
+	env := requireRelayEnv(b)
+	auths := availableAuths(b, env)
+	auth := auths[0]
+	b.Run(auth.name, func(b *testing.B) {
+		backend := &azureBackend{env: env, auth: auth}
+		relayparity.RunBenchSuite(b, backend)
+	})
+}

--- a/internal/testharness/relayparity/backend.go
+++ b/internal/testharness/relayparity/backend.go
@@ -32,6 +32,12 @@ func (m SenderMode) String() string {
 // Backend is the abstraction parity scenarios run against. Each
 // implementation knows how to bring up a topology that satisfies
 // SetupOptions and to tear it down cleanly via t.Cleanup.
+//
+// Setup takes testing.TB rather than *testing.T so the same backend
+// implementation is reachable from both tests (RunCoreSuite,
+// RunTopologySuite) and benchmarks (RunBenchSuite). The only TB
+// methods used are Helper / Fatalf / Logf / Cleanup, all on the
+// shared interface.
 type Backend interface {
 	// Name identifies the backend in test output (e.g. "mock",
 	// "azure-entra", "azure-sas"). Used to make sub-test paths
@@ -50,7 +56,7 @@ type Backend interface {
 	// the in-process backend, the aztunnel_control_channel_connected
 	// gauge). Scenarios assume the tunnel is fully connected on
 	// return.
-	Setup(t *testing.T, opts SetupOptions) *Tunnel
+	Setup(t testing.TB, opts SetupOptions) *Tunnel
 }
 
 // SetupOptions configures the topology a backend should create.

--- a/internal/testharness/relayparity/bench.go
+++ b/internal/testharness/relayparity/bench.go
@@ -1,0 +1,355 @@
+package relayparity
+
+import (
+	"crypto/rand"
+	"fmt"
+	"io"
+	"net"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// RunBenchSuite registers every parity benchmark as a sub-bench under
+// b. Mirrors RunCoreSuite for tests: a single entry point keeps the
+// per-backend bench_test.go files trivial.
+//
+// The sub-benches measure the exact dimensions PR #47 (connection
+// muxing) is supposed to improve, plus a control benchmark
+// (SteadyThroughput) that should NOT regress under mux. Run with
+// `-count=5 -benchmem` and feed both outputs into benchstat to
+// quantify the change.
+//
+// Each sub-bench stands up its own topology via backend.Setup(b, ...)
+// and tears it down through t.Cleanup. AssertNoLeaks is deliberately
+// not called: leak polling inside a benchmark would inflate the
+// timer.
+func RunBenchSuite(b *testing.B, backend Backend) {
+	b.Helper()
+	b.Run("ConnectLatency_Serial_PortForward", func(b *testing.B) {
+		benchConnectLatencySerial(b, backend, ModePortForward)
+	})
+	b.Run("ConnectLatency_Serial_SOCKS5", func(b *testing.B) {
+		benchConnectLatencySerial(b, backend, ModeSOCKS5)
+	})
+	b.Run("ConcurrentConnect_N100", func(b *testing.B) {
+		benchConcurrentConnect(b, backend, 100)
+	})
+	b.Run("ShortSessionRate_N1", func(b *testing.B) {
+		benchShortSessionRate(b, backend, 1)
+	})
+	b.Run("ShortSessionRate_N2", func(b *testing.B) {
+		benchShortSessionRate(b, backend, 2)
+	})
+	b.Run("SteadyThroughput", func(b *testing.B) {
+		benchSteadyThroughput(b, backend)
+	})
+	b.Run("ConnectFailureRate", func(b *testing.B) {
+		benchConnectFailureRate(b, backend)
+	})
+}
+
+// benchConnectLatencySerial measures the per-iteration wall time of:
+//
+//	Dial → write 1 byte → read 1 byte echoed back → close.
+//
+// Single connection per iteration, no concurrency. The headline #47
+// metric: each iteration pays one full relay rendezvous round-trip
+// (~1–2 s on Azure today; expected to drop to milliseconds with mux).
+//
+// Run against both modes (port-forward, SOCKS5) because the SOCKS5
+// path adds a handshake that may behave differently under mux.
+func benchConnectLatencySerial(b *testing.B, backend Backend, mode SenderMode) {
+	b.Helper()
+	echo := StartPlainEcho(b)
+	opts := SetupOptions{
+		NumListeners:   1,
+		SenderMode:     mode,
+		AllowedTargets: []string{echo.Addr()},
+	}
+	if mode == ModePortForward {
+		opts.Target = echo.Addr()
+	}
+	tun := backend.Setup(b, opts)
+
+	payload := []byte{0x42}
+	buf := make([]byte, 1)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		conn, err := benchDial(tun.SenderAddr, echo.Addr(), mode, 30*time.Second)
+		if err != nil {
+			b.Fatalf("dial: %v", err)
+		}
+		if err := writeFull(conn, payload); err != nil {
+			_ = conn.Close()
+			b.Fatalf("write: %v", err)
+		}
+		if _, err := io.ReadFull(conn, buf); err != nil {
+			_ = conn.Close()
+			b.Fatalf("read: %v", err)
+		}
+		if err := conn.Close(); err != nil {
+			b.Fatalf("close: %v", err)
+		}
+	}
+}
+
+// benchConcurrentConnect measures the wall time of opening n
+// concurrent connections, each of which round-trips 1 byte, per
+// iteration. Surfaces the concurrency-amplified setup cost: pre-#47
+// every flow waits its turn through the listener's serial rendezvous;
+// post-#47 they should fan out cheaply.
+//
+// Each iteration owns n goroutines; b.N controls how many iterations
+// run. Worker errors are collected and surfaced from the benchmark
+// goroutine (b.Fatalf from a worker is racy).
+func benchConcurrentConnect(b *testing.B, backend Backend, n int) {
+	b.Helper()
+	skipIfFDLimitTooLow(b, n*8+64)
+	echo := StartPlainEcho(b)
+	tun := backend.Setup(b, SetupOptions{
+		NumListeners:   1,
+		SenderMode:     ModePortForward,
+		Target:         echo.Addr(),
+		AllowedTargets: []string{echo.Addr()},
+	})
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		errs := make(chan error, n)
+		var wg sync.WaitGroup
+		wg.Add(n)
+		for j := 0; j < n; j++ {
+			go func() {
+				defer wg.Done()
+				conn, err := net.DialTimeout("tcp", tun.SenderAddr, 60*time.Second)
+				if err != nil {
+					errs <- fmt.Errorf("dial: %w", err)
+					return
+				}
+				defer conn.Close() //nolint:errcheck // best-effort
+				_ = conn.SetDeadline(time.Now().Add(60 * time.Second))
+				if err := writeFull(conn, []byte{0x42}); err != nil {
+					errs <- fmt.Errorf("write: %w", err)
+					return
+				}
+				buf := make([]byte, 1)
+				if _, err := io.ReadFull(conn, buf); err != nil {
+					errs <- fmt.Errorf("read: %w", err)
+					return
+				}
+			}()
+		}
+		wg.Wait()
+		close(errs)
+		if err := drainErrors(errs); err != nil {
+			b.Fatalf("iter %d: %v", i, err)
+		}
+	}
+}
+
+// benchShortSessionRate measures ops/sec of the
+// open → write 1 KB → read 1 KB → close cycle. The workload PR #47
+// explicitly cites as "intolerable" without mux.
+//
+// numSenders controls how many sender binds receive the load round-
+// robin. The single-sender variant is the strict baseline; the
+// multi-sender variant probes whether scaling out senders is a
+// workaround for the missing mux.
+//
+// b.SetBytes(1024) makes MB/s appear alongside ns/op for benchstat,
+// counting payload bytes written per iteration.
+func benchShortSessionRate(b *testing.B, backend Backend, numSenders int) {
+	b.Helper()
+	echo := StartPlainEcho(b)
+	tun := backend.Setup(b, SetupOptions{
+		NumListeners:   1,
+		NumSenders:     numSenders,
+		SenderMode:     ModePortForward,
+		Target:         echo.Addr(),
+		AllowedTargets: []string{echo.Addr()},
+	})
+
+	const payloadSize = 1024
+	payload := make([]byte, payloadSize)
+	if _, err := rand.Read(payload); err != nil {
+		b.Fatalf("rand: %v", err)
+	}
+
+	b.SetBytes(int64(payloadSize))
+	b.ReportAllocs()
+	b.ResetTimer()
+	buf := make([]byte, payloadSize)
+	for i := 0; i < b.N; i++ {
+		addr := tun.SenderAddrs[i%len(tun.SenderAddrs)]
+		conn, err := net.DialTimeout("tcp", addr, 30*time.Second)
+		if err != nil {
+			b.Fatalf("dial: %v", err)
+		}
+		_ = conn.SetDeadline(time.Now().Add(30 * time.Second))
+		if err := writeFull(conn, payload); err != nil {
+			_ = conn.Close()
+			b.Fatalf("write: %v", err)
+		}
+		if _, err := io.ReadFull(conn, buf); err != nil {
+			_ = conn.Close()
+			b.Fatalf("read: %v", err)
+		}
+		if err := conn.Close(); err != nil {
+			b.Fatalf("close: %v", err)
+		}
+	}
+}
+
+// benchSteadyThroughput measures MB/s through a single established
+// connection over a 1 MB bidirectional transfer per iteration. The
+// connection is dialed once before the timer starts and reused for
+// every iteration so setup cost is excluded.
+//
+// This is the control benchmark: it should NOT regress under mux.
+// Writes and reads run concurrently to avoid socket-buffer deadlock,
+// and each iteration drains exactly transferSize bytes before
+// starting the next.
+func benchSteadyThroughput(b *testing.B, backend Backend) {
+	b.Helper()
+	echo := StartPlainEcho(b)
+	tun := backend.Setup(b, SetupOptions{
+		NumListeners:   1,
+		SenderMode:     ModePortForward,
+		Target:         echo.Addr(),
+		AllowedTargets: []string{echo.Addr()},
+	})
+
+	conn, err := net.DialTimeout("tcp", tun.SenderAddr, 30*time.Second)
+	if err != nil {
+		b.Fatalf("dial: %v", err)
+	}
+	defer conn.Close() //nolint:errcheck // best-effort
+
+	const transferSize = 1024 * 1024
+	body := make([]byte, transferSize)
+	if _, err := rand.Read(body); err != nil {
+		b.Fatalf("rand: %v", err)
+	}
+	readBuf := make([]byte, transferSize)
+
+	b.SetBytes(int64(transferSize))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = conn.SetDeadline(time.Now().Add(2 * time.Minute))
+		writeDone := make(chan error, 1)
+		go func() {
+			writeDone <- writeFull(conn, body)
+		}()
+		if _, err := io.ReadFull(conn, readBuf); err != nil {
+			b.Fatalf("iter %d read: %v", i, err)
+		}
+		if err := <-writeDone; err != nil {
+			b.Fatalf("iter %d write: %v", i, err)
+		}
+	}
+}
+
+// benchConnectFailureRate measures stability under load. Each
+// iteration fires numDials=500 concurrent dials and counts how many
+// errored. The aggregate failure fraction across all iterations is
+// reported via b.ReportMetric so benchstat can diff it.
+//
+// The default ns/op reflects the wall time of one 500-dial round and
+// is preserved for completeness; the headline signal is the custom
+// fail% metric.
+func benchConnectFailureRate(b *testing.B, backend Backend) {
+	b.Helper()
+	const numDials = 500
+	skipIfFDLimitTooLow(b, numDials*4+64)
+	echo := StartPlainEcho(b)
+	tun := backend.Setup(b, SetupOptions{
+		NumListeners:   1,
+		SenderMode:     ModePortForward,
+		Target:         echo.Addr(),
+		AllowedTargets: []string{echo.Addr()},
+	})
+
+	var totalFailures atomic.Int64
+	var totalDials atomic.Int64
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		var wg sync.WaitGroup
+		wg.Add(numDials)
+		for j := 0; j < numDials; j++ {
+			go func() {
+				defer wg.Done()
+				totalDials.Add(1)
+				conn, err := net.DialTimeout("tcp", tun.SenderAddr, 30*time.Second)
+				if err != nil {
+					totalFailures.Add(1)
+					return
+				}
+				// Issue a tiny round-trip so a successful TCP that
+				// then fails inside the bridge is still counted as a
+				// failure. Without this, a sender that accepts the
+				// TCP and immediately drops would look like a
+				// success.
+				_ = conn.SetDeadline(time.Now().Add(30 * time.Second))
+				if err := writeFull(conn, []byte{0x42}); err != nil {
+					totalFailures.Add(1)
+					_ = conn.Close()
+					return
+				}
+				buf := make([]byte, 1)
+				if _, err := io.ReadFull(conn, buf); err != nil {
+					totalFailures.Add(1)
+					_ = conn.Close()
+					return
+				}
+				_ = conn.Close()
+			}()
+		}
+		wg.Wait()
+	}
+	b.StopTimer()
+
+	dials := totalDials.Load()
+	fails := totalFailures.Load()
+	var pct float64
+	if dials > 0 {
+		pct = float64(fails) / float64(dials) * 100.0
+	}
+	b.ReportMetric(pct, "fail%")
+}
+
+// benchDial opens a connection to the sender bind for the given
+// mode. For SOCKS5 it performs the CONNECT handshake to the supplied
+// target; for port-forward it returns the raw TCP connection.
+func benchDial(senderAddr, target string, mode SenderMode, timeout time.Duration) (net.Conn, error) {
+	switch mode {
+	case ModePortForward:
+		return net.DialTimeout("tcp", senderAddr, timeout)
+	case ModeSOCKS5:
+		return DialSOCKS5(senderAddr, target, timeout)
+	default:
+		return nil, fmt.Errorf("unknown SenderMode %v", mode)
+	}
+}
+
+// skipIfFDLimitTooLow skips the benchmark when the soft FD limit is
+// below need. High-concurrency benchmarks consume many FDs per
+// successful dial (client socket + sender bridge + listener bridge +
+// echo socket + relay control sockets), and an EMFILE-driven failure
+// reflects the host's ulimit rather than relay behavior.
+//
+// The actual rlimit check is delegated to platform-specific files
+// (fdlimit_unix.go / fdlimit_other.go) because RLIMIT_NOFILE is not
+// available on Windows.
+func skipIfFDLimitTooLow(b *testing.B, need int) {
+	b.Helper()
+	if cur, ok := getFDLimit(); ok && uint64(need) > cur { //nolint:gosec // need is bounded by callers
+		b.Skipf("benchmark needs >= %d file descriptors; soft limit is %d. Raise with `ulimit -n` and retry.", need, cur)
+	}
+}

--- a/internal/testharness/relayparity/echo.go
+++ b/internal/testharness/relayparity/echo.go
@@ -27,7 +27,10 @@ type PlainEcho struct {
 
 // StartPlainEcho starts a plain echo server on a free localhost port.
 // It is stopped by t.Cleanup.
-func StartPlainEcho(t *testing.T) *PlainEcho {
+//
+// Accepts testing.TB so it is callable from both *testing.T scenarios
+// and *testing.B benchmarks. Only Cleanup / Helper / Fatalf are used.
+func StartPlainEcho(t testing.TB) *PlainEcho {
 	t.Helper()
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {

--- a/internal/testharness/relayparity/fdlimit_other.go
+++ b/internal/testharness/relayparity/fdlimit_other.go
@@ -1,0 +1,13 @@
+//go:build !unix
+
+package relayparity
+
+// getFDLimit on non-Unix platforms (Windows, plan9, js) returns
+// (0, false) so skipIfFDLimitTooLow becomes a no-op there. Windows
+// has its own per-process handle limits but no analogue of
+// RLIMIT_NOFILE; tightening the cross-platform behaviour is left for
+// a future change if Windows actually starts running these
+// benchmarks.
+func getFDLimit() (uint64, bool) {
+	return 0, false
+}

--- a/internal/testharness/relayparity/fdlimit_unix.go
+++ b/internal/testharness/relayparity/fdlimit_unix.go
@@ -1,0 +1,16 @@
+//go:build unix
+
+package relayparity
+
+import "syscall"
+
+// getFDLimit returns the current soft RLIMIT_NOFILE for the process.
+// The second return is false on any error so callers treat the check
+// as unavailable rather than zero.
+func getFDLimit() (uint64, bool) {
+	var lim syscall.Rlimit
+	if err := syscall.Getrlimit(syscall.RLIMIT_NOFILE, &lim); err != nil {
+		return 0, false
+	}
+	return lim.Cur, true
+}

--- a/mockrelay/testharness/parity/bench_test.go
+++ b/mockrelay/testharness/parity/bench_test.go
@@ -1,0 +1,24 @@
+package parity_test
+
+import (
+	"testing"
+
+	"github.com/philsphicas/aztunnel/internal/testharness/relayparity"
+	"github.com/philsphicas/aztunnel/mockrelay/testharness/parity"
+)
+
+// BenchmarkParity_Mock runs the shared parity benchmark suite against
+// the in-process MockBackend. Pair with `e2e/parity_bench_test.go`
+// (BenchmarkParity_Azure, build tag e2e) for the source-of-truth
+// numbers; the mock variant is the fast feedback loop for benchmark
+// development.
+//
+// Standard invocation (-count=5 for stability, -benchmem for alloc
+// numbers in benchstat output):
+//
+//	go test -run='^$' -bench=. -benchmem -count=5 \
+//	    ./testharness/parity/...
+func BenchmarkParity_Mock(b *testing.B) {
+	var backend parity.MockBackend
+	relayparity.RunBenchSuite(b, &backend)
+}

--- a/mockrelay/testharness/parity/mock_backend.go
+++ b/mockrelay/testharness/parity/mock_backend.go
@@ -45,7 +45,7 @@ func (*MockBackend) Name() string { return "mock" }
 // until every listener's control channel is attached and every sender
 // bind is accepting TCP. All goroutines, the mock HTTP server, and
 // the sender binds are released via t.Cleanup.
-func (*MockBackend) Setup(t *testing.T, opts relayparity.SetupOptions) *relayparity.Tunnel {
+func (*MockBackend) Setup(t testing.TB, opts relayparity.SetupOptions) *relayparity.Tunnel {
 	t.Helper()
 	if opts.NumListeners < 1 {
 		t.Fatalf("NumListeners must be >= 1, got %d", opts.NumListeners)
@@ -87,7 +87,7 @@ func (*MockBackend) Setup(t *testing.T, opts relayparity.SetupOptions) *relaypar
 	// its relayparity handle. Each listener owns a private metrics
 	// surface so Completed() / Active() report only that listener's
 	// bridges.
-	startListener := func(t *testing.T) *relayparity.Listener {
+	startListener := func(t testing.TB) *relayparity.Listener {
 		t.Helper()
 		m := metrics.New()
 		lctx, lcancel := context.WithCancel(ctx)
@@ -249,7 +249,7 @@ func (*MockBackend) Setup(t *testing.T, opts relayparity.SetupOptions) *relaypar
 // messages and rely on the rendezvous timing out — fail-fast on each
 // retry instead of waiting the default. 1s is plenty for in-process
 // rendezvous round-trips.
-func startMockRelay(t *testing.T) (host string, opts relay.ClientOptions) {
+func startMockRelay(t testing.TB) (host string, opts relay.ClientOptions) {
 	t.Helper()
 	rs, err := server.NewServer(server.Config{
 		Logger:            slog.New(slog.NewTextHandler(io.Discard, nil)),
@@ -270,7 +270,7 @@ func startMockRelay(t *testing.T) (host string, opts relay.ClientOptions) {
 
 // mustEntityName returns a short random suffix appended to the
 // caller's test name. Keeps entities unique across scenarios.
-func mustEntityName(t *testing.T) string {
+func mustEntityName(t testing.TB) string {
 	t.Helper()
 	var b [4]byte
 	if _, err := rand.Read(b[:]); err != nil {

--- a/scripts/bench-compare.sh
+++ b/scripts/bench-compare.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+#
+# Run the parity benchmark suite against two git refs and produce a
+# benchstat comparison. Designed for characterising PR #47 once it
+# merges:
+#
+#   make bench-compare BASE=<pre-47-sha> HEAD=<post-47-sha>
+#
+# Equivalent direct invocation:
+#
+#   scripts/bench-compare.sh <pre-47-sha> [<post-47-sha>]
+#
+# Both refs MUST contain the benchmark suite (i.e. both must be at or
+# after issue #54). The script does not stub the suite into older
+# refs; if BASE predates the benchmarks the run at BASE will produce
+# no output and benchstat will fail to match.
+#
+# Each ref is checked out into its own `git worktree`, so the caller's
+# working tree is never modified and the script itself is read once
+# at the start (no self-overwriting hazard during checkout games).
+#
+# Environment knobs:
+#
+#   COUNT      -count= passed to `go test -bench` (default: 5).
+#   BENCH      -bench= regex passed to `go test` (default: .).
+#   BACKEND    "mock" (default) or "azure". Azure benchmarks require
+#              `make e2e-infra-setup` + `eval "$(make e2e-infra-env)"`
+#              first; pin E2E_AUTH for benchstat name stability.
+#   BENCHTIME  -benchtime= passed to `go test` (default: 1s for mock,
+#              10x for azure — each azure iteration is a real relay
+#              round-trip).
+#   ARTIFACTS  Optional directory to keep base.txt and head.txt; if
+#              unset, a mktemp dir is used and its path is printed on
+#              exit.
+
+set -euo pipefail
+
+BASE_REF=${1:?usage: $0 BASE_REF [HEAD_REF]}
+HEAD_REF=${2:-HEAD}
+
+COUNT=${COUNT:-5}
+BENCH=${BENCH:-.}
+BACKEND=${BACKEND:-mock}
+
+case "$BACKEND" in
+mock)
+  BENCHTIME=${BENCHTIME:-1s}
+  ;;
+azure)
+  BENCHTIME=${BENCHTIME:-10x}
+  ;;
+*)
+  echo "unknown BACKEND=$BACKEND (expected: mock, azure)" >&2
+  exit 1
+  ;;
+esac
+
+repo_root=$(git rev-parse --show-toplevel)
+cd "$repo_root"
+
+BASE_SHA=$(git rev-parse "$BASE_REF")
+HEAD_SHA=$(git rev-parse "$HEAD_REF")
+BASE_SHORT=$(git rev-parse --short "$BASE_SHA")
+HEAD_SHORT=$(git rev-parse --short "$HEAD_SHA")
+
+if [ -n "${ARTIFACTS:-}" ]; then
+  out_dir=$ARTIFACTS
+  mkdir -p "$out_dir"
+else
+  out_dir=$(mktemp -d -t aztunnel-bench.XXXXXX)
+fi
+
+work_root=$(mktemp -d -t aztunnel-bench-wt.XXXXXX)
+base_wt=$work_root/base
+head_wt=$work_root/head
+
+cleanup() {
+  for wt in "$base_wt" "$head_wt"; do
+    if [ -d "$wt" ]; then
+      git worktree remove --force "$wt" >/dev/null 2>&1 || true
+    fi
+  done
+  rmdir "$work_root" >/dev/null 2>&1 || true
+  echo "==> artifacts: $out_dir"
+}
+trap cleanup EXIT
+
+if ! command -v benchstat >/dev/null 2>&1; then
+  echo "==> installing benchstat"
+  GOBIN="$(go env GOPATH)/bin" go install golang.org/x/perf/cmd/benchstat@latest
+  PATH="$(go env GOPATH)/bin:$PATH"
+fi
+
+echo "==> adding worktree base@$BASE_SHORT"
+git worktree add --detach --quiet "$base_wt" "$BASE_SHA"
+echo "==> adding worktree head@$HEAD_SHORT"
+git worktree add --detach --quiet "$head_wt" "$HEAD_SHA"
+
+run_bench() {
+  local wt=$1
+  local out=$2
+  local label=$3
+  echo "==> running benchmarks @$label ($BACKEND backend, count=$COUNT, benchtime=$BENCHTIME)"
+  case "$BACKEND" in
+  mock)
+    (
+      cd "$wt/mockrelay"
+      go test -run='^$' -bench="$BENCH" -benchmem \
+        -count="$COUNT" -benchtime="$BENCHTIME" \
+        ./testharness/parity/...
+    ) | tee "$out"
+    ;;
+  azure)
+    (
+      cd "$wt"
+      go test -tags=e2e -run='^$' -bench="$BENCH" -benchmem \
+        -count="$COUNT" -benchtime="$BENCHTIME" -timeout=60m \
+        ./e2e/...
+    ) | tee "$out"
+    ;;
+  esac
+}
+
+run_bench "$base_wt" "$out_dir/base.txt" "$BASE_SHORT"
+run_bench "$head_wt" "$out_dir/head.txt" "$HEAD_SHORT"
+
+echo
+echo "==> benchstat $BASE_SHORT -> $HEAD_SHORT"
+benchstat "$out_dir/base.txt" "$out_dir/head.txt"


### PR DESCRIPTION
Closes #54

Adds `testing.B` benchmarks against the existing relay-parity scenario library so the connection-muxing work in PR #47 can be quantified with `benchstat`-compatible numbers.

## What this adds

Seven sub-benchmarks exposed via `relayparity.RunBenchSuite`, each running unmodified against both the in-process `MockBackend` (fast iteration, no Azure dependency) and the real `azureBackend` (source-of-truth numbers):

| Sub-bench | What it measures | Why it matters for #47 |
| --- | --- | --- |
| `ConnectLatency_Serial_PortForward` | Per-iter cost of one dial + 1-byte round-trip in port-forward mode | Headline metric — sequential connect latency |
| `ConnectLatency_Serial_SOCKS5` | Same in SOCKS5 mode | Confirms mux improvement applies on both data paths |
| `ConcurrentConnect_N100` | Wall time of 100 concurrent dials + 1-byte round-trip | Worst-case warmup behaviour |
| `ShortSessionRate_N1` | Open → 1 KB → read → close in tight loop, 1 sender | Sustained short-session throughput |
| `ShortSessionRate_N2` | Same with 2 senders | Probes whether multi-sender is a viable workaround for missing mux |
| `SteadyThroughput` | MB/s through one established connection (1 MB per iter, `b.SetBytes(1<<20)`) | Control variable — must NOT regress under mux |
| `ConnectFailureRate` | Of 500 concurrent dials per iter, error fraction (`b.ReportMetric(.., "fail%")`) | Regression guard for handshake stability |

## Running

```
make bench-compare BASE=<pre-47-sha> HEAD=<post-47-sha>
```

Or directly:

```
scripts/bench-compare.sh <pre-47-sha> <post-47-sha>
# env knobs:
#   BENCH=ConnectLatency_Serial   # benchmark pattern (default: .)
#   COUNT=5                        # -count for each run
#   BACKEND=mock|azure             # default: mock
#   BENCHTIME=1s                   # default: 1s mock, 10x azure
```

The script checks out each ref into a disposable `git worktree`, runs the suite at both, and feeds the two outputs to `benchstat`. The caller's working tree is untouched.

## Implementation notes

- `Backend.Setup`, `StartPlainEcho`, and the chain of e2e helpers that `azureBackend.Setup` transitively calls are widened from `*testing.T` to `testing.TB` so the same `Setup` is reachable from both `*testing.T` scenarios and `*testing.B` benchmarks. `Tunnel.AddListener` and `AssertNoLeaks` stay on `*testing.T` because no benchmark calls them.
- `ConcurrentConnect_N100` and `ConnectFailureRate` use a `skipIfFDLimitTooLow` guard that consults `RLIMIT_NOFILE` on Unix and is a no-op on Windows — keeps the package cross-compilable.
- The Azure entry point picks `auths[0]` deterministically rather than iterating, because running both auths doubles Azure runtime without adding benchmark signal.