### PR TITLE
fix(e2e/infra): bind context.Context as an interface so subcommands run

### DIFF
--- a/e2e/infra/cmd/e2e-infra/main.go
+++ b/e2e/infra/cmd/e2e-infra/main.go
@@ -231,17 +231,22 @@ func main() {
 }
 
 func run() int {
+	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer cancel()
+
 	cliCtx := kong.Parse(&CLI,
 		kong.Name("e2e-infra"),
 		kong.Description("Maintainer-facing setup CLI for aztunnel E2E test infrastructure."),
 		kong.UsageOnError(),
 		kong.ConfigureHelp(kong.HelpOptions{Compact: true}),
+		// BindTo (not Bind/Run-arg) is required for interface types: kong's
+		// runtime binding uses reflect.TypeOf, which on an interface value
+		// returns the concrete type, so binding via `cliCtx.Run(ctx)` would
+		// register the concrete *signalCtx rather than context.Context.
+		kong.BindTo(ctx, (*context.Context)(nil)),
 	)
 
-	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
-	defer cancel()
-
-	if err := cliCtx.Run(ctx); err != nil {
+	if err := cliCtx.Run(); err != nil {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)
 		return 1
 	}


### PR DESCRIPTION
## Summary

The E2E pipeline used to serialize every PR run behind a single `concurrency: e2e-tests` group because the two long-lived hybrid connections in the shared relay namespace (`e2e-entra`, `e2e-sas`) could only safely host one listener-sender pair at a time. Two concurrent runs would have routed each other's flows.

This PR moves the isolation boundary from the workflow scheduler to the hyco level: each `go test` invocation provisions its own pair of short-lived hybrid connections with unique names, and tears them down on exit. Concurrent PR pipelines can now share a single relay namespace without collisions, and the global serialization lock is gone.

## What contributors / maintainers see

- **PR pipelines run in parallel.** Force-pushes on the same PR still cancel superseded runs (per-ref `concurrency` group); different PRs no longer wait on each other.
- **No SAS keys in GitHub.** Listener and sender keys are minted on demand in `TestMain` and discarded afterward. The only secrets the workflow needs are `AZURE_CLIENT_ID`, `AZURE_TENANT_ID`, `AZURE_SUBSCRIPTION_ID` (already present for OIDC login).
- **No hyco names to configure.** `E2E_ENTRA_HYCO_NAME` / `E2E_SAS_HYCO_NAME` / `E2E_SAS_*_KEY*` are gone from the workflow env block. Contributors and CI both pass `E2E_RELAY_NAME`, `E2E_RESOURCE_GROUP`, and `AZURE_SUBSCRIPTION_ID`; everything else is provisioned at test-start.
- **Single setup tool.** Maintainer-facing setup is now a Go CLI under `e2e/infra/cmd/e2e-infra` (subcommands: `setup`, `ci`, `clean`, `grant`, `env`, `janitor`). All shell scripts and the per-module Makefile are removed. No `az`, `gh`, or `jq` shell-outs.
- **One RBAC role.** The CI service principal is granted the built-in `Azure Relay Owner` role at namespace scope, which covers both control plane (hyco / auth-rule CRUD, `ListKeys`) and data plane (Listen, Send). Replaces the prior `Azure Relay Listener` + `Sender` pair.
- **Daily janitor.** `.github/workflows/e2e-janitor.yml` reaps any per-invocation hycos older than 4 hours that were left behind by killed runners.

## Files of interest

- `e2e/azrelay/` — per-invocation hyco provisioner (Azure SDK, ARM).
- `e2e/testmain_test.go` — wires the provisioner into the suite. The 7-var `E2E_*` env contract is preserved verbatim, so `helpers_test.go` and every existing test are unchanged.
- `e2e/infra/` — separate Go module (sibling to `mockrelay`, registered in `go.work`) housing the maintainer CLI and the janitor library.
- `.github/workflows/e2e.yml` — drops the global `concurrency:` group in favor of a per-ref one, drops the SAS-key env block, adds `E2E_RESOURCE_GROUP`.
- `.github/workflows/e2e-janitor.yml` — new daily cron.
- `e2e/README.md` — rewritten to reflect the new flow.

## Migration notes for maintainers

Before merging:

1. Re-run `make e2e-infra-ci` once to upgrade the CI service principal to `Azure Relay Owner` and refresh the GitHub environment variables (`E2E_RELAY_NAME`, `E2E_RESOURCE_GROUP`) and secrets (`AZURE_CLIENT_ID`, `AZURE_TENANT_ID`, `AZURE_SUBSCRIPTION_ID`).
2. The legacy static `e2e-entra` / `e2e-sas` hybrid connections and the `e2e-listener` / `e2e-sender` SAS auth rules can be deleted; they are no longer used. The janitor regex is anchored and will not touch them.

Local contributors run `eval "$(make e2e-infra-env)"` before `make e2e`; the suite prints a prominent warning if it's invoked without a relay configured so all-skipped runs aren't mistaken for all-passing.
