### PR TITLE
fix(ci): let azure/login succeed for SP without subscription-level RBAC

### DIFF
--- a/.github/workflows/e2e-janitor.yml
+++ b/.github/workflows/e2e-janitor.yml
@@ -39,7 +39,17 @@ jobs:
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
-          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+          # The CI service principal has resource-scoped RBAC on the
+          # relay namespace but no subscription-level Reader, so
+          # `az login` (which enumerates subscriptions via ARM) fails
+          # with "No subscriptions found". `allow-no-subscriptions`
+          # lets `az login` succeed tenant-only, and `subscription-id`
+          # is omitted because azure/login would otherwise run
+          # `az account set --subscription <id>` against an empty
+          # local cache, which also fails. AZURE_SUBSCRIPTION_ID is
+          # still passed explicitly to the ARM clients via the
+          # janitor step's `env:` block below.
+          allow-no-subscriptions: true
 
       - name: Run janitor
         env:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -35,7 +35,17 @@ jobs:
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
-          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+          # The CI service principal has resource-scoped RBAC on the
+          # relay namespace but no subscription-level Reader, so
+          # `az login` (which enumerates subscriptions via ARM) fails
+          # with "No subscriptions found". `allow-no-subscriptions`
+          # lets `az login` succeed tenant-only, and `subscription-id`
+          # is omitted because azure/login would otherwise run
+          # `az account set --subscription <id>` against an empty
+          # local cache, which also fails. AZURE_SUBSCRIPTION_ID is
+          # still passed explicitly to the ARM clients via the test
+          # step's `env:` block below.
+          allow-no-subscriptions: true
 
       - name: Build
         run: make build


### PR DESCRIPTION
The `e2e` CI check has been failing on every PR since 2026-05-18 ~13:00Z with:

```
Attempting Azure CLI login by using OIDC...
##[error]No subscriptions found for ***.
##[error]Login failed with Error: The process '/usr/bin/az' failed with exit code 1.
```

## Root cause

The CI service principal has resource-scoped RBAC on the Azure Relay namespace but no subscription-level role. `azure/login@v3` calls `az login`, which enumerates subscriptions via ARM `/subscriptions` and exits with `No subscriptions found` when that list is empty. The login step never completes — so every `e2e` run is red, and the scheduled `E2E Janitor` would hit the same failure.

## Fix

Two changes to the `azure/login@v3` step in both `.github/workflows/e2e.yml` and `.github/workflows/e2e-janitor.yml`:

1. Add `allow-no-subscriptions: true` so `az login` succeeds tenant-only when no subs are visible.
2. Drop `subscription-id`. With tenant-only login the real subscription is not in the local CLI cache, so the action's unconditional follow-up `az account set --subscription <id>` (`Cli/AzureCliLogin.ts:138-148`) would otherwise fail with "doesn't exist in cloud" (verified against `azure-cli/_profile.py:564-575`).

`AZURE_SUBSCRIPTION_ID` is still passed explicitly via the downstream `Run E2E Tests` / `Run janitor` step's `env:` block — that is the only place the Go ARM client constructors (`armrelay.NewHybridConnectionsClient`, `armresources.NewResourceGroupsClient`, `armrelay.NewNamespacesClient`, `armauthorization.NewRoleAssignmentsClient`) consume it.

The Go credential chain (`azidentity.NewDefaultAzureCredential`) falls through to `AzureCLICredential`, which calls `az account get-access-token` against the tenant-only CLI session. That returns an ARM token bound to the tenant — usable against the SP's resource-scoped RBAC on the relay namespace.

## Verification

- `make build`, `make test`, `make lint`, `make fmt-check` all pass locally.
- The real proof is the `e2e` check on this PR — that is the whole point of the fix.