### PR TITLE
feat(e2e): per-test hybrid-connection isolation

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -1,9 +1,9 @@
 # End-to-End Tests
 
 These tests verify aztunnel against a real Azure Relay. They are gated behind
-the `e2e` build tag. Each test provisions its own pair of ephemeral hybrid
-connections in the configured relay namespace and tears them down via
-`t.Cleanup`, so tests run with `t.Parallel()` (concurrency capped by
+the `e2e` build tag. Each Azure-dependent test provisions its own pair of
+ephemeral hybrid connections in the configured relay namespace and tears them
+down via `t.Cleanup`, so tests run with `t.Parallel()` (concurrency capped by
 `E2E_PROVISIONER_CONCURRENCY`, default 4) and concurrent `go test` pipelines
 do not collide.
 
@@ -50,9 +50,13 @@ reaps anything left behind by killed runners.
 
 Authentication is via `DefaultAzureCredential`: `az login` for local
 development, OIDC federated workload identity for GitHub Actions. No SAS
-listener/sender keys need to be configured by hand — the `azrelay.Provider`
-mints them on the fly via `Microsoft.Relay/...ListKeys` for every test's
-fresh pair and tears them down on scenario cleanup.
+listener/sender keys need to be configured by hand — `TestMain` acquires
+two namespace-scoped authorization rules once per `go test` invocation
+(`e2e-run-<hex>-listener` for `Listen` and `e2e-run-<hex>-sender` for
+`Send`) via `azrelay.AcquireRunRules`, reads their keys via
+`Microsoft.Relay/...ListKeys`, and reuses them across every per-test SAS
+hyco. The rules are torn down on `TestMain` exit; the orphan janitor
+reaps anything left behind.
 
 ## Test Scenarios
 
@@ -132,14 +136,14 @@ out to no external tooling (no `az`, no `gh`, no `jq`).
 
 ### CLI Subcommands
 
-| Make target         | CLI subcommand                                 | Purpose                                                         |
-| ------------------- | ---------------------------------------------- | --------------------------------------------------------------- |
-| `e2e-infra-setup`   | `e2e-infra setup`                              | Create RG + namespace + grant yourself `Azure Relay Owner`.     |
-| `e2e-infra-ci`      | `e2e-infra ci`                                 | Above + Entra app + federated credential + GitHub secrets.      |
-| `e2e-infra-clean`   | `e2e-infra clean --yes`                        | Delete the resource group (and everything in it).               |
-| `e2e-infra-env`     | `e2e-infra env`                                | Print `export` statements for `E2E_*` and `AZURE_*` vars.       |
-| `e2e-infra-janitor` | `e2e-infra janitor [--max-age 4h] [--dry-run]` | Delete orphan `e2e-{entra,sas}-<hex>` hycos older than max-age. |
-| (none)              | `e2e-infra grant --self\|--user\|--sp …`       | Grant `Azure Relay Owner` to a principal.                       |
+| Make target         | CLI subcommand                                 | Purpose                                                                                                     |
+| ------------------- | ---------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
+| `e2e-infra-setup`   | `e2e-infra setup`                              | Create RG + namespace + grant yourself `Azure Relay Owner`.                                                 |
+| `e2e-infra-ci`      | `e2e-infra ci`                                 | Above + Entra app + federated credential + GitHub secrets.                                                  |
+| `e2e-infra-clean`   | `e2e-infra clean --yes`                        | Delete the resource group (and everything in it).                                                           |
+| `e2e-infra-env`     | `e2e-infra env`                                | Print `export` statements for `E2E_*` and `AZURE_*` vars.                                                   |
+| `e2e-infra-janitor` | `e2e-infra janitor [--max-age 4h] [--dry-run]` | Delete orphan `e2e-{entra,sas}-<hex>` hycos AND `e2e-run-<hex>-{listener,sender}` rules older than max-age. |
+| (none)              | `e2e-infra grant --self\|--user\|--sp …`       | Grant `Azure Relay Owner` to a principal.                                                                   |
 
 ### Environment Variable Overrides
 
@@ -238,13 +242,30 @@ az ad app delete --id "$APP_ID"
 PR pipelines no longer use a workflow `concurrency` group, because
 collisions between concurrent invocations are eliminated at the hyco level:
 
-- Each test (and each shared benchmark lease) generates a fresh suffix and
-  creates `e2e-entra-<suffix>` + `e2e-sas-<suffix>` via `azrelay.Provider`
-  in `TestMain`. `t.Parallel()` tests run with their hyco lifetime scoped
-  to a single `t.Cleanup`.
+- `TestMain` constructs the shared `azrelay.Provider` once. Each test
+  (and the shared benchmark lease) calls `Provider.Provision`, which
+  generates a fresh suffix and creates `e2e-entra-<suffix>` +
+  `e2e-sas-<suffix>`. `t.Parallel()` tests run with their hyco
+  lifetime scoped to a single `t.Cleanup`.
 - Static hyco names from prior versions (`e2e-entra`, `e2e-sas`) are no
   longer required and are intentionally not provisioned by the new setup.
 - Hyco names are matched against `^e2e-(entra|sas)-[0-9a-f]{12}$` for the
   janitor, so any unrelated hycos in the namespace are not touched.
+- SAS authorization rules live at **namespace scope**, not per hyco: each
+  `go test` invocation provisions two rules
+  (`e2e-run-<hex>-listener` with Listen-only, `e2e-run-<hex>-sender` with
+  Send-only) once in `TestMain` via `azrelay.AcquireRunRules` and tears
+  them down on exit. Every per-test hyco signs SAS tokens with these
+  run-scoped keys. The two-rule split preserves the contract that a
+  listener key cannot send and vice versa
+  (asserted by `TestWrongSASClaim`).
+- Run rules are matched against `^e2e-run-[0-9a-f]{12}-(listener|sender)$`
+  for the janitor, which sweeps orphaned rules with the same `--max-age`
+  rule as orphaned hycos.
+- Azure Relay caps authorization rules at 12 per namespace, and the
+  default `RootManageSharedAccessKey` rule consumes one of those
+  slots, so the two-rule-per-run design supports up to five
+  concurrent `go test` invocations in the same namespace before the
+  cap bites.
 - The relay namespace itself is shared across pipelines; only hybrid
-  connections (and their SAS auth rules) are per-test.
+  connections are per-test and authorization rules are per-`go test`-run.

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -1,9 +1,11 @@
 # End-to-End Tests
 
 These tests verify aztunnel against a real Azure Relay. They are gated behind
-the `e2e` build tag. Each `go test` invocation provisions its own pair of
-ephemeral hybrid connections in the configured relay namespace, so concurrent
-pipelines (or `make e2e` runs) do not collide.
+the `e2e` build tag. Each test provisions its own pair of ephemeral hybrid
+connections in the configured relay namespace and tears them down via
+`t.Cleanup`, so tests run with `t.Parallel()` (concurrency capped by
+`E2E_PROVISIONER_CONCURRENCY`, default 4) and concurrent `go test` pipelines
+do not collide.
 
 ## Quick Start
 
@@ -18,32 +20,39 @@ make e2e
 make e2e-infra-ci
 ```
 
-`AZURE_SUBSCRIPTION_ID` falls back to the Azure CLI's default subscription
-(`~/.azure/azureProfile.json`) if unset, so `az login` alone is enough for
-most contributors. Set it explicitly if you have multiple subscriptions
-and don't want to rely on the CLI's default.
+`AZURE_SUBSCRIPTION_ID` must be set when `TestMain` constructs the relay
+`Provider`. `make e2e-infra-env` resolves it from the Azure CLI's default
+subscription (`~/.azure/azureProfile.json`) so `az login` plus
+`eval "$(make e2e-infra-env)"` is enough for most contributors. Set it
+explicitly if you have multiple subscriptions and don't want to rely on
+the CLI's default.
 
-`TestMain` creates two short-lived hybrid connections —
-`e2e-entra-<hex>` for Entra-ID auth and `e2e-sas-<hex>` for SAS-key auth —
-and tears them down on exit. The orphan janitor workflow
-(`.github/workflows/e2e-janitor.yml`) reaps anything left behind by killed
-runners.
+`TestMain` constructs a process-scoped `azrelay.Provider` that hands out
+freshly-suffixed pairs (`e2e-entra-<hex>` for Entra ID auth and
+`e2e-sas-<hex>` for SAS-key auth) to each test via `requireDedicatedHyco`.
+Tests register a `t.Cleanup` that tears their pair down at the end of the
+scenario. Benchmarks instead share a single pair leased on first use and
+drained on `TestMain` exit, so benchstat runs do not pay per-sub-bench
+provisioning. The orphan janitor workflow (`.github/workflows/e2e-janitor.yml`)
+reaps anything left behind by killed runners.
 
 ## Environment Variables
 
-| Variable                | Required | Description                                                                |
-| ----------------------- | -------- | -------------------------------------------------------------------------- |
-| `E2E_RELAY_NAME`        | Yes      | Azure Relay namespace name                                                 |
-| `E2E_RESOURCE_GROUP`    | Yes      | Resource group containing the relay namespace                              |
-| `AZURE_SUBSCRIPTION_ID` | No       | Subscription used to provision per-invocation hycos; defaults to Azure CLI |
-| `E2E_AUTH`              | No       | `entra`, `sas`, or both (default)                                          |
-| `E2E_LARGE_TRANSFER`    | No       | Set to `1` to enable 100MB bulk transfer                                   |
-| `E2E_LONG_LIVED`        | No       | Set to `1` to enable >2 min keepalive test                                 |
+| Variable                      | Required | Description                                                            |
+| ----------------------------- | -------- | ---------------------------------------------------------------------- |
+| `E2E_RELAY_NAME`              | Yes      | Azure Relay namespace name                                             |
+| `E2E_RESOURCE_GROUP`          | Yes      | Resource group containing the relay namespace                          |
+| `AZURE_SUBSCRIPTION_ID`       | Yes      | Subscription used to provision per-test hycos                          |
+| `E2E_AUTH`                    | No       | `entra`, `sas`, or both (default)                                      |
+| `E2E_PROVISIONER_CONCURRENCY` | No       | Cap on in-flight hyco provisions across `t.Parallel` tests (default 4) |
+| `E2E_LARGE_TRANSFER`          | No       | Set to `1` to enable 100MB bulk transfer                               |
+| `E2E_LONG_LIVED`              | No       | Set to `1` to enable >2 min keepalive test                             |
 
 Authentication is via `DefaultAzureCredential`: `az login` for local
 development, OIDC federated workload identity for GitHub Actions. No SAS
-listener/sender keys need to be configured by hand — `TestMain` mints them
-on the fly via `Microsoft.Relay/...ListKeys` and tears them down on exit.
+listener/sender keys need to be configured by hand — the `azrelay.Provider`
+mints them on the fly via `Microsoft.Relay/...ListKeys` for every test's
+fresh pair and tears them down on scenario cleanup.
 
 ## Test Scenarios
 
@@ -207,10 +216,11 @@ cd e2e/infra && GITHUB_TOKEN=$(gh auth token) go run ./cmd/e2e-infra ci --depend
 - **During tests**: fractions of a penny (pro-rated per listener-hour, ~$0.014/hr)
 - **Monthly**: $0 if only used for CI runs
 
-Healthy `make e2e` invocations clean up their hybrid connections in
-`TestMain`. A daily `E2E Janitor` workflow (`make e2e-infra-janitor`)
-reaps orphans left behind by killed runners or panicking tests, so the
-namespace does not accumulate billable resources over time.
+Healthy `make e2e` invocations clean up their hybrid connections via
+`t.Cleanup` registered by `requireDedicatedHyco`. A daily `E2E Janitor`
+workflow (`make e2e-infra-janitor`) reaps orphans left behind by killed
+runners or panicking tests, so the namespace does not accumulate billable
+resources over time.
 
 ### Tear Down
 
@@ -228,11 +238,13 @@ az ad app delete --id "$APP_ID"
 PR pipelines no longer use a workflow `concurrency` group, because
 collisions between concurrent invocations are eliminated at the hyco level:
 
-- Each `go test` binary invocation generates a fresh suffix and creates
-  `e2e-entra-<suffix>` + `e2e-sas-<suffix>` in `TestMain`.
+- Each test (and each shared benchmark lease) generates a fresh suffix and
+  creates `e2e-entra-<suffix>` + `e2e-sas-<suffix>` via `azrelay.Provider`
+  in `TestMain`. `t.Parallel()` tests run with their hyco lifetime scoped
+  to a single `t.Cleanup`.
 - Static hyco names from prior versions (`e2e-entra`, `e2e-sas`) are no
   longer required and are intentionally not provisioned by the new setup.
 - Hyco names are matched against `^e2e-(entra|sas)-[0-9a-f]{12}$` for the
   janitor, so any unrelated hycos in the namespace are not touched.
 - The relay namespace itself is shared across pipelines; only hybrid
-  connections (and their SAS auth rules) are per-invocation.
+  connections (and their SAS auth rules) are per-test.

--- a/e2e/azrelay/provider.go
+++ b/e2e/azrelay/provider.go
@@ -1,0 +1,240 @@
+package azrelay
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/relay/armrelay"
+)
+
+// DefaultProvisionerConcurrency caps the number of in-flight Provision
+// calls a Provider runs concurrently. Each provision performs ~6 ARM
+// round-trips against the same namespace; running many in parallel
+// invites the namespace-level 429 throttling envelope. Empirically a
+// concurrency of 4 stays well clear of the threshold while still
+// overlapping enough provisioning to hide the ARM tail in test-body
+// time when the e2e suite runs with -parallel=GOMAXPROCS.
+//
+// Override at the call site by setting Config.Concurrency.
+const DefaultProvisionerConcurrency = 4
+
+// DefaultARMMaxRetries widens azcore's default 3 retries to 6 for
+// transient 429s and 5xx on the per-test provisioning path. The SDK's
+// retry policy already honours `Retry-After` headers when present, so
+// 6 attempts comfortably absorbs a brief namespace-level throttling
+// burst (~Retry-After=30s × 6 = ~3 min total budget) without us
+// stacking an outer retry loop that would fight the SDK's own backoff.
+const DefaultARMMaxRetries = 6
+
+// DefaultARMMaxRetryDelay caps any single SDK-managed retry delay.
+// azcore's default is already 60 s; we set it explicitly so it stays
+// visible if a future SDK release changes the default.
+const DefaultARMMaxRetryDelay = 60 * time.Second
+
+// Provider creates fresh hybrid-connection pairs on demand. Safe for
+// concurrent use by multiple goroutines: ARM operations are gated by
+// an internal semaphore so a swarm of t.Parallel tests cannot stampede
+// the relay control plane.
+//
+// Construct one with NewProvider, then call Provision per test. Each
+// successful call returns a single-use PairToken whose Teardown must
+// be invoked (typically via t.Cleanup) to release the underlying
+// Azure resources.
+type Provider struct {
+	cfg   Config
+	cred  azcore.TokenCredential
+	hycos *armrelay.HybridConnectionsClient
+	sem   chan struct{}
+}
+
+// NewProvider builds a Provider bound to cfg. It performs no Azure
+// I/O — the ARM client is constructed eagerly but no requests are
+// issued until the first Provision call.
+//
+// If cfg.Cred is nil, NewProvider constructs a DefaultAzureCredential.
+// If cfg.ClientOptions is nil, NewProvider applies a per-test-tuned
+// retry policy (DefaultARMMaxRetries / DefaultARMMaxRetryDelay) so
+// transient 429s are absorbed by the SDK pipeline.
+// If cfg.Concurrency is zero, DefaultProvisionerConcurrency is used.
+func NewProvider(cfg Config) (*Provider, error) {
+	if err := cfg.validate(); err != nil {
+		return nil, err
+	}
+	cred := cfg.Cred
+	if cred == nil {
+		c, err := azidentity.NewDefaultAzureCredential(nil)
+		if err != nil {
+			return nil, fmt.Errorf("default azure credential: %w", err)
+		}
+		cred = c
+	}
+	opts := cfg.ClientOptions
+	if opts == nil {
+		opts = DefaultClientOptions()
+	}
+	hycos, err := armrelay.NewHybridConnectionsClient(cfg.SubscriptionID, cred, opts)
+	if err != nil {
+		return nil, fmt.Errorf("new hybrid connections client: %w", err)
+	}
+	conc := cfg.Concurrency
+	if conc <= 0 {
+		conc = DefaultProvisionerConcurrency
+	}
+	return &Provider{
+		cfg:   cfg,
+		cred:  cred,
+		hycos: hycos,
+		sem:   make(chan struct{}, conc),
+	}, nil
+}
+
+// DefaultClientOptions returns the arm.ClientOptions used by NewProvider
+// when Config.ClientOptions is nil. Exported so callers building their
+// own ClientOptions (e.g. with a custom user-agent or test-only HTTP
+// transport) can layer their tweaks on top of the per-test-tuned
+// retry policy.
+func DefaultClientOptions() *arm.ClientOptions {
+	return &arm.ClientOptions{
+		ClientOptions: policy.ClientOptions{
+			Retry: policy.RetryOptions{
+				MaxRetries:    DefaultARMMaxRetries,
+				MaxRetryDelay: DefaultARMMaxRetryDelay,
+			},
+		},
+	}
+}
+
+// Provision creates a fresh (entra, sas) hybrid-connection pair using
+// the same sequence as Provisioner.Provision: create entra hyco,
+// create sas hyco, attach Listen + Send authorization rules to the
+// sas hyco, read both SAS keys, and let the data plane settle. The
+// returned PairToken's Teardown method releases both hycos.
+//
+// Provision blocks if the concurrency semaphore is full. The block
+// honours ctx.Done so callers (typically t.Cleanup-registered)
+// observe cancellation.
+//
+// If Provision returns an error, the caller does not need to call
+// Teardown — partial state is cleaned up best-effort internally.
+func (p *Provider) Provision(ctx context.Context) (*PairToken, error) {
+	if err := p.acquire(ctx); err != nil {
+		return nil, err
+	}
+	defer p.release()
+
+	suffix, err := newSuffix()
+	if err != nil {
+		return nil, fmt.Errorf("generate suffix: %w", err)
+	}
+	inner := &Provisioner{
+		cfg:    p.cfg,
+		hycos:  p.hycos,
+		suffix: suffix,
+	}
+	result, err := inner.Provision(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return &PairToken{
+		provider: p,
+		result:   result,
+		suffix:   suffix,
+		deleteFn: func(ctx context.Context, name string) error {
+			_, err := p.hycos.Delete(ctx, p.cfg.ResourceGroup, p.cfg.Namespace, name, nil)
+			return err
+		},
+	}, nil
+}
+
+func (p *Provider) acquire(ctx context.Context) error {
+	select {
+	case p.sem <- struct{}{}:
+		return nil
+	case <-ctx.Done():
+		return fmt.Errorf("waiting for provisioner concurrency slot: %w", ctx.Err())
+	}
+}
+
+func (p *Provider) release() {
+	<-p.sem
+}
+
+// PairToken represents one successfully provisioned hyco pair. It is
+// single-use: a second Teardown call returns the same error as the
+// first without re-issuing any ARM Delete requests.
+type PairToken struct {
+	provider *Provider
+	result   *Result
+	suffix   string
+
+	// deleteFn issues a single ARM Delete against the named hyco.
+	// Provider.Provision populates this with a closure over the
+	// shared *armrelay.HybridConnectionsClient; tests override it to
+	// drive Teardown without ARM I/O.
+	deleteFn func(ctx context.Context, name string) error
+
+	teardownOnce sync.Once
+	teardownErr  error
+}
+
+// Result returns the connection metadata for this pair. Never nil for
+// a token returned by a successful Provision call.
+func (t *PairToken) Result() *Result {
+	return t.result
+}
+
+// HycoNames returns the (entra, sas) names this token holds. Useful
+// for log messages.
+func (t *PairToken) HycoNames() (entra, sas string) {
+	return "e2e-entra-" + t.suffix, "e2e-sas-" + t.suffix
+}
+
+// Teardown deletes both hybrid connections. Safe to call multiple
+// times: only the first call performs the deletes; subsequent calls
+// return the same error.
+//
+// Teardown uses a fresh context derived from ctx (via
+// context.WithoutCancel) so cleanup completes even when ctx has been
+// cancelled (e.g. on test timeout).
+//
+// When the token was created by Provider.Provision (i.e. provider
+// and deleteFn are non-nil) Teardown also acquires the provider's
+// concurrency slot for the duration of the ARM Delete calls so a
+// wave of test cleanups cannot stampede the relay control plane and
+// exhaust the namespace 429 envelope. If the slot acquire fails
+// (e.g. the detached context's 60s budget expires while the sem is
+// saturated) Teardown proceeds without the slot rather than orphan
+// the hyco — the janitor will reap anything we leak.
+//
+// Individual delete failures are joined and returned. The janitor
+// will also reap anything we can't clean up here.
+func (t *PairToken) Teardown(ctx context.Context) error {
+	t.teardownOnce.Do(func() {
+		ctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 60*time.Second)
+		defer cancel()
+		if t.provider != nil {
+			if err := t.provider.acquire(ctx); err == nil {
+				defer t.provider.release()
+			}
+		}
+		var errs []error
+		entra, sas := t.HycoNames()
+		if err := t.deleteFn(ctx, entra); err != nil {
+			errs = append(errs, fmt.Errorf("delete %s: %w", entra, err))
+		}
+		if err := t.deleteFn(ctx, sas); err != nil {
+			errs = append(errs, fmt.Errorf("delete %s: %w", sas, err))
+		}
+		if len(errs) > 0 {
+			t.teardownErr = errors.Join(errs...)
+		}
+	})
+	return t.teardownErr
+}

--- a/e2e/azrelay/provider.go
+++ b/e2e/azrelay/provider.go
@@ -58,6 +58,11 @@ type Provider struct {
 // I/O — the ARM client is constructed eagerly but no requests are
 // issued until the first Provision call.
 //
+// cfg.RunRules must be non-nil — call AcquireRunRules first to
+// populate it (TestMain pattern). Per-pair Provision does not create
+// SAS rules; it stamps RunRules.{Listener,Sender}{Name,Key} onto every
+// PairToken Result.
+//
 // If cfg.Cred is nil, NewProvider constructs a DefaultAzureCredential.
 // If cfg.ClientOptions is nil, NewProvider applies a per-test-tuned
 // retry policy (DefaultARMMaxRetries / DefaultARMMaxRetryDelay) so
@@ -66,6 +71,9 @@ type Provider struct {
 func NewProvider(cfg Config) (*Provider, error) {
 	if err := cfg.validate(); err != nil {
 		return nil, err
+	}
+	if cfg.RunRules == nil {
+		return nil, errors.New("azrelay.Config.RunRules is required (call AcquireRunRules first)")
 	}
 	cred := cfg.Cred
 	if cred == nil {
@@ -111,11 +119,12 @@ func DefaultClientOptions() *arm.ClientOptions {
 	}
 }
 
-// Provision creates a fresh (entra, sas) hybrid-connection pair using
-// the same sequence as Provisioner.Provision: create entra hyco,
-// create sas hyco, attach Listen + Send authorization rules to the
-// sas hyco, read both SAS keys, and let the data plane settle. The
-// returned PairToken's Teardown method releases both hycos.
+// Provision creates a fresh (entra, sas) hybrid-connection pair via
+// Provisioner: create entra hyco, create sas hyco. The returned
+// PairToken's Result is stamped with the namespace-scoped SAS rule
+// key info from p.cfg.RunRules. Teardown deletes both hycos; the
+// shared run-scoped rules live on past every PairToken and are
+// torn down by RunRules.Teardown from TestMain.
 //
 // Provision blocks if the concurrency semaphore is full. The block
 // honours ctx.Done so callers (typically t.Cleanup-registered)
@@ -148,6 +157,9 @@ func (p *Provider) Provision(ctx context.Context) (*PairToken, error) {
 		suffix:   suffix,
 		deleteFn: func(ctx context.Context, name string) error {
 			_, err := p.hycos.Delete(ctx, p.cfg.ResourceGroup, p.cfg.Namespace, name, nil)
+			if err != nil && isNotFound(err) {
+				return nil
+			}
 			return err
 		},
 	}, nil
@@ -214,8 +226,10 @@ func (t *PairToken) HycoNames() (entra, sas string) {
 // wave of test cleanups cannot stampede the relay control plane and
 // exhaust the namespace 429 envelope. If the slot acquire fails
 // (e.g. the deadline expires while the sem is saturated) Teardown
-// proceeds without the slot rather than orphan the hyco — the
-// janitor will reap anything we leak.
+// still attempts the deletes without the slot rather than skip them
+// outright; in that case the deadline is already past, so the
+// deletes will most likely also fail and the hycos will leak. The
+// janitor reaps anything left behind.
 //
 // Individual delete failures are joined and returned. The janitor
 // will also reap anything we can't clean up here.

--- a/e2e/azrelay/provider.go
+++ b/e2e/azrelay/provider.go
@@ -200,24 +200,28 @@ func (t *PairToken) HycoNames() (entra, sas string) {
 // times: only the first call performs the deletes; subsequent calls
 // return the same error.
 //
-// Teardown uses a fresh context derived from ctx (via
-// context.WithoutCancel) so cleanup completes even when ctx has been
-// cancelled (e.g. on test timeout).
+// Teardown strips cancellation from ctx (via context.WithoutCancel)
+// so cleanup completes even when the test's ctx has been cancelled
+// (e.g. on test timeout), but it preserves any deadline the caller
+// set so the cleanup budget is what the caller declared. If ctx has
+// no deadline, Teardown applies a defensive 60s ceiling so a stuck
+// control plane cannot hang the run indefinitely; callers wanting a
+// longer budget must pass a context with that deadline themselves.
 //
 // When the token was created by Provider.Provision (i.e. provider
 // and deleteFn are non-nil) Teardown also acquires the provider's
 // concurrency slot for the duration of the ARM Delete calls so a
 // wave of test cleanups cannot stampede the relay control plane and
 // exhaust the namespace 429 envelope. If the slot acquire fails
-// (e.g. the detached context's 60s budget expires while the sem is
-// saturated) Teardown proceeds without the slot rather than orphan
-// the hyco — the janitor will reap anything we leak.
+// (e.g. the deadline expires while the sem is saturated) Teardown
+// proceeds without the slot rather than orphan the hyco — the
+// janitor will reap anything we leak.
 //
 // Individual delete failures are joined and returned. The janitor
 // will also reap anything we can't clean up here.
 func (t *PairToken) Teardown(ctx context.Context) error {
 	t.teardownOnce.Do(func() {
-		ctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 60*time.Second)
+		ctx, cancel := detachAndBoundContext(ctx, 60*time.Second)
 		defer cancel()
 		if t.provider != nil {
 			if err := t.provider.acquire(ctx); err == nil {
@@ -237,4 +241,20 @@ func (t *PairToken) Teardown(ctx context.Context) error {
 		}
 	})
 	return t.teardownErr
+}
+
+// detachAndBoundContext returns a context that ignores ctx's
+// cancellation but preserves ctx's deadline. If ctx has no deadline
+// the returned context applies fallback as the deadline so callers
+// passing context.Background() still get a hang ceiling. Used by
+// Teardown / Provisioner.Teardown to decouple cleanup from the
+// caller's cancellation (so test timeouts don't abort cleanup) while
+// still honouring an explicit cleanup budget the caller wired in.
+func detachAndBoundContext(ctx context.Context, fallback time.Duration) (context.Context, context.CancelFunc) {
+	deadline, ok := ctx.Deadline()
+	ctx = context.WithoutCancel(ctx)
+	if ok {
+		return context.WithDeadline(ctx, deadline)
+	}
+	return context.WithTimeout(ctx, fallback)
 }

--- a/e2e/azrelay/provider_test.go
+++ b/e2e/azrelay/provider_test.go
@@ -1,0 +1,319 @@
+package azrelay
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"sort"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+)
+
+func TestNewProvider_RejectsBadConfig(t *testing.T) {
+	cases := []struct {
+		name string
+		cfg  Config
+		want string
+	}{
+		{"missing subscription", Config{ResourceGroup: "rg", Namespace: "ns"}, "SubscriptionID"},
+		{"missing resource group", Config{SubscriptionID: "sub", Namespace: "ns"}, "ResourceGroup"},
+		{"missing namespace", Config{SubscriptionID: "sub", ResourceGroup: "rg"}, "Namespace"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := NewProvider(tc.cfg)
+			if err == nil {
+				t.Fatalf("NewProvider: expected error containing %q, got nil", tc.want)
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("NewProvider: error %q does not contain %q", err.Error(), tc.want)
+			}
+		})
+	}
+}
+
+func TestNewProvider_DefaultsConcurrencyAndClientOptions(t *testing.T) {
+	p, err := NewProvider(Config{
+		SubscriptionID: "sub",
+		ResourceGroup:  "rg",
+		Namespace:      "ns",
+		Cred:           stubCred{},
+	})
+	if err != nil {
+		t.Fatalf("NewProvider: %v", err)
+	}
+	if cap(p.sem) != DefaultProvisionerConcurrency {
+		t.Errorf("sem cap = %d, want default %d", cap(p.sem), DefaultProvisionerConcurrency)
+	}
+}
+
+func TestNewProvider_HonoursExplicitConcurrency(t *testing.T) {
+	p, err := NewProvider(Config{
+		SubscriptionID: "sub",
+		ResourceGroup:  "rg",
+		Namespace:      "ns",
+		Cred:           stubCred{},
+		Concurrency:    2,
+	})
+	if err != nil {
+		t.Fatalf("NewProvider: %v", err)
+	}
+	if cap(p.sem) != 2 {
+		t.Errorf("sem cap = %d, want 2", cap(p.sem))
+	}
+}
+
+func TestDefaultClientOptions_AppliesTunedRetryPolicy(t *testing.T) {
+	opts := DefaultClientOptions()
+	if opts == nil {
+		t.Fatal("DefaultClientOptions returned nil")
+	}
+	if got := opts.Retry.MaxRetries; got != DefaultARMMaxRetries {
+		t.Errorf("Retry.MaxRetries = %d, want %d", got, DefaultARMMaxRetries)
+	}
+	if got := opts.Retry.MaxRetryDelay; got != DefaultARMMaxRetryDelay {
+		t.Errorf("Retry.MaxRetryDelay = %v, want %v", got, DefaultARMMaxRetryDelay)
+	}
+}
+
+// TestProvider_AcquireRespectsConcurrencyLimit asserts that acquire
+// returns immediately while the semaphore has slack and blocks once
+// the limit is reached. The test does not invoke any ARM operations
+// — it drives the semaphore directly through acquire/release so it
+// exercises the bounding behaviour without needing a stub for ARM.
+func TestProvider_AcquireRespectsConcurrencyLimit(t *testing.T) {
+	p := &Provider{sem: make(chan struct{}, 2)}
+	ctx := t.Context()
+
+	if err := p.acquire(ctx); err != nil {
+		t.Fatalf("acquire 1: %v", err)
+	}
+	if err := p.acquire(ctx); err != nil {
+		t.Fatalf("acquire 2: %v", err)
+	}
+
+	// A third acquire must block until a slot is released. Drive that
+	// by attempting acquire with a deadline shorter than any plausible
+	// scheduler delay and expecting the deadline to fire.
+	deadline, cancel := context.WithTimeout(ctx, 50*time.Millisecond)
+	defer cancel()
+	err := p.acquire(deadline)
+	if err == nil {
+		t.Fatal("acquire 3 with full semaphore should have blocked until ctx deadline")
+	}
+	if !strings.Contains(err.Error(), "concurrency slot") {
+		t.Errorf("acquire 3 err = %v; want a wrap mentioning 'concurrency slot'", err)
+	}
+
+	// Release one slot and a fresh acquire must succeed.
+	p.release()
+	if err := p.acquire(ctx); err != nil {
+		t.Fatalf("acquire after release: %v", err)
+	}
+}
+
+// TestProvider_AcquireSerialisesBeyondCap drives 8 concurrent acquire
+// calls against a cap-2 semaphore and asserts the peak in-flight count
+// never exceeds the cap. Surfaces a bug where the semaphore is sized
+// or used incorrectly more reliably than a single-goroutine test.
+func TestProvider_AcquireSerialisesBeyondCap(t *testing.T) {
+	const cap = 2
+	const goroutines = 8
+	p := &Provider{sem: make(chan struct{}, cap)}
+
+	var inflight atomic.Int64
+	var peak atomic.Int64
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer wg.Done()
+			if err := p.acquire(t.Context()); err != nil {
+				t.Errorf("acquire: %v", err)
+				return
+			}
+			cur := inflight.Add(1)
+			for {
+				old := peak.Load()
+				if cur <= old || peak.CompareAndSwap(old, cur) {
+					break
+				}
+			}
+			// Hold the slot briefly to give peers a chance to race.
+			time.Sleep(2 * time.Millisecond)
+			inflight.Add(-1)
+			p.release()
+		}()
+	}
+	wg.Wait()
+
+	if got := peak.Load(); got > int64(cap) {
+		t.Fatalf("peak in-flight = %d, want <= %d (semaphore breach)", got, cap)
+	}
+}
+
+// TestPairToken_TeardownInvokesDeleteOncePerHyco asserts that the
+// first Teardown call invokes deleteFn exactly twice (entra + sas)
+// and that subsequent calls do not re-enter deleteFn. This is the
+// "delete-side" half of the production idempotency contract.
+func TestPairToken_TeardownInvokesDeleteOncePerHyco(t *testing.T) {
+	var calls atomic.Int32
+	var mu sync.Mutex
+	var capturedNames []string
+	tok := &PairToken{
+		suffix: "0123456789ab",
+		deleteFn: func(ctx context.Context, name string) error {
+			calls.Add(1)
+			mu.Lock()
+			capturedNames = append(capturedNames, name)
+			mu.Unlock()
+			return nil
+		},
+	}
+
+	if err := tok.Teardown(t.Context()); err != nil {
+		t.Fatalf("first teardown: %v", err)
+	}
+	if got := calls.Load(); got != 2 {
+		t.Errorf("first call invoked deleteFn %d times, want 2", got)
+	}
+	sort.Strings(capturedNames)
+	want := []string{"e2e-entra-0123456789ab", "e2e-sas-0123456789ab"}
+	if !reflect.DeepEqual(capturedNames, want) {
+		t.Errorf("deleted names = %v, want %v", capturedNames, want)
+	}
+
+	if err := tok.Teardown(t.Context()); err != nil {
+		t.Fatalf("second teardown: %v", err)
+	}
+	if got := calls.Load(); got != 2 {
+		t.Errorf("after second call, deleteFn invoked %d times, want still 2", got)
+	}
+
+	if err := tok.Teardown(t.Context()); err != nil {
+		t.Fatalf("third teardown: %v", err)
+	}
+	if got := calls.Load(); got != 2 {
+		t.Errorf("after third call, deleteFn invoked %d times, want still 2", got)
+	}
+}
+
+// TestPairToken_TeardownReplaysError asserts that an error from the
+// first Teardown is returned identically on every subsequent call —
+// callers polling Teardown for cleanup status get the same answer
+// each time. This is the "error-side" half of the production
+// idempotency contract.
+func TestPairToken_TeardownReplaysError(t *testing.T) {
+	sentinel := errors.New("boom")
+	var calls atomic.Int32
+	tok := &PairToken{
+		suffix: "deadbeef0000",
+		deleteFn: func(ctx context.Context, name string) error {
+			calls.Add(1)
+			return sentinel
+		},
+	}
+
+	err1 := tok.Teardown(t.Context())
+	if err1 == nil || !errors.Is(err1, sentinel) {
+		t.Fatalf("first teardown err = %v; want errors.Is(sentinel)", err1)
+	}
+	err2 := tok.Teardown(t.Context())
+	if err2 != err1 {
+		t.Errorf("second teardown err = %v; want same value as first (%v)", err2, err1)
+	}
+	if got := calls.Load(); got != 2 {
+		t.Errorf("deleteFn invoked %d times across 2 teardowns, want 2", got)
+	}
+}
+
+func TestPairToken_HycoNamesMirrorSuffix(t *testing.T) {
+	tok := &PairToken{suffix: "abcdef012345"}
+	entra, sas := tok.HycoNames()
+	if entra != "e2e-entra-abcdef012345" {
+		t.Errorf("entra = %q", entra)
+	}
+	if sas != "e2e-sas-abcdef012345" {
+		t.Errorf("sas = %q", sas)
+	}
+	for _, n := range []string{entra, sas} {
+		if !HycoNamePattern.MatchString(n) {
+			t.Errorf("name %q does not match janitor pattern", n)
+		}
+	}
+}
+
+func TestPairToken_ResultPassesThrough(t *testing.T) {
+	r := &Result{EntraHycoName: "x", SASHycoName: "y"}
+	tok := &PairToken{result: r}
+	if tok.Result() != r {
+		t.Fatal("Result() did not return the stored *Result")
+	}
+}
+
+// TestPairToken_TeardownGatesOnProviderSemaphore asserts that Teardown
+// acquires the same concurrency slot used by Provision, so a swarm of
+// test cleanups cannot stampede the relay control plane beyond the
+// per-Provider cap. The test pre-saturates a cap-1 semaphore, runs
+// Teardown in a goroutine, observes that deleteFn does NOT run until
+// the slot is freed, and then asserts deleteFn runs once the slot is
+// released.
+func TestPairToken_TeardownGatesOnProviderSemaphore(t *testing.T) {
+	p := &Provider{sem: make(chan struct{}, 1)}
+	// Hold the only slot from the test goroutine.
+	if err := p.acquire(t.Context()); err != nil {
+		t.Fatalf("seed acquire: %v", err)
+	}
+
+	var calls atomic.Int32
+	tok := &PairToken{
+		provider: p,
+		suffix:   "00112233aabb",
+		deleteFn: func(ctx context.Context, name string) error {
+			calls.Add(1)
+			return nil
+		},
+	}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		_ = tok.Teardown(context.Background())
+	}()
+
+	// Give Teardown a chance to block on the saturated sem; deleteFn
+	// must NOT have run yet.
+	time.Sleep(20 * time.Millisecond)
+	if got := calls.Load(); got != 0 {
+		t.Fatalf("Teardown ran deleteFn while sem was saturated: calls = %d", got)
+	}
+
+	// Release the slot; Teardown should now complete and run deleteFn
+	// twice (entra + sas).
+	p.release()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Teardown did not complete after sem release")
+	}
+	if got := calls.Load(); got != 2 {
+		t.Errorf("deleteFn invoked %d times after sem release, want 2", got)
+	}
+}
+
+// stubCred satisfies azcore.TokenCredential without producing a token.
+// NewProvider only needs Cred to construct the ARM client; it does not
+// invoke GetToken in the constructor path. The empty implementation
+// would panic if a test ever drove a request through it.
+type stubCred struct{}
+
+func (stubCred) GetToken(ctx context.Context, opts policy.TokenRequestOptions) (azcore.AccessToken, error) {
+	return azcore.AccessToken{}, nil
+}

--- a/e2e/azrelay/provider_test.go
+++ b/e2e/azrelay/provider_test.go
@@ -257,6 +257,67 @@ func TestPairToken_ResultPassesThrough(t *testing.T) {
 	}
 }
 
+// TestPairToken_TeardownHonoursCallerDeadline verifies that a
+// deadline set on the caller's context is preserved across the
+// cancellation strip in Teardown. Specifically: a deadline shorter
+// than the fallback 60s ceiling should fire and abort the deletes.
+// Without this contract, callers wiring an explicit budget into
+// requireDedicatedHyco's t.Cleanup would silently fall back to the
+// internal ceiling.
+func TestPairToken_TeardownHonoursCallerDeadline(t *testing.T) {
+	var calls atomic.Int32
+	tok := &PairToken{
+		suffix: "feedface0001",
+		deleteFn: func(ctx context.Context, name string) error {
+			calls.Add(1)
+			// Block until the context fires so we can observe
+			// whether the caller's deadline propagated.
+			<-ctx.Done()
+			return ctx.Err()
+		},
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	if err := tok.Teardown(ctx); err == nil {
+		t.Fatal("expected Teardown to surface context deadline error")
+	}
+	elapsed := time.Since(start)
+	if elapsed > 5*time.Second {
+		t.Errorf("Teardown ran for %v; caller's 30ms deadline was not honoured (internal 60s ceiling leaked through)", elapsed)
+	}
+	if got := calls.Load(); got < 1 {
+		t.Errorf("deleteFn invoked %d times, want >= 1 (first delete should have started)", got)
+	}
+}
+
+// TestPairToken_TeardownStripsCallerCancellation asserts that an
+// already-cancelled caller context does NOT short-circuit Teardown —
+// cleanup must still run so test-timeout aborts don't orphan hycos.
+// We use a context that's both cancelled AND has a deadline well in
+// the future; Teardown should ignore the cancellation, honour the
+// future deadline, and complete the deletes.
+func TestPairToken_TeardownStripsCallerCancellation(t *testing.T) {
+	var calls atomic.Int32
+	tok := &PairToken{
+		suffix: "deadbabe0002",
+		deleteFn: func(ctx context.Context, name string) error {
+			calls.Add(1)
+			return nil
+		},
+	}
+	parent, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	cancel()
+
+	if err := tok.Teardown(parent); err != nil {
+		t.Fatalf("Teardown returned err on already-cancelled parent: %v", err)
+	}
+	if got := calls.Load(); got != 2 {
+		t.Errorf("deleteFn invoked %d times, want 2 (both deletes should have run despite parent cancellation)", got)
+	}
+}
+
 // TestPairToken_TeardownGatesOnProviderSemaphore asserts that Teardown
 // acquires the same concurrency slot used by Provision, so a swarm of
 // test cleanups cannot stampede the relay control plane beyond the

--- a/e2e/azrelay/provider_test.go
+++ b/e2e/azrelay/provider_test.go
@@ -21,9 +21,10 @@ func TestNewProvider_RejectsBadConfig(t *testing.T) {
 		cfg  Config
 		want string
 	}{
-		{"missing subscription", Config{ResourceGroup: "rg", Namespace: "ns"}, "SubscriptionID"},
-		{"missing resource group", Config{SubscriptionID: "sub", Namespace: "ns"}, "ResourceGroup"},
-		{"missing namespace", Config{SubscriptionID: "sub", ResourceGroup: "rg"}, "Namespace"},
+		{"missing subscription", Config{ResourceGroup: "rg", Namespace: "ns", RunRules: stubRunRules()}, "SubscriptionID"},
+		{"missing resource group", Config{SubscriptionID: "sub", Namespace: "ns", RunRules: stubRunRules()}, "ResourceGroup"},
+		{"missing namespace", Config{SubscriptionID: "sub", ResourceGroup: "rg", RunRules: stubRunRules()}, "Namespace"},
+		{"missing run rules", Config{SubscriptionID: "sub", ResourceGroup: "rg", Namespace: "ns"}, "RunRules"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -44,6 +45,7 @@ func TestNewProvider_DefaultsConcurrencyAndClientOptions(t *testing.T) {
 		ResourceGroup:  "rg",
 		Namespace:      "ns",
 		Cred:           stubCred{},
+		RunRules:       stubRunRules(),
 	})
 	if err != nil {
 		t.Fatalf("NewProvider: %v", err)
@@ -60,6 +62,7 @@ func TestNewProvider_HonoursExplicitConcurrency(t *testing.T) {
 		Namespace:      "ns",
 		Cred:           stubCred{},
 		Concurrency:    2,
+		RunRules:       stubRunRules(),
 	})
 	if err != nil {
 		t.Fatalf("NewProvider: %v", err)
@@ -123,9 +126,9 @@ func TestProvider_AcquireRespectsConcurrencyLimit(t *testing.T) {
 // never exceeds the cap. Surfaces a bug where the semaphore is sized
 // or used incorrectly more reliably than a single-goroutine test.
 func TestProvider_AcquireSerialisesBeyondCap(t *testing.T) {
-	const cap = 2
+	const semSize = 2
 	const goroutines = 8
-	p := &Provider{sem: make(chan struct{}, cap)}
+	p := &Provider{sem: make(chan struct{}, semSize)}
 
 	var inflight atomic.Int64
 	var peak atomic.Int64
@@ -153,8 +156,8 @@ func TestProvider_AcquireSerialisesBeyondCap(t *testing.T) {
 	}
 	wg.Wait()
 
-	if got := peak.Load(); got > int64(cap) {
-		t.Fatalf("peak in-flight = %d, want <= %d (semaphore breach)", got, cap)
+	if got := peak.Load(); got > int64(semSize) {
+		t.Fatalf("peak in-flight = %d, want <= %d (semaphore breach)", got, semSize)
 	}
 }
 

--- a/e2e/azrelay/provisioner.go
+++ b/e2e/azrelay/provisioner.go
@@ -260,9 +260,12 @@ func (p *Provisioner) Provision(ctx context.Context) (*Result, error) {
 // call even if Provision failed partway through — entities that no longer
 // exist are silently ignored. Callers typically defer this from TestMain.
 //
-// Teardown uses its own context derived from the supplied parent so that
-// cleanup still runs when the parent has been cancelled (e.g. on test
-// timeout). The caller is responsible for the outer lifetime.
+// Teardown strips cancellation from ctx so it still runs when the
+// caller's parent has been cancelled (e.g. on test timeout) but it
+// preserves any deadline the caller set so the cleanup budget is
+// what the caller declared. If ctx has no deadline, Teardown applies
+// a defensive 60s ceiling so a stuck control plane cannot hang the
+// run indefinitely.
 //
 // Note: Azure Relay's HCO Delete cascades to the SAS authorization rules
 // created on the SAS hyco — we deliberately do not delete rules
@@ -272,8 +275,7 @@ func (p *Provisioner) Teardown(ctx context.Context) error {
 	if p.result == nil {
 		return nil
 	}
-	// Detach from caller cancellation; cleanup needs a fresh budget.
-	ctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 60*time.Second)
+	ctx, cancel := detachAndBoundContext(ctx, 60*time.Second)
 	defer cancel()
 
 	var errs []error

--- a/e2e/azrelay/provisioner.go
+++ b/e2e/azrelay/provisioner.go
@@ -102,9 +102,16 @@ type Config struct {
 	// will construct a DefaultAzureCredential.
 	Cred azcore.TokenCredential
 
-	// ClientOptions is forwarded to the armrelay clients. Nil uses Azure
-	// Public Cloud defaults.
+	// ClientOptions is forwarded to the armrelay clients. Nil applies
+	// the per-test-tuned retry policy returned by DefaultClientOptions
+	// (azcore MaxRetries=DefaultARMMaxRetries, honouring Retry-After
+	// headers up to DefaultARMMaxRetryDelay).
 	ClientOptions *arm.ClientOptions
+
+	// Concurrency caps the number of in-flight Provider.Provision
+	// calls. Zero applies DefaultProvisionerConcurrency. Ignored by
+	// the single-use Provisioner type (it serialises by construction).
+	Concurrency int
 }
 
 // Result holds the data needed by tests to connect to the freshly-created
@@ -146,6 +153,11 @@ type Provisioner struct {
 
 // New constructs a Provisioner. It does not call Azure — that happens in
 // Provision. The returned Provisioner is single-use.
+//
+// Prefer NewProvider for code paths that may need multiple provisions:
+// Provisioner exists for back-compat with the original single-pair-per-
+// process TestMain shape and is implemented today as a thin wrapper
+// over the same per-call helpers Provider uses internally.
 func New(cfg Config) (*Provisioner, error) {
 	if err := cfg.validate(); err != nil {
 		return nil, err
@@ -158,7 +170,11 @@ func New(cfg Config) (*Provisioner, error) {
 		}
 		cred = c
 	}
-	hycos, err := armrelay.NewHybridConnectionsClient(cfg.SubscriptionID, cred, cfg.ClientOptions)
+	opts := cfg.ClientOptions
+	if opts == nil {
+		opts = DefaultClientOptions()
+	}
+	hycos, err := armrelay.NewHybridConnectionsClient(cfg.SubscriptionID, cred, opts)
 	if err != nil {
 		return nil, fmt.Errorf("new hybrid connections client: %w", err)
 	}

--- a/e2e/azrelay/provisioner.go
+++ b/e2e/azrelay/provisioner.go
@@ -34,13 +34,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/relay/armrelay"
 )
 
-// Names of the SAS authorization rules created on the SAS hyco. The names
-// are scoped to a single hyco so global uniqueness is not a concern.
-const (
-	ListenerRuleName = "listener"
-	SenderRuleName   = "sender"
-)
-
 // HycoNamePattern matches per-invocation hybrid connection names created by
 // this package. The janitor uses this exact pattern (anchored) to identify
 // orphaned hycos that should be cleaned up.
@@ -52,21 +45,21 @@ var HycoNamePattern = regexp.MustCompile(`^e2e-(entra|sas)-[0-9a-f]{12}$`)
 // for any realistic CI volume.
 const suffixLen = 12
 
-// readinessMaxWait bounds how long Provision will retry reading the SAS
-// keys after creating the auth rules. ARM propagation is normally well
-// under a second; we allow more to absorb the occasional regional blip
-// without forcing tests to handle the transient 404 themselves.
+// readinessMaxWait bounds how long readKey will retry ListKeys after a
+// rule create. ARM propagation is normally well under a second; we allow
+// more to absorb the occasional regional blip without forcing tests to
+// handle the transient 404 themselves.
 const readinessMaxWait = 30 * time.Second
 
-// Bounds on the createRule / bestEffortDelete retry loop that absorbs the
-// transient 40901 MessagingGatewayTooManyRequests conflict produced when
-// Azure Relay's control plane serialises authorizationRule mutations per
-// hybrid connection: the ARM SDK returns 2xx for one mutation before the
-// backend has committed it, so a back-to-back mutation on the same hyco
-// (e.g. listener-rule then sender-rule, or delete-during-pending-create)
-// can race the per-hyco serialization gate and get rejected with 40901.
-// This is the same constraint that requires `@batchSize(1)` in Bicep on
-// Microsoft.Relay/namespaces/hybridConnections/authorizationRules.
+// Bounds on the createRule / bestEffortDelete retry loop that absorbs
+// the transient 40901 MessagingGatewayTooManyRequests conflict produced
+// when Azure Relay's control plane serialises authorizationRule
+// mutations per scope: the ARM SDK returns 2xx for one mutation before
+// the backend has committed it, so a back-to-back mutation on the same
+// scope (e.g. listener-rule then sender-rule create at namespace scope,
+// or delete-during-pending-create) can race the per-scope serialization
+// gate and get rejected with 40901. This is the same constraint that
+// requires `@batchSize(1)` in Bicep on Microsoft.Relay/.../authorizationRules.
 //
 // Six attempts with equal-jittered exponential backoff (500ms → 8s, cap)
 // is comfortably more than empirically observed convergence (sub-second)
@@ -74,22 +67,12 @@ const readinessMaxWait = 30 * time.Second
 // rather than hanging. Note: the underlying azcore HTTP pipeline already
 // retries 429s a small number of times honouring Retry-After before
 // surfacing the error here, so the real cumulative wall time of a fully
-// exhausted createRule call is larger than ~15.5s of sleep alone — the
-// 30s ceiling in bestEffortDelete still dominates that path.
+// exhausted createRule call is larger than ~15.5s of sleep alone.
 const (
 	authRuleMaxAttempts  = 6
 	authRuleInitialDelay = 500 * time.Millisecond
 	authRuleMaxDelay     = 8 * time.Second
 )
-
-// dataPlaneSettleAfterKeys gives Relay's data plane a brief grace period
-// to propagate a newly-created SAS auth rule after the control plane
-// (ListKeys) has acknowledged it. Without this, the very first sender
-// or listener handshake using a fresh key can observe a 401 before the
-// rule has converged across the data-plane nodes. Empirically a sub-
-// second wait suffices; 2 seconds adds a comfortable margin without
-// noticeably slowing the suite.
-const dataPlaneSettleAfterKeys = 2 * time.Second
 
 // Config describes which Azure subscription / resource group / namespace
 // the provisioner should create hycos in. All fields are required.
@@ -112,6 +95,12 @@ type Config struct {
 	// calls. Zero applies DefaultProvisionerConcurrency. Ignored by
 	// the single-use Provisioner type (it serialises by construction).
 	Concurrency int
+
+	// RunRules supplies the run-scoped namespace SAS rules whose keys
+	// every PairToken Result stamps onto its ListenerKey/SenderKey
+	// fields. Required for NewProvider and Provisioner; AcquireRunRules
+	// populates it.
+	RunRules *RunRules
 }
 
 // Result holds the data needed by tests to connect to the freshly-created
@@ -185,14 +174,21 @@ func New(cfg Config) (*Provisioner, error) {
 	return &Provisioner{cfg: cfg, hycos: hycos, suffix: suffix}, nil
 }
 
-// Provision creates the Entra and SAS hybrid connections, creates listener
-// and sender authorization rules on the SAS hyco, fetches the SAS keys, and
-// returns the resulting connection metadata. If any step fails after a
-// hyco has been created, Provision attempts a best-effort teardown before
-// returning the error so the caller does not need to handle partial state.
+// Provision creates the Entra and SAS hybrid connections and stamps the
+// run-scoped SAS rule key info from cfg.RunRules onto the returned
+// Result. If any step fails after a hyco has been created, Provision
+// attempts a best-effort teardown before returning the error so the
+// caller does not need to handle partial state.
+//
+// Authorization rules are NOT created here — they live at namespace
+// scope and are provisioned once per `go test` invocation via
+// AcquireRunRules. cfg.RunRules must be non-nil.
 func (p *Provisioner) Provision(ctx context.Context) (*Result, error) {
 	if p.result != nil {
 		return nil, errors.New("provisioner already used")
+	}
+	if p.cfg.RunRules == nil {
+		return nil, errors.New("azrelay.Config.RunRules is required (call AcquireRunRules first)")
 	}
 
 	entraName := "e2e-entra-" + p.suffix
@@ -211,47 +207,15 @@ func (p *Provisioner) Provision(ctx context.Context) (*Result, error) {
 		return nil, fmt.Errorf("create %s: %w", sasName, err)
 	}
 
-	if err := p.createRule(ctx, sasName, ListenerRuleName, armrelay.AccessRightsListen); err != nil {
-		p.bestEffortDelete(ctx, entraName)
-		p.bestEffortDelete(ctx, sasName)
-		return nil, fmt.Errorf("create %s/%s rule: %w", sasName, ListenerRuleName, err)
-	}
-	if err := p.createRule(ctx, sasName, SenderRuleName, armrelay.AccessRightsSend); err != nil {
-		p.bestEffortDelete(ctx, entraName)
-		p.bestEffortDelete(ctx, sasName)
-		return nil, fmt.Errorf("create %s/%s rule: %w", sasName, SenderRuleName, err)
-	}
-
-	listenerKey, err := p.readKey(ctx, sasName, ListenerRuleName)
-	if err != nil {
-		p.bestEffortDelete(ctx, entraName)
-		p.bestEffortDelete(ctx, sasName)
-		return nil, fmt.Errorf("read %s/%s key: %w", sasName, ListenerRuleName, err)
-	}
-	senderKey, err := p.readKey(ctx, sasName, SenderRuleName)
-	if err != nil {
-		p.bestEffortDelete(ctx, entraName)
-		p.bestEffortDelete(ctx, sasName)
-		return nil, fmt.Errorf("read %s/%s key: %w", sasName, SenderRuleName, err)
-	}
-
-	// Brief data-plane settle window — see dataPlaneSettleAfterKeys.
-	select {
-	case <-ctx.Done():
-		p.bestEffortDelete(ctx, entraName)
-		p.bestEffortDelete(ctx, sasName)
-		return nil, ctx.Err()
-	case <-time.After(dataPlaneSettleAfterKeys):
-	}
-
+	rr := p.cfg.RunRules
 	p.result = &Result{
 		RelayName:       p.cfg.Namespace,
 		EntraHycoName:   entraName,
 		SASHycoName:     sasName,
-		ListenerKeyName: ListenerRuleName,
-		ListenerKey:     listenerKey,
-		SenderKeyName:   SenderRuleName,
-		SenderKey:       senderKey,
+		ListenerKeyName: rr.ListenerName,
+		ListenerKey:     rr.ListenerKey,
+		SenderKeyName:   rr.SenderName,
+		SenderKey:       rr.SenderKey,
 	}
 	return p.result, nil
 }
@@ -267,10 +231,8 @@ func (p *Provisioner) Provision(ctx context.Context) (*Result, error) {
 // a defensive 60s ceiling so a stuck control plane cannot hang the
 // run indefinitely.
 //
-// Note: Azure Relay's HCO Delete cascades to the SAS authorization rules
-// created on the SAS hyco — we deliberately do not delete rules
-// individually. If this is ever changed to selective rule cleanup (or
-// delete-rules-then-delete-hyco), the cascade dependency goes away.
+// Note: authorization rules are not deleted here — they live at
+// namespace scope and have a separate lifecycle owned by RunRules.
 func (p *Provisioner) Teardown(ctx context.Context) error {
 	if p.result == nil {
 		return nil
@@ -279,10 +241,10 @@ func (p *Provisioner) Teardown(ctx context.Context) error {
 	defer cancel()
 
 	var errs []error
-	if _, err := p.hycos.Delete(ctx, p.cfg.ResourceGroup, p.cfg.Namespace, p.result.EntraHycoName, nil); err != nil {
+	if _, err := p.hycos.Delete(ctx, p.cfg.ResourceGroup, p.cfg.Namespace, p.result.EntraHycoName, nil); err != nil && !isNotFound(err) {
 		errs = append(errs, fmt.Errorf("delete %s: %w", p.result.EntraHycoName, err))
 	}
-	if _, err := p.hycos.Delete(ctx, p.cfg.ResourceGroup, p.cfg.Namespace, p.result.SASHycoName, nil); err != nil {
+	if _, err := p.hycos.Delete(ctx, p.cfg.ResourceGroup, p.cfg.Namespace, p.result.SASHycoName, nil); err != nil && !isNotFound(err) {
 		errs = append(errs, fmt.Errorf("delete %s: %w", p.result.SASHycoName, err))
 	}
 	if len(errs) > 0 {
@@ -307,57 +269,12 @@ func (p *Provisioner) createHyco(ctx context.Context, name string) error {
 	return err
 }
 
-func (p *Provisioner) createRule(ctx context.Context, hyco, ruleName string, right armrelay.AccessRights) error {
-	return retryOnAuthRuleConflict(ctx, defaultAuthRuleRetry(), func() error {
-		_, err := p.hycos.CreateOrUpdateAuthorizationRule(ctx, p.cfg.ResourceGroup, p.cfg.Namespace, hyco, ruleName, armrelay.AuthorizationRule{
-			Properties: &armrelay.AuthorizationRuleProperties{
-				Rights: []*armrelay.AccessRights{&right},
-			},
-		}, nil)
-		return err
-	})
-}
-
-// readKey fetches the primary key for the given auth rule, retrying on
-// transient 404s that occasionally follow rule creation. The retry budget
-// is bounded by readinessMaxWait.
-func (p *Provisioner) readKey(ctx context.Context, hyco, ruleName string) (string, error) {
-	deadline := time.Now().Add(readinessMaxWait)
-	var lastErr error
-	for {
-		resp, err := p.hycos.ListKeys(ctx, p.cfg.ResourceGroup, p.cfg.Namespace, hyco, ruleName, nil)
-		if err == nil {
-			if resp.PrimaryKey == nil {
-				return "", errors.New("ListKeys returned nil PrimaryKey")
-			}
-			return *resp.PrimaryKey, nil
-		}
-		lastErr = err
-		if !isTransient(err) {
-			return "", err
-		}
-		if time.Now().After(deadline) {
-			return "", fmt.Errorf("ListKeys timed out after %s: %w", readinessMaxWait, lastErr)
-		}
-		select {
-		case <-ctx.Done():
-			return "", ctx.Err()
-		case <-time.After(500 * time.Millisecond):
-		}
-	}
-}
-
 func (p *Provisioner) bestEffortDelete(ctx context.Context, name string) {
 	ctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 30*time.Second)
 	defer cancel()
-	// Failure-path cleanup can race a not-yet-committed rule create on the
-	// same hyco; absorb the 40901 conflict the same way createRule does so
-	// we maximise cleanup success and reduce janitor load. Other errors
-	// (404, 403, ...) are swallowed by best-effort semantics.
-	_ = retryOnAuthRuleConflict(ctx, defaultAuthRuleRetry(), func() error {
-		_, err := p.hycos.Delete(ctx, p.cfg.ResourceGroup, p.cfg.Namespace, name, nil)
-		return err
-	})
+	// Failure-path cleanup; other errors (404, 403, ...) are swallowed
+	// by best-effort semantics.
+	_, _ = p.hycos.Delete(ctx, p.cfg.ResourceGroup, p.cfg.Namespace, name, nil)
 }
 
 // newSuffix returns a fresh suffixLen-character lowercase hex string.
@@ -385,6 +302,20 @@ func defaultAuthRuleRetry() authRuleRetry {
 		initialDelay: authRuleInitialDelay,
 		maxDelay:     authRuleMaxDelay,
 	}
+}
+
+// RetryOnAuthRuleConflict invokes fn, retrying with the package's
+// default backoff schedule while fn returns a transient Azure Relay
+// 40901 conflict on an authorizationRule mutation. Any other error —
+// including generic 429s — is returned to the caller immediately.
+// The function honours ctx cancellation between retries.
+//
+// Exposed for use by callers outside this package that mutate the same
+// Microsoft.Relay authorizationRules scope (e.g. the janitor's
+// sweep-and-delete loop), so they share the same retry envelope as
+// AcquireRunRules / RunRules.Teardown.
+func RetryOnAuthRuleConflict(ctx context.Context, fn func() error) error {
+	return retryOnAuthRuleConflict(ctx, defaultAuthRuleRetry(), fn)
 }
 
 // retryOnAuthRuleConflict invokes fn, retrying with jittered exponential
@@ -424,11 +355,13 @@ func retryOnAuthRuleConflict(ctx context.Context, cfg authRuleRetry, fn func() e
 
 // isAuthRuleConflict reports whether err is the transient Azure Relay
 // 40901 MessagingGatewayTooManyRequests conflict produced when sequential
-// authorizationRule mutations race the per-hybrid-connection serialization
-// gate. Only this specific class is retried; generic 429s, other ARM
-// errors, and other SubCodes under the same ErrorCode (e.g. namespace-
-// level throttling that wouldn't benefit from short-window backoff
-// against a single hyco's commit window) are returned as-is.
+// authorizationRule mutations race the per-scope serialization gate
+// (where "scope" is either a hybrid connection or — for run-scoped
+// rules — the namespace itself). Only this specific class is retried;
+// generic 429s, other ARM errors, and other SubCodes under the same
+// ErrorCode (e.g. namespace-level throttling that wouldn't benefit
+// from short-window backoff against a single rule's commit window)
+// are returned as-is.
 //
 // The SubCode marker is matched against ResponseError.Error() — azcore
 // embeds the raw response body in that string, and the body is the

--- a/e2e/azrelay/runrules.go
+++ b/e2e/azrelay/runrules.go
@@ -1,0 +1,273 @@
+package azrelay
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"regexp"
+	"sync"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/relay/armrelay"
+)
+
+// RunRuleNamePattern matches per-`go test` namespace authorization rules
+// created by AcquireRunRules. The janitor uses this exact pattern
+// (anchored) to identify orphaned run rules that should be cleaned up.
+// Listener and sender rules share the same 12-char suffix so a janitor
+// pass can trivially correlate the two halves of a run.
+var RunRuleNamePattern = regexp.MustCompile(`^e2e-run-[0-9a-f]{12}-(listener|sender)$`)
+
+// runRulePrefix is the common prefix of every run-scoped namespace
+// authorization rule. Listener and sender rules append the role
+// (and share the 12-char suffix) so the janitor can correlate the
+// two halves of a run.
+const runRulePrefix = "e2e-run-"
+
+// dataPlaneSettleAfterKeys gives Relay's data plane a brief grace
+// period to propagate a newly-created SAS auth rule after the control
+// plane (ListKeys) has acknowledged it. Without this, the first
+// handshake using the fresh key can observe a 401 before the rule has
+// converged across the data-plane nodes. Empirically a sub-second wait
+// suffices; 2s adds a comfortable margin. Paid once per RunRules
+// acquisition, not once per pair.
+const dataPlaneSettleAfterKeys = 2 * time.Second
+
+// RunRules holds the two namespace-scoped authorization rules a single
+// `go test` invocation provisions: one Listen-only rule whose key the
+// relay-listener uses, and one Send-only rule whose key the
+// relay-sender uses. Both rules live at namespace scope, so the same
+// key authorizes the corresponding action against every hybrid
+// connection the run creates.
+//
+// Two rules (not one combined Listen+Send rule) is deliberate: the
+// suite asserts that a listener key cannot be used to send and vice
+// versa (TestWrongSASClaim). A single rule with both rights would
+// silently pass that test.
+//
+// Acquire one with AcquireRunRules, propagate via Config.RunRules
+// into NewProvider, and defer Teardown from TestMain.
+type RunRules struct {
+	ListenerName string
+	ListenerKey  string
+	SenderName   string
+	SenderKey    string
+
+	cfg    Config
+	ns     *armrelay.NamespacesClient
+	suffix string
+
+	teardownOnce sync.Once
+	teardownErr  error
+}
+
+// AcquireRunRules creates two namespace-scoped authorization rules in
+// cfg.Namespace — one Listen-only, one Send-only, both named
+// "e2e-run-<hex>-<role>" with a shared random 12-char suffix — reads
+// their primary keys, lets the data plane settle, and returns the
+// populated *RunRules.
+//
+// On any failure after a rule has been created, AcquireRunRules issues
+// a best-effort delete before returning the error, so the caller does
+// not need to handle partial state.
+//
+// cfg.RunRules is ignored by this function (the returned *RunRules is
+// what the caller would set on cfg.RunRules before constructing a
+// Provider).
+func AcquireRunRules(ctx context.Context, cfg Config) (*RunRules, error) {
+	if err := cfg.validateForRunRules(); err != nil {
+		return nil, err
+	}
+	cred := cfg.Cred
+	if cred == nil {
+		c, err := azidentity.NewDefaultAzureCredential(nil)
+		if err != nil {
+			return nil, fmt.Errorf("default azure credential: %w", err)
+		}
+		cred = c
+	}
+	opts := cfg.ClientOptions
+	if opts == nil {
+		opts = DefaultClientOptions()
+	}
+	ns, err := armrelay.NewNamespacesClient(cfg.SubscriptionID, cred, opts)
+	if err != nil {
+		return nil, fmt.Errorf("new namespaces client: %w", err)
+	}
+	suffix, err := newSuffix()
+	if err != nil {
+		return nil, fmt.Errorf("generate suffix: %w", err)
+	}
+
+	r := &RunRules{
+		cfg:          cfg,
+		ns:           ns,
+		suffix:       suffix,
+		ListenerName: runRulePrefix + suffix + "-listener",
+		SenderName:   runRulePrefix + suffix + "-sender",
+	}
+
+	if err := r.createRule(ctx, r.ListenerName, armrelay.AccessRightsListen); err != nil {
+		r.bestEffortDelete(ctx, r.ListenerName)
+		return nil, fmt.Errorf("create %s: %w", r.ListenerName, err)
+	}
+	if err := r.createRule(ctx, r.SenderName, armrelay.AccessRightsSend); err != nil {
+		r.bestEffortDelete(ctx, r.ListenerName)
+		r.bestEffortDelete(ctx, r.SenderName)
+		return nil, fmt.Errorf("create %s: %w", r.SenderName, err)
+	}
+
+	listenerKey, err := r.readKey(ctx, r.ListenerName)
+	if err != nil {
+		r.bestEffortDelete(ctx, r.ListenerName)
+		r.bestEffortDelete(ctx, r.SenderName)
+		return nil, fmt.Errorf("read %s key: %w", r.ListenerName, err)
+	}
+	senderKey, err := r.readKey(ctx, r.SenderName)
+	if err != nil {
+		r.bestEffortDelete(ctx, r.ListenerName)
+		r.bestEffortDelete(ctx, r.SenderName)
+		return nil, fmt.Errorf("read %s key: %w", r.SenderName, err)
+	}
+	r.ListenerKey = listenerKey
+	r.SenderKey = senderKey
+
+	select {
+	case <-ctx.Done():
+		r.bestEffortDelete(ctx, r.ListenerName)
+		r.bestEffortDelete(ctx, r.SenderName)
+		return nil, ctx.Err()
+	case <-time.After(dataPlaneSettleAfterKeys):
+	}
+
+	return r, nil
+}
+
+// Teardown deletes both namespace authorization rules. Safe to call
+// multiple times: only the first call performs the deletes; subsequent
+// calls return the same error.
+//
+// Teardown strips cancellation from ctx (via context.WithoutCancel)
+// so cleanup completes even when ctx has been cancelled (e.g. on
+// TestMain timeout), but preserves any deadline the caller set. If
+// ctx has no deadline, Teardown applies a defensive 60s ceiling so a
+// stuck control plane cannot hang the run indefinitely.
+//
+// Individual delete failures are joined and returned. The janitor
+// (RunRuleNamePattern sweep) will reap anything we can't clean up
+// here.
+func (r *RunRules) Teardown(ctx context.Context) error {
+	r.teardownOnce.Do(func() {
+		ctx, cancel := detachAndBoundContext(ctx, 60*time.Second)
+		defer cancel()
+		var errs []error
+		if err := r.deleteRule(ctx, r.ListenerName); err != nil {
+			errs = append(errs, fmt.Errorf("delete %s: %w", r.ListenerName, err))
+		}
+		if err := r.deleteRule(ctx, r.SenderName); err != nil {
+			errs = append(errs, fmt.Errorf("delete %s: %w", r.SenderName, err))
+		}
+		if len(errs) > 0 {
+			r.teardownErr = errors.Join(errs...)
+		}
+	})
+	return r.teardownErr
+}
+
+func (r *RunRules) createRule(ctx context.Context, name string, right armrelay.AccessRights) error {
+	return retryOnAuthRuleConflict(ctx, defaultAuthRuleRetry(), func() error {
+		_, err := r.ns.CreateOrUpdateAuthorizationRule(ctx, r.cfg.ResourceGroup, r.cfg.Namespace, name, armrelay.AuthorizationRule{
+			Properties: &armrelay.AuthorizationRuleProperties{
+				Rights: []*armrelay.AccessRights{&right},
+			},
+		}, nil)
+		return err
+	})
+}
+
+// readKey fetches the primary key for the given namespace-scoped rule,
+// retrying on transient 404s that occasionally follow rule creation
+// before ARM has fully propagated the new entity. Bounded by
+// readinessMaxWait.
+func (r *RunRules) readKey(ctx context.Context, name string) (string, error) {
+	deadline := time.Now().Add(readinessMaxWait)
+	var lastErr error
+	for {
+		resp, err := r.ns.ListKeys(ctx, r.cfg.ResourceGroup, r.cfg.Namespace, name, nil)
+		if err == nil {
+			if resp.PrimaryKey == nil {
+				return "", errors.New("ListKeys returned nil PrimaryKey")
+			}
+			return *resp.PrimaryKey, nil
+		}
+		lastErr = err
+		if !isTransient(err) {
+			return "", err
+		}
+		if time.Now().After(deadline) {
+			return "", fmt.Errorf("ListKeys timed out after %s: %w", readinessMaxWait, lastErr)
+		}
+		select {
+		case <-ctx.Done():
+			return "", ctx.Err()
+		case <-time.After(500 * time.Millisecond):
+		}
+	}
+}
+
+func (r *RunRules) deleteRule(ctx context.Context, name string) error {
+	// Same per-scope serialization gate as createRule — back-to-back
+	// deletes on the namespace authorizationRules scope (listener
+	// immediately followed by sender) can race the gate and surface
+	// as 40901. The retry envelope is bounded; a stuck control plane
+	// still surfaces through retryOnAuthRuleConflict's "after N
+	// attempts" wrap.
+	return retryOnAuthRuleConflict(ctx, defaultAuthRuleRetry(), func() error {
+		_, err := r.ns.DeleteAuthorizationRule(ctx, r.cfg.ResourceGroup, r.cfg.Namespace, name, nil)
+		if err != nil && isNotFound(err) {
+			return nil
+		}
+		return err
+	})
+}
+
+// bestEffortDelete swallows errors. Used on the AcquireRunRules
+// failure path; the janitor will reap anything left behind. We also
+// retry 40901 here for the same reason createRule does — a not-yet-
+// committed create can race the cleanup delete.
+func (r *RunRules) bestEffortDelete(ctx context.Context, name string) {
+	ctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 30*time.Second)
+	defer cancel()
+	_ = retryOnAuthRuleConflict(ctx, defaultAuthRuleRetry(), func() error {
+		_, err := r.ns.DeleteAuthorizationRule(ctx, r.cfg.ResourceGroup, r.cfg.Namespace, name, nil)
+		if err != nil && isNotFound(err) {
+			return nil
+		}
+		return err
+	})
+}
+
+// validateForRunRules is the same as validate today (Subscription, RG,
+// Namespace required) but exists as a separate entry point so a future
+// addition of a "RunRules required" field on Config doesn't accidentally
+// short-circuit AcquireRunRules — which is what populates that field.
+func (c Config) validateForRunRules() error { return c.validate() }
+
+// IsNotFound reports whether err is an ARM HTTP 404 NotFound response.
+// Useful for callers that treat absent resources as success during
+// cleanup (e.g. teardown / janitor sweeps that race other deletes).
+// Inspects azcore.ResponseError.StatusCode only; 404s from any parent
+// scope (missing namespace, missing resource group) are returned as
+// true on the same basis, which is the intended behaviour for cleanup
+// callers — the cleanup post-condition holds regardless.
+func IsNotFound(err error) bool { return isNotFound(err) }
+
+func isNotFound(err error) bool {
+	var respErr *azcore.ResponseError
+	if !errors.As(err, &respErr) {
+		return false
+	}
+	return respErr.StatusCode == 404
+}

--- a/e2e/azrelay/runrules_test.go
+++ b/e2e/azrelay/runrules_test.go
@@ -1,0 +1,132 @@
+package azrelay
+
+import (
+	"errors"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+)
+
+func TestRunRuleNamePattern(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want bool
+	}{
+		{"valid listener", "e2e-run-0123456789ab-listener", true},
+		{"valid sender", "e2e-run-abcdef012345-sender", true},
+		{"missing role", "e2e-run-0123456789ab", false},
+		{"unknown role", "e2e-run-0123456789ab-admin", false},
+		{"short suffix", "e2e-run-0123456789a-listener", false},
+		{"long suffix", "e2e-run-0123456789abc-listener", false},
+		{"uppercase suffix", "e2e-run-0123456789AB-listener", false},
+		{"non-hex suffix", "e2e-run-0123456789xy-listener", false},
+		{"uppercase role", "e2e-run-0123456789ab-LISTENER", false},
+		{"wrong prefix", "e2e-rule-0123456789ab-listener", false},
+		{"unrelated name", "production-rule", false},
+		{"empty", "", false},
+		// Hyco names must NOT accidentally match.
+		{"hyco entra rejected", "e2e-entra-0123456789ab", false},
+		{"hyco sas rejected", "e2e-sas-0123456789ab", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := RunRuleNamePattern.MatchString(tc.in); got != tc.want {
+				t.Errorf("RunRuleNamePattern.MatchString(%q) = %v, want %v", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestRunRuleAndHycoPatternsAreDisjoint(t *testing.T) {
+	// Janitor relies on the two sweeps owning disjoint name spaces;
+	// regression-test the pair so a future rename can't silently
+	// cause one sweep to delete entities the other owns.
+	const suffix = "0123456789ab"
+	listener := "e2e-run-" + suffix + "-listener"
+	sender := "e2e-run-" + suffix + "-sender"
+	entra := "e2e-entra-" + suffix
+	sas := "e2e-sas-" + suffix
+
+	if !RunRuleNamePattern.MatchString(listener) || !RunRuleNamePattern.MatchString(sender) {
+		t.Fatalf("RunRuleNamePattern must match its own outputs (%s, %s)", listener, sender)
+	}
+	if HycoNamePattern.MatchString(listener) || HycoNamePattern.MatchString(sender) {
+		t.Fatalf("HycoNamePattern must not match run-rule names (%s, %s)", listener, sender)
+	}
+	if !HycoNamePattern.MatchString(entra) || !HycoNamePattern.MatchString(sas) {
+		t.Fatalf("HycoNamePattern must match its own outputs (%s, %s)", entra, sas)
+	}
+	if RunRuleNamePattern.MatchString(entra) || RunRuleNamePattern.MatchString(sas) {
+		t.Fatalf("RunRuleNamePattern must not match hyco names (%s, %s)", entra, sas)
+	}
+}
+
+func TestIsNotFound(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"plain error", errors.New("boom"), false},
+		{"404 ResponseError", &azcore.ResponseError{StatusCode: http.StatusNotFound}, true},
+		{"wrapped 404", &wrapErr{inner: &azcore.ResponseError{StatusCode: http.StatusNotFound}}, true},
+		{"403", &azcore.ResponseError{StatusCode: http.StatusForbidden}, false},
+		{"500", &azcore.ResponseError{StatusCode: http.StatusInternalServerError}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isNotFound(tc.err); got != tc.want {
+				t.Errorf("isNotFound(%v) = %v, want %v", tc.err, got, tc.want)
+			}
+		})
+	}
+}
+
+type wrapErr struct{ inner error }
+
+func (w *wrapErr) Error() string { return "wrap: " + w.inner.Error() }
+func (w *wrapErr) Unwrap() error { return w.inner }
+
+func TestValidateForRunRules_MirrorsValidate(t *testing.T) {
+	cases := []struct {
+		name    string
+		cfg     Config
+		wantErr string
+	}{
+		{"missing subscription", Config{ResourceGroup: "rg", Namespace: "ns"}, "SubscriptionID"},
+		{"missing resource group", Config{SubscriptionID: "sub", Namespace: "ns"}, "ResourceGroup"},
+		{"missing namespace", Config{SubscriptionID: "sub", ResourceGroup: "rg"}, "Namespace"},
+		{"all set", Config{SubscriptionID: "sub", ResourceGroup: "rg", Namespace: "ns"}, ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.cfg.validateForRunRules()
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Fatalf("validateForRunRules: unexpected error: %v", err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("validateForRunRules: err = %v, want containing %q", err, tc.wantErr)
+			}
+		})
+	}
+}
+
+// stubRunRules returns a non-nil *RunRules suitable only for satisfying
+// the Config.RunRules-required check in NewProvider for unit tests that
+// never reach the actual ARM rule-mutation path. Production callers
+// must go through AcquireRunRules.
+func stubRunRules() *RunRules {
+	return &RunRules{
+		ListenerName: "e2e-run-stubstubstub-listener",
+		ListenerKey:  "stub-listener-key",
+		SenderName:   "e2e-run-stubstubstub-sender",
+		SenderKey:    "stub-sender-key",
+	}
+}

--- a/e2e/azure_backend_test.go
+++ b/e2e/azure_backend_test.go
@@ -16,23 +16,35 @@ import (
 // in-process MockBackend (mockrelay/testharness/parity) is a behavioural gap in
 // the mock that we have to either fix or document.
 //
-// Each instance is bound to a single authConfig (Entra or SAS) so the
-// caller can run the same scenario suite once per available auth.
-// All listeners and senders are real aztunnel subprocesses driven by
-// the existing helpers (startListener, startPortForwardSender,
+// Each instance is bound to a single auth method ("entra" or "sas")
+// so the caller can run the same scenario suite once per available
+// auth. All listeners and senders are real aztunnel subprocesses
+// driven by the existing helpers (startListener, startPortForwardSender,
 // startSOCKS5Sender), so they exercise the same code paths that
 // production users hit. Each subprocess exposes its own Prometheus
 // /metrics endpoint via --metrics-addr 127.0.0.1:0, which the
 // Listener / Sender accessor closures scrape on demand to satisfy
 // Completed() / Active() reads.
+//
+// Each Setup call acquires a relayEnv via acquireEnv. The two
+// strategies in tree:
+//
+//   - requireDedicatedHyco: provisions a fresh (entra, sas) hyco pair
+//     and registers a t.Cleanup that tears it down. Used by
+//     TestParity_Azure so each scenario gets isolation between
+//     successive Setup calls — and so scenarios that call Setup
+//     twice (e.g. ScenarioErrorPropagation_*) hold disjoint hycos.
+//   - leaseSharedHyco: returns a process-shared, lazily-leased pair
+//     drained at TestMain exit. Used by BenchmarkParity_Azure so
+//     benchstat runs do not pay per-sub-bench provisioning.
 type azureBackend struct {
-	env  *relayEnv
-	auth authConfig
+	authName   string
+	acquireEnv func(testing.TB) *relayEnv
 }
 
 // Name returns the backend identifier used in test sub-paths, e.g.
 // "azure-entra" or "azure-sas".
-func (b *azureBackend) Name() string { return "azure-" + b.auth.name }
+func (b *azureBackend) Name() string { return "azure-" + b.authName }
 
 // Setup brings up the requested topology (NumListeners listeners and
 // max(NumSenders,1) senders), waits until every listener has logged
@@ -40,6 +52,14 @@ func (b *azureBackend) Name() string { return "azure-" + b.auth.name }
 // address, then attaches metrics-scrape closures and returns the
 // Tunnel handle. All subprocesses are torn down via the existing
 // t.Cleanup wiring inside startAztunnelWithSAS.
+//
+// acquireEnv MUST be the first side-effect: when it provisions a
+// dedicated pair (requireDedicatedHyco), the t.Cleanup registered
+// for PairToken.Teardown then sits BENEATH the listener/sender
+// Stop cleanups registered later. LIFO order ensures every
+// subprocess in this Setup is killed before its hyco pair is
+// deleted, which prevents ARM Delete from racing a still-attached
+// listener's keep-alives.
 func (b *azureBackend) Setup(t testing.TB, opts relayparity.SetupOptions) *relayparity.Tunnel {
 	t.Helper()
 	if opts.NumListeners < 1 {
@@ -49,6 +69,9 @@ func (b *azureBackend) Setup(t testing.TB, opts relayparity.SetupOptions) *relay
 	if numSenders < 1 {
 		numSenders = 1
 	}
+
+	env := b.acquireEnv(t)
+	auth := authFromEnv(t, env, b.authName)
 
 	listenerArgs := []string{"--metrics-addr", "127.0.0.1:0"}
 	for _, target := range opts.AllowedTargets {
@@ -65,7 +88,7 @@ func (b *azureBackend) Setup(t testing.TB, opts relayparity.SetupOptions) *relay
 
 	spawnListener := func(t testing.TB) *relayparity.Listener {
 		t.Helper()
-		lst := startListener(t, b.env, b.auth, listenerArgs...)
+		lst := startListener(t, env, auth, listenerArgs...)
 		waitForLog(t, lst, "control channel connected", 30*time.Second)
 		metricsAddr := lst.MetricsAddr(t, 15*time.Second)
 		return &relayparity.Listener{
@@ -90,10 +113,10 @@ func (b *azureBackend) Setup(t testing.TB, opts relayparity.SetupOptions) *relay
 		var logMsg string
 		switch opts.SenderMode {
 		case relayparity.ModePortForward:
-			proc = startPortForwardSender(t, b.env, b.auth, opts.Target, senderArgs...)
+			proc = startPortForwardSender(t, env, auth, opts.Target, senderArgs...)
 			logMsg = "port-forward listening"
 		case relayparity.ModeSOCKS5:
-			proc = startSOCKS5Sender(t, b.env, b.auth, senderArgs...)
+			proc = startSOCKS5Sender(t, env, auth, senderArgs...)
 			logMsg = "socks5-proxy listening"
 		default:
 			t.Fatalf("unknown SenderMode %v", opts.SenderMode)

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -49,7 +49,8 @@ import (
 
 // TestPortForwardBasic verifies a simple echo round-trip through port-forward mode.
 func TestPortForwardBasic(t *testing.T) {
-	env := requireRelayEnv(t)
+	t.Parallel()
+	env := requireDedicatedHyco(t)
 
 	for _, auth := range availableAuths(t, env) {
 		t.Run(auth.name, func(t *testing.T) {
@@ -90,7 +91,8 @@ func TestPortForwardBasic(t *testing.T) {
 
 // TestSOCKS5Basic verifies a SOCKS5 proxy echo round-trip.
 func TestSOCKS5Basic(t *testing.T) {
-	env := requireRelayEnv(t)
+	t.Parallel()
+	env := requireDedicatedHyco(t)
 
 	for _, auth := range availableAuths(t, env) {
 		t.Run(auth.name, func(t *testing.T) {
@@ -127,7 +129,8 @@ func TestSOCKS5Basic(t *testing.T) {
 
 // TestConnectStdio verifies the connect (stdin/stdout) mode with raw TCP data.
 func TestConnectStdio(t *testing.T) {
-	env := requireRelayEnv(t)
+	t.Parallel()
+	env := requireDedicatedHyco(t)
 
 	for _, auth := range availableAuths(t, env) {
 		t.Run(auth.name, func(t *testing.T) {
@@ -187,7 +190,8 @@ func TestConnectStdio(t *testing.T) {
 
 // TestSSHProxyCommand runs a real SSH session through the tunnel.
 func TestSSHProxyCommand(t *testing.T) {
-	env := requireRelayEnv(t)
+	t.Parallel()
+	env := requireDedicatedHyco(t)
 
 	// Check that ssh client is available.
 	if _, err := exec.LookPath("ssh"); err != nil {
@@ -237,7 +241,8 @@ func TestSSHProxyCommand(t *testing.T) {
 
 // TestSASKeyAuth verifies port-forward works with separate listener/sender SAS keys.
 func TestSASKeyAuth(t *testing.T) {
-	env := requireRelayEnv(t)
+	t.Parallel()
+	env := requireDedicatedHyco(t)
 	if env.sasHyco == "" || env.sasListenerKeyName == "" || env.sasListenerKey == "" || env.sasSenderKeyName == "" || env.sasSenderKey == "" {
 		t.Skip("SAS credentials not configured (E2E_SAS_HYCO_NAME, E2E_SAS_*_KEY_NAME, E2E_SAS_*_KEY)")
 	}
@@ -294,7 +299,8 @@ func TestSASKeyAuth(t *testing.T) {
 func TestAllowlistAllow(t *testing.T) {
 	// This is covered by TestSOCKS5Basic (which uses --allow).
 	// Explicit test with CIDR notation.
-	env := requireRelayEnv(t)
+	t.Parallel()
+	env := requireDedicatedHyco(t)
 
 	for _, auth := range availableAuths(t, env) {
 		t.Run(auth.name, func(t *testing.T) {
@@ -334,7 +340,8 @@ func TestAllowlistAllow(t *testing.T) {
 
 // TestAllowlistDeny verifies that connections to non-allowed targets are rejected.
 func TestAllowlistDeny(t *testing.T) {
-	env := requireRelayEnv(t)
+	t.Parallel()
+	env := requireDedicatedHyco(t)
 
 	for _, auth := range availableAuths(t, env) {
 		t.Run(auth.name, func(t *testing.T) {
@@ -368,7 +375,8 @@ func TestAllowlistDeny(t *testing.T) {
 
 // TestMaxConnections verifies the --max-connections limit.
 func TestMaxConnections(t *testing.T) {
-	env := requireRelayEnv(t)
+	t.Parallel()
+	env := requireDedicatedHyco(t)
 
 	for _, auth := range availableAuths(t, env) {
 		t.Run(auth.name, func(t *testing.T) {
@@ -452,7 +460,8 @@ func TestMaxConnections(t *testing.T) {
 
 // TestSmallPayload sends 1-byte writes.
 func TestSmallPayload(t *testing.T) {
-	env := requireRelayEnv(t)
+	t.Parallel()
+	env := requireDedicatedHyco(t)
 
 	for _, auth := range availableAuths(t, env) {
 		t.Run(auth.name, func(t *testing.T) {
@@ -491,7 +500,8 @@ func TestSmallPayload(t *testing.T) {
 
 // TestLargePayload sends a 1MB payload and verifies SHA256.
 func TestLargePayload(t *testing.T) {
-	env := requireRelayEnv(t)
+	t.Parallel()
+	env := requireDedicatedHyco(t)
 
 	for _, auth := range availableAuths(t, env) {
 		t.Run(auth.name, func(t *testing.T) {
@@ -539,7 +549,8 @@ func TestBulkTransfer(t *testing.T) {
 	if os.Getenv("E2E_LARGE_TRANSFER") != "1" {
 		t.Skip("set E2E_LARGE_TRANSFER=1 to enable (sends 100MB through relay)")
 	}
-	env := requireRelayEnv(t)
+	t.Parallel()
+	env := requireDedicatedHyco(t)
 
 	for _, auth := range availableAuths(t, env) {
 		t.Run(auth.name, func(t *testing.T) {
@@ -599,7 +610,8 @@ func TestLongLivedConnection(t *testing.T) {
 	if os.Getenv("E2E_LONG_LIVED") != "1" {
 		t.Skip("set E2E_LONG_LIVED=1 to enable (runs for >2 minutes)")
 	}
-	env := requireRelayEnv(t)
+	t.Parallel()
+	env := requireDedicatedHyco(t)
 
 	for _, auth := range availableAuths(t, env) {
 		t.Run(auth.name, func(t *testing.T) {
@@ -642,7 +654,8 @@ func TestLongLivedConnection(t *testing.T) {
 
 // TestConcurrentSameTarget opens 50 simultaneous connections through port-forward.
 func TestConcurrentSameTarget(t *testing.T) {
-	env := requireRelayEnv(t)
+	t.Parallel()
+	env := requireDedicatedHyco(t)
 
 	for _, auth := range availableAuths(t, env) {
 		t.Run(auth.name, func(t *testing.T) {
@@ -697,7 +710,8 @@ func TestConcurrentSameTarget(t *testing.T) {
 
 // TestConcurrentDistinctTargets opens 50 SOCKS5 connections to 50 different echo servers.
 func TestConcurrentDistinctTargets(t *testing.T) {
-	env := requireRelayEnv(t)
+	t.Parallel()
+	env := requireDedicatedHyco(t)
 
 	for _, auth := range availableAuths(t, env) {
 		t.Run(auth.name, func(t *testing.T) {
@@ -765,7 +779,8 @@ func TestConcurrentDistinctTargets(t *testing.T) {
 
 // TestMetricsEndpoint verifies the metrics HTTP endpoint returns valid Prometheus data.
 func TestMetricsEndpoint(t *testing.T) {
-	env := requireRelayEnv(t)
+	t.Parallel()
+	env := requireDedicatedHyco(t)
 
 	for _, auth := range availableAuths(t, env) {
 		t.Run(auth.name, func(t *testing.T) {
@@ -803,7 +818,8 @@ func TestMetricsEndpoint(t *testing.T) {
 
 // TestMetricsConnectionCount verifies connection counters after traffic.
 func TestMetricsConnectionCount(t *testing.T) {
-	env := requireRelayEnv(t)
+	t.Parallel()
+	env := requireDedicatedHyco(t)
 
 	for _, auth := range availableAuths(t, env) {
 		t.Run(auth.name, func(t *testing.T) {
@@ -857,7 +873,8 @@ func TestMetricsConnectionCount(t *testing.T) {
 
 // TestMetricsErrorReason verifies error reason labels from allowlist rejection.
 func TestMetricsErrorReason(t *testing.T) {
-	env := requireRelayEnv(t)
+	t.Parallel()
+	env := requireDedicatedHyco(t)
 
 	for _, auth := range availableAuths(t, env) {
 		t.Run(auth.name, func(t *testing.T) {
@@ -891,7 +908,8 @@ func TestMetricsErrorReason(t *testing.T) {
 
 // TestMetricsDialDuration verifies the dial duration histogram has observations.
 func TestMetricsDialDuration(t *testing.T) {
-	env := requireRelayEnv(t)
+	t.Parallel()
+	env := requireDedicatedHyco(t)
 
 	for _, auth := range availableAuths(t, env) {
 		t.Run(auth.name, func(t *testing.T) {
@@ -934,7 +952,8 @@ func TestMetricsDialDuration(t *testing.T) {
 // TestSenderRetriesUntilListenerReady verifies that the sender connect mode
 // retries on 404 and succeeds once the listener becomes available.
 func TestSenderRetriesUntilListenerReady(t *testing.T) {
-	env := requireRelayEnv(t)
+	t.Parallel()
+	env := requireDedicatedHyco(t)
 
 	for _, auth := range availableAuths(t, env) {
 		t.Run(auth.name, func(t *testing.T) {
@@ -1003,7 +1022,8 @@ func TestSenderRetriesUntilListenerReady(t *testing.T) {
 // TestPortForwardRecoveryAfterListenerRestart verifies that port-forward
 // mode recovers after the listener restarts.
 func TestPortForwardRecoveryAfterListenerRestart(t *testing.T) {
-	env := requireRelayEnv(t)
+	t.Parallel()
+	env := requireDedicatedHyco(t)
 
 	for _, auth := range availableAuths(t, env) {
 		t.Run(auth.name, func(t *testing.T) {
@@ -1120,7 +1140,8 @@ func assertNoUsageDump(t *testing.T, output string) {
 // client surfaces as a non-retryable failure. The test name is preserved for
 // continuity with the original behavior the suite was designed around.
 func TestConnectNoListener(t *testing.T) {
-	env := requireRelayEnv(t)
+	t.Parallel()
+	env := requireDedicatedHyco(t)
 
 	for _, auth := range availableAuths(t, env) {
 		t.Run(auth.name, func(t *testing.T) {
@@ -1147,7 +1168,8 @@ func TestConnectNoListener(t *testing.T) {
 
 // TestBadRelayName verifies a clean error for a non-existent relay namespace.
 func TestBadRelayName(t *testing.T) {
-	env := requireRelayEnv(t)
+	t.Parallel()
+	env := requireDedicatedHyco(t)
 
 	for _, auth := range availableAuths(t, env) {
 		t.Run(auth.name, func(t *testing.T) {
@@ -1167,7 +1189,8 @@ func TestBadRelayName(t *testing.T) {
 
 // TestBadHycoName verifies a clean error for a non-existent hybrid connection.
 func TestBadHycoName(t *testing.T) {
-	env := requireRelayEnv(t)
+	t.Parallel()
+	env := requireDedicatedHyco(t)
 
 	for _, auth := range availableAuths(t, env) {
 		t.Run(auth.name, func(t *testing.T) {
@@ -1186,7 +1209,8 @@ func TestBadHycoName(t *testing.T) {
 
 // TestBadSASKey verifies a clean error and no key leakage for an invalid SAS key.
 func TestBadSASKey(t *testing.T) {
-	env := requireRelayEnv(t)
+	t.Parallel()
+	env := requireDedicatedHyco(t)
 	if env.sasHyco == "" || env.sasListenerKeyName == "" {
 		t.Skip("SAS hyco / listener key name not configured")
 	}
@@ -1269,7 +1293,8 @@ func TestMissingRequiredArgs(t *testing.T) {
 // log line WITHOUT the "(retrying)" suffix) rather than just sleeping and
 // checking for the absence of a leak.
 func TestBadSASKeySender(t *testing.T) {
-	env := requireRelayEnv(t)
+	t.Parallel()
+	env := requireDedicatedHyco(t)
 	if env.sasHyco == "" || env.sasSenderKeyName == "" {
 		t.Skip("SAS hyco / sender key name not configured")
 	}
@@ -1300,7 +1325,8 @@ func TestBadSASKeySender(t *testing.T) {
 
 // TestWrongSASClaim verifies that using a listener key for sending (and vice versa) fails.
 func TestWrongSASClaim(t *testing.T) {
-	env := requireRelayEnv(t)
+	t.Parallel()
+	env := requireDedicatedHyco(t)
 	if env.sasHyco == "" ||
 		env.sasListenerKeyName == "" || env.sasListenerKey == "" ||
 		env.sasSenderKeyName == "" || env.sasSenderKey == "" {
@@ -1367,7 +1393,8 @@ func TestWrongSASClaim(t *testing.T) {
 
 // TestPortForwardClosedPort verifies clean behavior when the listener dials a closed port.
 func TestPortForwardClosedPort(t *testing.T) {
-	env := requireRelayEnv(t)
+	t.Parallel()
+	env := requireDedicatedHyco(t)
 
 	for _, auth := range availableAuths(t, env) {
 		t.Run(auth.name, func(t *testing.T) {
@@ -1415,7 +1442,8 @@ func TestPortForwardClosedPort(t *testing.T) {
 
 // TestSOCKS5ClosedPort verifies clean behavior when SOCKS5 targets a closed port.
 func TestSOCKS5ClosedPort(t *testing.T) {
-	env := requireRelayEnv(t)
+	t.Parallel()
+	env := requireDedicatedHyco(t)
 
 	for _, auth := range availableAuths(t, env) {
 		t.Run(auth.name, func(t *testing.T) {
@@ -1453,7 +1481,8 @@ func TestSOCKS5ClosedPort(t *testing.T) {
 
 // TestPortForwardUnreachable verifies timeout behavior when the target is unreachable.
 func TestPortForwardUnreachable(t *testing.T) {
-	env := requireRelayEnv(t)
+	t.Parallel()
+	env := requireDedicatedHyco(t)
 
 	for _, auth := range availableAuths(t, env) {
 		t.Run(auth.name, func(t *testing.T) {

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -15,9 +15,13 @@
 //
 // Each test provisions its own pair of ephemeral hybrid connections —
 // e2e-entra-<hex> for Entra ID auth and e2e-sas-<hex> for SAS key auth —
-// via azrelay.Provider in TestMain and tears them down via t.Cleanup. No
-// SAS keys are configured by hand; the provisioner creates the SAS
-// authorization rules and reads the listener/sender keys on the fly.
+// via azrelay.Provider in TestMain and tears them down via t.Cleanup.
+// SAS keys are not configured by hand: TestMain acquires two namespace-
+// scoped authorization rules once per `go test` invocation (Listen-only
+// and Send-only, named e2e-run-<hex>-{listener,sender}) via
+// azrelay.AcquireRunRules, and Provider.Provision stamps the resulting
+// keys onto every per-test SAS hyco. The run rules are torn down on
+// TestMain exit; the orphan janitor reaps anything left behind.
 //
 // Functional tests run against all available auth methods (entra, sas)
 // unless E2E_AUTH=entra or E2E_AUTH=sas is set to pin one.
@@ -245,13 +249,35 @@ func TestSSHProxyCommand(t *testing.T) {
 // TestSASKeyAuth verifies port-forward works with separate listener/sender SAS keys.
 func TestSASKeyAuth(t *testing.T) {
 	t.Parallel()
+	requireAuth(t, "sas")
 	env := requireDedicatedHyco(t)
-	// requireDedicatedHyco always returns a fully-populated SAS pair
-	// (Provider.Provision creates the listener+sender authorizationRules
-	// and reads their keys). The defensive check here flags a Provider
-	// contract regression rather than a contributor mis-configuration.
+	// requireDedicatedHyco always returns a fully-populated SAS pair:
+	// the per-test SAS hyco is created by Provider.Provision, and the
+	// listener/sender keys are stamped from the run-scoped namespace
+	// rules acquired once by AcquireRunRules in TestMain. The defensive
+	// check here flags a Provider contract regression rather than a
+	// contributor mis-configuration.
 	if env.sasHyco == "" || env.sasListenerKeyName == "" || env.sasListenerKey == "" || env.sasSenderKeyName == "" || env.sasSenderKey == "" {
-		t.Fatalf("provisioner returned env with empty SAS fields: %+v", env)
+		var missing []string
+		if env.sasHyco == "" {
+			missing = append(missing, "sasHyco")
+		}
+		if env.sasListenerKeyName == "" {
+			missing = append(missing, "sasListenerKeyName")
+		}
+		if env.sasListenerKey == "" {
+			missing = append(missing, "sasListenerKey")
+		}
+		if env.sasSenderKeyName == "" {
+			missing = append(missing, "sasSenderKeyName")
+		}
+		if env.sasSenderKey == "" {
+			missing = append(missing, "sasSenderKey")
+		}
+		// Report only the names of the empty fields, never the populated key
+		// values themselves — this branch shouldn't trigger in CI, but %+v
+		// of relayEnv would leak live SAS keys if it ever did.
+		t.Fatalf("provisioner returned env with empty SAS fields: %v", missing)
 	}
 
 	echo := startEchoServer(t)
@@ -1217,6 +1243,7 @@ func TestBadHycoName(t *testing.T) {
 // TestBadSASKey verifies a clean error and no key leakage for an invalid SAS key.
 func TestBadSASKey(t *testing.T) {
 	t.Parallel()
+	requireAuth(t, "sas")
 	env := requireDedicatedHyco(t)
 	if env.sasHyco == "" || env.sasListenerKeyName == "" {
 		t.Skip("SAS hyco / listener key name not configured")
@@ -1301,6 +1328,7 @@ func TestMissingRequiredArgs(t *testing.T) {
 // checking for the absence of a leak.
 func TestBadSASKeySender(t *testing.T) {
 	t.Parallel()
+	requireAuth(t, "sas")
 	env := requireDedicatedHyco(t)
 	if env.sasHyco == "" || env.sasSenderKeyName == "" {
 		t.Skip("SAS hyco / sender key name not configured")
@@ -1333,6 +1361,7 @@ func TestBadSASKeySender(t *testing.T) {
 // TestWrongSASClaim verifies that using a listener key for sending (and vice versa) fails.
 func TestWrongSASClaim(t *testing.T) {
 	t.Parallel()
+	requireAuth(t, "sas")
 	env := requireDedicatedHyco(t)
 	if env.sasHyco == "" ||
 		env.sasListenerKeyName == "" || env.sasListenerKey == "" ||

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -4,25 +4,28 @@
 // Azure Relay. Tests are gated behind the "e2e" build tag and require:
 //
 //   - E2E_RELAY_NAME: Azure Relay namespace name
-//   - At least one auth method configured (Entra ID and/or SAS keys)
+//   - E2E_RESOURCE_GROUP: resource group containing the namespace
+//   - AZURE_SUBSCRIPTION_ID: subscription ID for ARM API calls
+//   - Valid Azure credentials (az login, managed identity, OIDC, etc.)
 //
-// Entra ID auth:
+// Run `eval "$(make e2e-infra-env)"` to export all three from the
+// resource group provisioned by `make e2e-infra-setup`; the
+// `e2e-infra env` tool resolves AZURE_SUBSCRIPTION_ID from the
+// Azure CLI default if not already exported.
 //
-//   - E2E_ENTRA_HYCO_NAME: hybrid connection name (Entra ID auth)
-//   - Valid Azure credentials (az login, managed identity, etc.)
+// Each test provisions its own pair of ephemeral hybrid connections —
+// e2e-entra-<hex> for Entra ID auth and e2e-sas-<hex> for SAS key auth —
+// via azrelay.Provider in TestMain and tears them down via t.Cleanup. No
+// SAS keys are configured by hand; the provisioner creates the SAS
+// authorization rules and reads the listener/sender keys on the fly.
 //
-// SAS key auth:
-//
-//   - E2E_SAS_HYCO_NAME: hybrid connection for SAS key tests
-//   - E2E_SAS_LISTENER_KEY_NAME + E2E_SAS_LISTENER_KEY: listener SAS credentials
-//   - E2E_SAS_SENDER_KEY_NAME + E2E_SAS_SENDER_KEY: sender SAS credentials
-//
-// Functional tests run against all available auth methods. Auth-specific tests
-// (e.g., TestSASKeyAuth, TestWrongSASClaim) only run when their credentials
-// are configured.
+// Functional tests run against all available auth methods (entra, sas)
+// unless E2E_AUTH=entra or E2E_AUTH=sas is set to pin one.
 //
 // Optional:
 //
+//   - E2E_AUTH: restrict to "entra" or "sas" (default: both)
+//   - E2E_PROVISIONER_CONCURRENCY: cap on parallel hyco provisions (default 4)
 //   - E2E_LARGE_TRANSFER=1: enable 100MB bulk transfer test
 //   - E2E_LONG_LIVED=1: enable >2min keepalive test
 //
@@ -243,8 +246,12 @@ func TestSSHProxyCommand(t *testing.T) {
 func TestSASKeyAuth(t *testing.T) {
 	t.Parallel()
 	env := requireDedicatedHyco(t)
+	// requireDedicatedHyco always returns a fully-populated SAS pair
+	// (Provider.Provision creates the listener+sender authorizationRules
+	// and reads their keys). The defensive check here flags a Provider
+	// contract regression rather than a contributor mis-configuration.
 	if env.sasHyco == "" || env.sasListenerKeyName == "" || env.sasListenerKey == "" || env.sasSenderKeyName == "" || env.sasSenderKey == "" {
-		t.Skip("SAS credentials not configured (E2E_SAS_HYCO_NAME, E2E_SAS_*_KEY_NAME, E2E_SAS_*_KEY)")
+		t.Fatalf("provisioner returned env with empty SAS fields: %+v", env)
 	}
 
 	echo := startEchoServer(t)

--- a/e2e/helpers_test.go
+++ b/e2e/helpers_test.go
@@ -239,9 +239,15 @@ var (
 	buildErr    error
 )
 
-// aztunnelBinary builds the aztunnel binary once and returns its path.
-func aztunnelBinary(t testing.TB) string {
-	t.Helper()
+// buildAztunnelBinary compiles cmd/aztunnel into ./bin/aztunnel under
+// the repo root. Safe to call repeatedly: only the first call does
+// the work (sync.Once), subsequent calls are free.
+//
+// Called from TestMain so the build cost is paid before any test
+// starts and is never charged against a per-test deadline. Tests
+// keep going through aztunnelBinary(t) which surfaces any build
+// error through t.Fatalf on the calling goroutine.
+func buildAztunnelBinary() error {
 	buildOnce.Do(func() {
 		// Find the repo root (parent of e2e/).
 		dir, _ := os.Getwd()
@@ -258,8 +264,18 @@ func aztunnelBinary(t testing.TB) string {
 			buildErr = fmt.Errorf("build: %w\n%s", err, out)
 		}
 	})
-	if buildErr != nil {
-		t.Fatalf("build aztunnel: %v", buildErr)
+	return buildErr
+}
+
+// aztunnelBinary returns the path to the pre-built aztunnel binary.
+// TestMain pre-warms the build before tests start; tests that call
+// this on a cold sync.Once (e.g. running a single test through `go
+// test -run`) will still trigger the build on first use, but every
+// CI / `go test ./...` path goes through TestMain first.
+func aztunnelBinary(t testing.TB) string {
+	t.Helper()
+	if err := buildAztunnelBinary(); err != nil {
+		t.Fatalf("build aztunnel: %v", err)
 	}
 	return builtBinary
 }

--- a/e2e/helpers_test.go
+++ b/e2e/helpers_test.go
@@ -3,6 +3,7 @@
 package e2e
 
 import (
+	"context"
 	"encoding/binary"
 	"fmt"
 	"io"
@@ -16,6 +17,8 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/philsphicas/aztunnel/e2e/azrelay"
 )
 
 // relayEnv holds the Azure Relay configuration for e2e tests.
@@ -38,6 +41,15 @@ type authConfig struct {
 }
 
 // requireRelayEnv reads config from env vars and skips if nothing is configured.
+//
+// Phase 2 of the per-test isolation work (#49) introduces
+// requireDedicatedHyco as the preferred entry point: each test owns
+// its own freshly-provisioned hyco pair, and the test is free to
+// call t.Parallel(). requireRelayEnv reads the legacy shared pair
+// established by TestMain and is kept for callers that have not yet
+// migrated; Phase 3 will convert this function into a thin forwarder
+// over requireDedicatedHyco so the migration cannot silently skip
+// any unmigrated tests once TestMain stops pre-provisioning.
 func requireRelayEnv(t testing.TB) *relayEnv {
 	t.Helper()
 	relay := os.Getenv("E2E_RELAY_NAME")
@@ -57,6 +69,103 @@ func requireRelayEnv(t testing.TB) *relayEnv {
 		sasListenerKey:     os.Getenv("E2E_SAS_LISTENER_KEY"),
 		sasSenderKeyName:   os.Getenv("E2E_SAS_SENDER_KEY_NAME"),
 		sasSenderKey:       os.Getenv("E2E_SAS_SENDER_KEY"),
+	}
+}
+
+// hycoProvisionTimeout bounds a single Provider.Provision call from
+// requireDedicatedHyco. The provisioner already retries 429s and
+// transient 5xx through azcore (MaxRetries=6, MaxRetryDelay=60s) and
+// 40901 conflicts through retryOnAuthRuleConflict; this ceiling
+// stops a genuinely stuck control plane from hanging the test until
+// the suite-wide go-test -timeout fires.
+const hycoProvisionTimeout = 3 * time.Minute
+
+// hycoTeardownTimeout bounds the t.Cleanup-registered Teardown call.
+// Teardown also gates on the Provider semaphore so a swarm of test
+// cleanups cannot stampede the namespace 429 envelope; the budget
+// here must be larger than the worst-case sem wait + 2 × ARM Delete.
+const hycoTeardownTimeout = 90 * time.Second
+
+// requireProvider returns the process-scoped Provider. Skips the
+// test when E2E_RELAY_NAME is unset (i.e. when TestMain did not
+// construct a Provider).
+func requireProvider(t testing.TB) *azrelay.Provider {
+	t.Helper()
+	if relayProvider == nil {
+		t.Skip("E2E_RELAY_NAME must be set for e2e tests")
+	}
+	return relayProvider
+}
+
+// requireDedicatedHyco provisions a fresh (entra, sas) hyco pair for
+// the calling test, registers a t.Cleanup that tears the pair down,
+// and returns its connection metadata in the legacy *relayEnv shape.
+// The pair is independent of every other test's pair: there is no
+// way for a stray listener or sender from another test to route
+// through it.
+//
+// # Ordering requirement
+//
+// Callers MUST invoke t.Parallel() BEFORE calling this function:
+//
+//	func TestSomething(t *testing.T) {
+//	    t.Parallel()                            // FIRST
+//	    env := requireDedicatedHyco(t)          // THEN provision
+//	    auth := availableAuths(t, env)[0]
+//	    // ...
+//	}
+//
+// Go's testing package only releases a test to run in parallel with
+// its peers once it calls t.Parallel(). If a test calls
+// requireDedicatedHyco BEFORE t.Parallel(), the Provision will
+// happen on the serial path and the Provider's concurrency semaphore
+// cannot overlap it with peer provisions — the suite-wide wall-clock
+// win collapses. Reviewing this ordering is a code-review checklist
+// item; the function cannot enforce it because the testing package
+// exposes no "am I parallel yet?" signal.
+//
+// Skips the test when E2E_RELAY_NAME is unset.
+//
+// Backend contract (for callers wiring this into a parity Backend
+// implementation): one call → one fresh hyco pair. Scenarios that
+// need multiple hyco pairs (e.g. cross-version listeners on
+// different hycos) call requireDedicatedHyco multiple times and pay
+// N× provisioning. Cross-call sharing within one scenario is out of
+// scope for the Backend.Setup contract.
+func requireDedicatedHyco(t testing.TB) *relayEnv {
+	t.Helper()
+	p := requireProvider(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), hycoProvisionTimeout)
+	defer cancel()
+	tok, err := p.Provision(ctx)
+	if err != nil {
+		t.Fatalf("provision dedicated hyco pair: %v", err)
+	}
+
+	entra, sas := tok.HycoNames()
+	t.Logf("provisioned dedicated hyco pair: %s, %s", entra, sas)
+
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), hycoTeardownTimeout)
+		defer cancel()
+		if err := tok.Teardown(ctx); err != nil {
+			// Log only — the janitor will reap anything we miss,
+			// and failing the test on cleanup errors would mask
+			// the actual test outcome.
+			t.Logf("teardown dedicated hyco pair %s/%s: %v", entra, sas, err)
+		}
+	})
+
+	r := tok.Result()
+	return &relayEnv{
+		relayName:          r.RelayName,
+		hyco:               r.EntraHycoName,
+		sasHyco:            r.SASHycoName,
+		sasListenerKeyName: r.ListenerKeyName,
+		sasListenerKey:     r.ListenerKey,
+		sasSenderKeyName:   r.SenderKeyName,
+		sasSenderKey:       r.SenderKey,
 	}
 }
 

--- a/e2e/helpers_test.go
+++ b/e2e/helpers_test.go
@@ -40,36 +40,32 @@ type authConfig struct {
 	senderSAS   *sasCredentials // nil → Entra ID auth
 }
 
-// requireRelayEnv reads config from env vars and skips if nothing is configured.
+// requireRelayEnv is a thin compatibility forwarder over
+// requireDedicatedHyco. Every caller of this function now receives a
+// freshly-provisioned, dedicated hyco pair; the legacy shared
+// E2E_*_HYCO_NAME / E2E_SAS_*_KEY env vars are no longer consulted.
 //
-// Phase 2 of the per-test isolation work (#49) introduces
-// requireDedicatedHyco as the preferred entry point: each test owns
-// its own freshly-provisioned hyco pair, and the test is free to
-// call t.Parallel(). requireRelayEnv reads the legacy shared pair
-// established by TestMain and is kept for callers that have not yet
-// migrated; Phase 3 will convert this function into a thin forwarder
-// over requireDedicatedHyco so the migration cannot silently skip
-// any unmigrated tests once TestMain stops pre-provisioning.
+// Kept (rather than mechanically renaming all callers) for two
+// reasons during the per-test isolation migration (#49):
+//
+//  1. parity_test.go and parity_bench_test.go (slice-2 territory)
+//     intentionally do NOT call t.Parallel() and own their own
+//     migration path; they continue to call requireRelayEnv so the
+//     parallel-test rules in requireDedicatedHyco's godoc do not
+//     apply to them transitively. They still get a dedicated pair,
+//     just on the serial path.
+//
+//  2. Avoids a "silent t.Skip" failure mode during the migration
+//     window: if TestMain stopped pre-provisioning the legacy shared
+//     pair AND an unmigrated test still read E2E_ENTRA_HYCO_NAME,
+//     that test would skip without provisioning anything, leaving
+//     CI green but coverage gone.
+//
+// Phase 6 will delete this once parity tests have their own
+// per-scenario Backend wiring and there are no callers left.
 func requireRelayEnv(t testing.TB) *relayEnv {
 	t.Helper()
-	relay := os.Getenv("E2E_RELAY_NAME")
-	if relay == "" {
-		t.Skip("E2E_RELAY_NAME must be set for e2e tests")
-	}
-	hyco := os.Getenv("E2E_ENTRA_HYCO_NAME")
-	sasHyco := os.Getenv("E2E_SAS_HYCO_NAME")
-	if hyco == "" && sasHyco == "" {
-		t.Skip("at least one of E2E_ENTRA_HYCO_NAME or E2E_SAS_HYCO_NAME must be set")
-	}
-	return &relayEnv{
-		relayName:          relay,
-		hyco:               hyco,
-		sasHyco:            sasHyco,
-		sasListenerKeyName: os.Getenv("E2E_SAS_LISTENER_KEY_NAME"),
-		sasListenerKey:     os.Getenv("E2E_SAS_LISTENER_KEY"),
-		sasSenderKeyName:   os.Getenv("E2E_SAS_SENDER_KEY_NAME"),
-		sasSenderKey:       os.Getenv("E2E_SAS_SENDER_KEY"),
-	}
+	return requireDedicatedHyco(t)
 }
 
 // hycoProvisionTimeout bounds a single Provider.Provision call from

--- a/e2e/helpers_test.go
+++ b/e2e/helpers_test.go
@@ -42,10 +42,12 @@ type authConfig struct {
 
 // hycoProvisionTimeout bounds a single Provider.Provision call from
 // requireDedicatedHyco. The provisioner already retries 429s and
-// transient 5xx through azcore (MaxRetries=6, MaxRetryDelay=60s) and
-// 40901 conflicts through retryOnAuthRuleConflict; this ceiling
-// stops a genuinely stuck control plane from hanging the test until
-// the suite-wide go-test -timeout fires.
+// transient 5xx through azcore (MaxRetries=6, MaxRetryDelay=60s); per-
+// pair provisioning no longer mutates authorization rules, so the
+// 40901 retry loop in retryOnAuthRuleConflict is only paid once per
+// `go test` invocation (by AcquireRunRules), not per Provision. This
+// ceiling stops a genuinely stuck control plane from hanging the test
+// until the suite-wide go-test -timeout fires.
 const hycoProvisionTimeout = 3 * time.Minute
 
 // hycoTeardownTimeout bounds the t.Cleanup-registered Teardown call.
@@ -228,6 +230,26 @@ func drainBenchLease() {
 	entra, sas := tok.HycoNames()
 	if err := tok.Teardown(ctx); err != nil {
 		fmt.Fprintf(os.Stderr, "==> e2e: teardown shared bench hyco pair %s/%s: %v\n", entra, sas, err)
+	}
+}
+
+// requireAuth skips the calling test if E2E_AUTH is set to a value that
+// excludes the given auth method ("entra" or "sas"). This is used by
+// tests that are intrinsically tied to a single auth method (e.g. the
+// SAS-specific TestSASKeyAuth, TestBadSASKey, TestBadSASKeySender,
+// TestWrongSASClaim) so a contributor running with E2E_AUTH=entra
+// genuinely skips the SAS suite instead of running SAS-only assertions
+// against unfiltered fixtures.
+func requireAuth(t testing.TB, name string) {
+	t.Helper()
+	filter := os.Getenv("E2E_AUTH")
+	switch filter {
+	case "", name:
+		return
+	case "entra", "sas":
+		t.Skipf("E2E_AUTH=%q excludes %q", filter, name)
+	default:
+		t.Fatalf("unsupported E2E_AUTH value %q; expected \"entra\", \"sas\", or \"\" (both)", filter)
 	}
 }
 

--- a/e2e/helpers_test.go
+++ b/e2e/helpers_test.go
@@ -40,34 +40,6 @@ type authConfig struct {
 	senderSAS   *sasCredentials // nil → Entra ID auth
 }
 
-// requireRelayEnv is a thin compatibility forwarder over
-// requireDedicatedHyco. Every caller of this function now receives a
-// freshly-provisioned, dedicated hyco pair; the legacy shared
-// E2E_*_HYCO_NAME / E2E_SAS_*_KEY env vars are no longer consulted.
-//
-// Kept (rather than mechanically renaming all callers) for two
-// reasons during the per-test isolation migration (#49):
-//
-//  1. parity_test.go and parity_bench_test.go (slice-2 territory)
-//     intentionally do NOT call t.Parallel() and own their own
-//     migration path; they continue to call requireRelayEnv so the
-//     parallel-test rules in requireDedicatedHyco's godoc do not
-//     apply to them transitively. They still get a dedicated pair,
-//     just on the serial path.
-//
-//  2. Avoids a "silent t.Skip" failure mode during the migration
-//     window: if TestMain stopped pre-provisioning the legacy shared
-//     pair AND an unmigrated test still read E2E_ENTRA_HYCO_NAME,
-//     that test would skip without provisioning anything, leaving
-//     CI green but coverage gone.
-//
-// Phase 6 will delete this once parity tests have their own
-// per-scenario Backend wiring and there are no callers left.
-func requireRelayEnv(t testing.TB) *relayEnv {
-	t.Helper()
-	return requireDedicatedHyco(t)
-}
-
 // hycoProvisionTimeout bounds a single Provider.Provision call from
 // requireDedicatedHyco. The provisioner already retries 429s and
 // transient 5xx through azcore (MaxRetries=6, MaxRetryDelay=60s) and
@@ -102,7 +74,7 @@ func requireProvider(t testing.TB) *azrelay.Provider {
 //
 // # Ordering requirement
 //
-// Callers MUST invoke t.Parallel() BEFORE calling this function:
+// Callers SHOULD invoke t.Parallel() BEFORE calling this function:
 //
 //	func TestSomething(t *testing.T) {
 //	    t.Parallel()                            // FIRST
@@ -119,6 +91,13 @@ func requireProvider(t testing.TB) *azrelay.Provider {
 // win collapses. Reviewing this ordering is a code-review checklist
 // item; the function cannot enforce it because the testing package
 // exposes no "am I parallel yet?" signal.
+//
+// Exception: TestParity_Azure deliberately does NOT call t.Parallel()
+// because relayparity.AssertNoLeaks samples process-wide goroutine
+// and FD counts and would false-positive under parallel scenarios.
+// Parity therefore provisions serially via azureBackend.acquireEnv,
+// which is fine — the wall-clock win is bounded by goroutine-leak
+// detection there, not by hyco provisioning.
 //
 // Skips the test when E2E_RELAY_NAME is unset.
 //
@@ -154,6 +133,15 @@ func requireDedicatedHyco(t testing.TB) *relayEnv {
 	})
 
 	r := tok.Result()
+	return resultToEnv(r)
+}
+
+// resultToEnv converts an azrelay.Result (the per-pair metadata
+// returned by Provider.Provision) into the legacy *relayEnv shape
+// the existing helpers (startListener, startPortForwardSender, ...)
+// take. Shared by requireDedicatedHyco and leaseSharedHyco so the
+// field mapping cannot drift between the two acquisition paths.
+func resultToEnv(r *azrelay.Result) *relayEnv {
 	return &relayEnv{
 		relayName:          r.RelayName,
 		hyco:               r.EntraHycoName,
@@ -162,6 +150,84 @@ func requireDedicatedHyco(t testing.TB) *relayEnv {
 		sasListenerKey:     r.ListenerKey,
 		sasSenderKeyName:   r.SenderKeyName,
 		sasSenderKey:       r.SenderKey,
+	}
+}
+
+// benchLease holds the single process-wide hyco pair leased on the
+// first leaseSharedHyco call. drainBenchLease releases it after
+// m.Run returns. Concurrent leaseSharedHyco callers are serialised
+// by the mutex; in practice b.Run sub-benches inside a single
+// BenchmarkParity_Azure run sequentially so the lock is uncontended
+// past the first call.
+var (
+	benchLeaseMu  sync.Mutex
+	benchLeaseEnv *relayEnv
+	benchLeaseTok *azrelay.PairToken
+	benchLeaseErr error
+)
+
+// leaseSharedHyco returns a process-shared (entra, sas) hyco pair
+// suitable for sub-benches that should NOT pay per-Setup provisioning
+// cost. The first call provisions the pair via the same Provider used
+// by requireDedicatedHyco; subsequent calls return the cached env.
+// drainBenchLease (called from testMain after m.Run) tears it down.
+//
+// Errors from the first Provision are sticky: every subsequent call
+// in the same process re-fatals with the cached error so retry loops
+// inside the bench framework do not silently mask a control-plane
+// failure that already burned wall-clock budget.
+//
+// Not registered with t.Cleanup — the lease is intentionally process-
+// scoped, not test-scoped, so multiple b.Run sub-benches can share
+// it. Safe to call from any benchmark goroutine.
+func leaseSharedHyco(tb testing.TB) *relayEnv {
+	tb.Helper()
+	p := requireProvider(tb)
+
+	benchLeaseMu.Lock()
+	defer benchLeaseMu.Unlock()
+
+	if benchLeaseEnv != nil {
+		return benchLeaseEnv
+	}
+	if benchLeaseErr != nil {
+		tb.Fatalf("lease shared bench hyco pair (cached error): %v", benchLeaseErr)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), hycoProvisionTimeout)
+	defer cancel()
+	tok, err := p.Provision(ctx)
+	if err != nil {
+		benchLeaseErr = err
+		tb.Fatalf("provision shared bench hyco pair: %v", err)
+	}
+	entra, sas := tok.HycoNames()
+	tb.Logf("leased shared bench hyco pair: %s, %s", entra, sas)
+	benchLeaseTok = tok
+	benchLeaseEnv = resultToEnv(tok.Result())
+	return benchLeaseEnv
+}
+
+// drainBenchLease tears down the shared bench hyco pair, if any.
+// Called from testMain via defer after m.Run() so the lease is
+// released on every exit path including panics that the testing
+// framework recovers from. No-op when no benchmark called
+// leaseSharedHyco. Failures are logged to stderr — the janitor will
+// reap anything we leak, and the process is already exiting so
+// failing it on cleanup would provide no extra signal.
+func drainBenchLease() {
+	benchLeaseMu.Lock()
+	defer benchLeaseMu.Unlock()
+	if benchLeaseTok == nil {
+		return
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), hycoTeardownTimeout)
+	defer cancel()
+	tok := benchLeaseTok
+	benchLeaseTok = nil
+	entra, sas := tok.HycoNames()
+	if err := tok.Teardown(ctx); err != nil {
+		fmt.Fprintf(os.Stderr, "==> e2e: teardown shared bench hyco pair %s/%s: %v\n", entra, sas, err)
 	}
 }
 
@@ -193,9 +259,68 @@ func availableAuths(t testing.TB, env *relayEnv) []authConfig {
 		})
 	}
 	if len(configs) == 0 {
-		t.Skip("no auth configured (need E2E_ENTRA_HYCO_NAME or SAS credentials)")
+		t.Skip("no auth configured (set E2E_AUTH=entra|sas or leave unset for both)")
 	}
 	return configs
+}
+
+// availableAuthNames returns the auth method names to exercise based
+// on the E2E_AUTH filter, without binding to a specific env. Used by
+// callers that pick an authConfig only AFTER provisioning a fresh
+// hyco pair (e.g. TestParity_Azure / BenchmarkParity_Azure, which
+// build authConfig inside Backend.Setup via authFromEnv).
+//
+// Returns ["entra", "sas"] when E2E_AUTH is empty, ["entra"] when
+// E2E_AUTH=entra, ["sas"] when E2E_AUTH=sas. Any other value fails
+// the caller.
+//
+// The shared Provider always provisions both an Entra hyco and a SAS
+// hyco per call, so there is no "auth method is unavailable" branch
+// here — every name returned is guaranteed buildable by authFromEnv
+// once a fresh env is in hand.
+func availableAuthNames(t testing.TB) []string {
+	t.Helper()
+	filter := os.Getenv("E2E_AUTH")
+	switch filter {
+	case "":
+		return []string{"entra", "sas"}
+	case "entra", "sas":
+		return []string{filter}
+	default:
+		t.Fatalf("unsupported E2E_AUTH value %q; expected \"entra\", \"sas\", or \"\" (both)", filter)
+		return nil
+	}
+}
+
+// authFromEnv builds the authConfig for the named auth method from a
+// freshly-provisioned env. Used by azureBackend.Setup to derive the
+// concrete auth (hyco + optional SAS creds) AFTER each Setup call
+// provisions its own hyco pair. The env is assumed to have been
+// produced by Provider.Provision (i.e. both entra and SAS slots are
+// populated); a missing field will fail the test rather than skip.
+func authFromEnv(t testing.TB, env *relayEnv, name string) authConfig {
+	t.Helper()
+	switch name {
+	case "entra":
+		if env.hyco == "" {
+			t.Fatalf("authFromEnv: env.hyco is empty for entra auth")
+		}
+		return authConfig{name: "entra", hyco: env.hyco}
+	case "sas":
+		if env.sasHyco == "" || env.sasListenerKeyName == "" || env.sasListenerKey == "" ||
+			env.sasSenderKeyName == "" || env.sasSenderKey == "" {
+			t.Fatalf("authFromEnv: SAS fields missing on env for sas auth")
+		}
+		return authConfig{
+			name:        "sas",
+			hyco:        env.sasHyco,
+			listenerSAS: &sasCredentials{keyName: env.sasListenerKeyName, key: env.sasListenerKey},
+			senderSAS:   &sasCredentials{keyName: env.sasSenderKeyName, key: env.sasSenderKey},
+		}
+	default:
+		t.Fatalf("authFromEnv: unknown auth name %q", name)
+		return authConfig{}
+	}
 }
 
 // startListener starts an aztunnel relay-listener with the given auth config.

--- a/e2e/infra/cmd/e2e-infra/main.go
+++ b/e2e/infra/cmd/e2e-infra/main.go
@@ -10,7 +10,9 @@
 //	clean      — Delete the resource group (and everything in it)
 //	grant      — Grant Azure Relay Owner to a principal
 //	env        — Print the env vars required to run e2e tests locally
-//	janitor    — Delete orphan e2e-{entra,sas}-<hex> hycos older than --max-age
+//	janitor    — Delete orphan e2e-{entra,sas}-<hex> hycos AND
+//	             e2e-run-<hex>-{listener,sender} namespace SAS rules
+//	             older than --max-age
 package main
 
 import (
@@ -39,7 +41,7 @@ var CLI struct {
 	Clean   CleanCmd   `cmd:"" help:"Delete the resource group."`
 	Grant   GrantCmd   `cmd:"" help:"Grant Azure Relay Owner to a principal."`
 	Env     EnvCmd     `cmd:"" help:"Print E2E_* env vars for local test runs."`
-	Janitor JanitorCmd `cmd:"" help:"Delete orphan e2e-{entra,sas}-<hex> hybrid connections."`
+	Janitor JanitorCmd `cmd:"" help:"Delete orphan e2e-{entra,sas}-<hex> hycos AND e2e-run-<hex>-{listener,sender} namespace SAS rules."`
 }
 
 // SetupCmd creates the resource group + relay namespace and grants the
@@ -198,9 +200,10 @@ func (c *EnvCmd) Run(ctx context.Context) error {
 	return nil
 }
 
-// JanitorCmd deletes orphan per-invocation hycos older than --max-age.
+// JanitorCmd deletes orphan per-invocation hycos and per-run namespace
+// SAS rules older than --max-age.
 type JanitorCmd struct {
-	MaxAge time.Duration `name:"max-age" default:"4h" help:"Delete e2e-{entra,sas}-<hex> hycos older than this."`
+	MaxAge time.Duration `name:"max-age" default:"4h" help:"Delete e2e-{entra,sas}-<hex> hycos AND e2e-run-<hex>-{listener,sender} rules older than this."`
 	DryRun bool          `name:"dry-run" help:"Print what would be deleted without deleting."`
 }
 

--- a/e2e/infra/janitor/janitor.go
+++ b/e2e/infra/janitor/janitor.go
@@ -1,7 +1,8 @@
-// Package janitor deletes orphan per-invocation hybrid connections from
-// the aztunnel E2E relay namespace. Names are matched against
-// azrelay.HycoNamePattern so static bootstrap hycos and unrelated hycos
-// in the namespace are not touched.
+// Package janitor deletes orphan per-invocation hybrid connections and
+// per-`go test`-run namespace authorization rules from the aztunnel E2E
+// relay namespace. Names are matched against azrelay.HycoNamePattern
+// and azrelay.RunRuleNamePattern so static bootstrap entities and any
+// unrelated entities in the namespace are not touched.
 package janitor
 
 import (
@@ -21,9 +22,9 @@ type Config struct {
 	SubscriptionID string
 	ResourceGroup  string
 	Namespace      string
-	// MaxAge is the minimum age before a matching hyco is considered
-	// orphaned. Hycos younger than MaxAge are skipped (they may belong
-	// to a currently-running test).
+	// MaxAge is the minimum age before a matching entity is considered
+	// orphaned. Entities younger than MaxAge are skipped (they may
+	// belong to a currently-running test).
 	MaxAge time.Duration
 	// DryRun, when true, prints what would be deleted without deleting.
 	DryRun bool
@@ -31,9 +32,11 @@ type Config struct {
 	Cred azcore.TokenCredential
 }
 
-// Run lists hycos in the namespace, filters by name pattern and age, and
-// deletes the matching ones. Per-delete errors are logged but do not
-// abort the run; the function returns the first list-time error or nil.
+// Run lists hycos AND namespace authorization rules in the namespace,
+// filters by name pattern and age, and deletes the matching orphans.
+// Per-delete errors are logged but do not abort the run; the function
+// returns the first list-time error or nil if everything succeeded
+// (a non-zero per-delete failure count surfaces as the return error).
 func Run(ctx context.Context, cfg Config) error {
 	if cfg.SubscriptionID == "" || cfg.ResourceGroup == "" || cfg.Namespace == "" {
 		return fmt.Errorf("janitor: SubscriptionID, ResourceGroup, Namespace are required")
@@ -44,9 +47,13 @@ func Run(ctx context.Context, cfg Config) error {
 	if cfg.Cred == nil {
 		return fmt.Errorf("janitor: Cred is required")
 	}
-	client, err := armrelay.NewHybridConnectionsClient(cfg.SubscriptionID, cfg.Cred, nil)
+	hycoClient, err := armrelay.NewHybridConnectionsClient(cfg.SubscriptionID, cfg.Cred, nil)
 	if err != nil {
 		return fmt.Errorf("new hybrid connections client: %w", err)
+	}
+	nsClient, err := armrelay.NewNamespacesClient(cfg.SubscriptionID, cfg.Cred, nil)
+	if err != nil {
+		return fmt.Errorf("new namespaces client: %w", err)
 	}
 	now := time.Now().UTC()
 	threshold := now.Add(-cfg.MaxAge)
@@ -54,12 +61,27 @@ func Run(ctx context.Context, cfg Config) error {
 	fmt.Fprintf(os.Stderr, "==> janitor: namespace=%s max-age=%s (cutoff=%s) dry-run=%t\n",
 		cfg.Namespace, cfg.MaxAge, threshold.Format(time.RFC3339), cfg.DryRun)
 
+	hycoFailed, err := sweepHycos(ctx, hycoClient, cfg, now, threshold)
+	if err != nil {
+		return err
+	}
+	ruleFailed, err := sweepRunRules(ctx, nsClient, cfg, now, threshold)
+	if err != nil {
+		return err
+	}
+	if total := hycoFailed + ruleFailed; total > 0 {
+		return fmt.Errorf("%d delete(s) failed", total)
+	}
+	return nil
+}
+
+func sweepHycos(ctx context.Context, client *armrelay.HybridConnectionsClient, cfg Config, now, threshold time.Time) (failed int, err error) {
 	pager := client.NewListByNamespacePager(cfg.ResourceGroup, cfg.Namespace, nil)
-	var matched, deleted, failed, missingCreatedAt int
+	var matched, deleted, missingCreatedAt int
 	for pager.More() {
 		page, err := pager.NextPage(ctx)
 		if err != nil {
-			return fmt.Errorf("list hycos: %w", err)
+			return 0, fmt.Errorf("list hycos: %w", err)
 		}
 		for _, hc := range page.Value {
 			if hc == nil || hc.Name == nil {
@@ -76,49 +98,107 @@ func Run(ctx context.Context, cfg Config) error {
 				// to a per-item GET before deciding.
 				full, getErr := client.Get(ctx, cfg.ResourceGroup, cfg.Namespace, name, nil)
 				if getErr != nil {
-					fmt.Fprintf(os.Stderr, "    ? %s: list missing createdAt; GET failed: %v; skipping\n", name, getErr)
+					fmt.Fprintf(os.Stderr, "    ? hyco %s: list missing createdAt; GET failed: %v; skipping\n", name, getErr)
 					missingCreatedAt++
 					continue
 				}
 				created = hcCreatedAt(&full.HybridConnection)
 				if created.IsZero() {
-					fmt.Fprintf(os.Stderr, "    ? %s: createdAt unavailable after GET; skipping\n", name)
+					fmt.Fprintf(os.Stderr, "    ? hyco %s: createdAt unavailable after GET; skipping\n", name)
 					missingCreatedAt++
 					continue
 				}
 			}
 			age := now.Sub(created)
 			if created.After(threshold) {
-				fmt.Fprintf(os.Stderr, "    · %s: age=%s < max-age; skipping\n", name, age.Round(time.Second))
+				fmt.Fprintf(os.Stderr, "    · hyco %s: age=%s < max-age; skipping\n", name, age.Round(time.Second))
 				continue
 			}
 			if cfg.DryRun {
-				fmt.Fprintf(os.Stderr, "    - %s: age=%s; would delete (dry-run)\n", name, age.Round(time.Second))
+				fmt.Fprintf(os.Stderr, "    - hyco %s: age=%s; would delete (dry-run)\n", name, age.Round(time.Second))
 				continue
 			}
-			if _, err := client.Delete(ctx, cfg.ResourceGroup, cfg.Namespace, name, nil); err != nil {
-				fmt.Fprintf(os.Stderr, "    ! %s: delete failed: %v\n", name, err)
+			if _, err := client.Delete(ctx, cfg.ResourceGroup, cfg.Namespace, name, nil); err != nil && !azrelay.IsNotFound(err) {
+				fmt.Fprintf(os.Stderr, "    ! hyco %s: delete failed: %v\n", name, err)
 				failed++
 				continue
 			}
-			fmt.Fprintf(os.Stderr, "    ✓ %s: age=%s; deleted\n", name, age.Round(time.Second))
+			fmt.Fprintf(os.Stderr, "    ✓ hyco %s: age=%s; deleted\n", name, age.Round(time.Second))
 			deleted++
 		}
 	}
-	fmt.Fprintf(os.Stderr, "==> janitor: matched=%d deleted=%d failed=%d missing-createdAt=%d\n",
+	fmt.Fprintf(os.Stderr, "==> janitor hycos: matched=%d deleted=%d failed=%d missing-createdAt=%d\n",
 		matched, deleted, failed, missingCreatedAt)
-	// Any matched hyco that we couldn't determine the age of is silently
-	// skipped above (the janitor cannot decide whether it's an orphan).
-	// Surface even a partial outage loudly so operators don't lose track
-	// of slowly-accreting orphans when only some entries lack createdAt.
 	if missingCreatedAt > 0 {
 		fmt.Fprintf(os.Stderr, "==> janitor: WARNING: %d of %d matched hyco(s) were missing createdAt and could not be aged — orphan-reaping is degraded\n",
 			missingCreatedAt, matched)
 	}
-	if failed > 0 {
-		return fmt.Errorf("%d delete(s) failed", failed)
+	return failed, nil
+}
+
+func sweepRunRules(ctx context.Context, client *armrelay.NamespacesClient, cfg Config, now, threshold time.Time) (failed int, err error) {
+	pager := client.NewListAuthorizationRulesPager(cfg.ResourceGroup, cfg.Namespace, nil)
+	var matched, deleted, missingCreatedAt int
+	for pager.More() {
+		page, err := pager.NextPage(ctx)
+		if err != nil {
+			return 0, fmt.Errorf("list authorization rules: %w", err)
+		}
+		for _, rule := range page.Value {
+			if rule == nil || rule.Name == nil {
+				continue
+			}
+			name := *rule.Name
+			if !azrelay.RunRuleNamePattern.MatchString(name) {
+				continue
+			}
+			matched++
+			created := ruleCreatedAt(rule)
+			if created.IsZero() {
+				full, getErr := client.GetAuthorizationRule(ctx, cfg.ResourceGroup, cfg.Namespace, name, nil)
+				if getErr != nil {
+					fmt.Fprintf(os.Stderr, "    ? rule %s: list missing createdAt; GET failed: %v; skipping\n", name, getErr)
+					missingCreatedAt++
+					continue
+				}
+				created = ruleCreatedAt(&full.AuthorizationRule)
+				if created.IsZero() {
+					fmt.Fprintf(os.Stderr, "    ? rule %s: createdAt unavailable after GET; skipping\n", name)
+					missingCreatedAt++
+					continue
+				}
+			}
+			age := now.Sub(created)
+			if created.After(threshold) {
+				fmt.Fprintf(os.Stderr, "    · rule %s: age=%s < max-age; skipping\n", name, age.Round(time.Second))
+				continue
+			}
+			if cfg.DryRun {
+				fmt.Fprintf(os.Stderr, "    - rule %s: age=%s; would delete (dry-run)\n", name, age.Round(time.Second))
+				continue
+			}
+			if err := azrelay.RetryOnAuthRuleConflict(ctx, func() error {
+				_, err := client.DeleteAuthorizationRule(ctx, cfg.ResourceGroup, cfg.Namespace, name, nil)
+				if err != nil && azrelay.IsNotFound(err) {
+					return nil
+				}
+				return err
+			}); err != nil {
+				fmt.Fprintf(os.Stderr, "    ! rule %s: delete failed: %v\n", name, err)
+				failed++
+				continue
+			}
+			fmt.Fprintf(os.Stderr, "    ✓ rule %s: age=%s; deleted\n", name, age.Round(time.Second))
+			deleted++
+		}
 	}
-	return nil
+	fmt.Fprintf(os.Stderr, "==> janitor rules: matched=%d deleted=%d failed=%d missing-createdAt=%d\n",
+		matched, deleted, failed, missingCreatedAt)
+	if missingCreatedAt > 0 {
+		fmt.Fprintf(os.Stderr, "==> janitor: WARNING: %d of %d matched rule(s) were missing createdAt and could not be aged — orphan-reaping is degraded\n",
+			missingCreatedAt, matched)
+	}
+	return failed, nil
 }
 
 func hcCreatedAt(hc *armrelay.HybridConnection) time.Time {
@@ -126,4 +206,11 @@ func hcCreatedAt(hc *armrelay.HybridConnection) time.Time {
 		return time.Time{}
 	}
 	return hc.Properties.CreatedAt.UTC()
+}
+
+func ruleCreatedAt(rule *armrelay.AuthorizationRule) time.Time {
+	if rule == nil || rule.SystemData == nil || rule.SystemData.CreatedAt == nil {
+		return time.Time{}
+	}
+	return rule.SystemData.CreatedAt.UTC()
 }

--- a/e2e/multi_test.go
+++ b/e2e/multi_test.go
@@ -21,7 +21,13 @@ import (
 //
 //   - all N connections through the sender round-trip data correctly;
 //   - distribution: every listener handles at least 1 connection AND
-//     no single listener handles all N (i.e. 0 ≤ min and max ≤ N-1).
+//     no single listener handles every connection — i.e.
+//     min(counts) >= 1 and max(counts) < sum(counts). The bound is
+//     framed against the observed sum (not against N) because the
+//     metrics counters can legitimately exceed N when a connection
+//     retried and re-incremented the counter; the contract we want
+//     to assert is "every listener got at least one and no listener
+//     monopolised everything", not "exactly N connections occurred".
 //     Empirically observed splits range from 1:7 to 6:2 with N=8, so
 //     this bound permits the full known variance while still catching
 //     pathological dropout (listener handling 0 connections, which
@@ -107,14 +113,14 @@ func TestMultiListenerPortForwardSmoke(t *testing.T) {
 
 			// Log per-listener counts so a human reading the test output can
 			// see distribution, and assert the bounded shape: every listener
-			// handled at least 1 flow, and no single listener handled all
-			// numFlows. See the function comment for the rationale.
+			// handled at least 1 flow, and no single listener handled every
+			// observed connection. See the function comment for the rationale.
 			counts := make([]int, len(listenerMetricsAddrs))
 			for i, addr := range listenerMetricsAddrs {
 				counts[i] = int(sumMetric(scrapeMetricsBest(addr), "aztunnel_connections_total"))
 				t.Logf("listener %d (%s) handled %d connections", i, addr, counts[i])
 			}
-			minC, maxC := counts[0], counts[0]
+			minC, maxC, total := counts[0], counts[0], counts[0]
 			for _, c := range counts[1:] {
 				if c < minC {
 					minC = c
@@ -122,12 +128,17 @@ func TestMultiListenerPortForwardSmoke(t *testing.T) {
 				if c > maxC {
 					maxC = c
 				}
+				total += c
 			}
 			if minC < 1 {
 				t.Errorf("distribution: some listener handled 0 connections (counts=%v); expected every listener to handle at least 1 of %d flows", counts, numFlows)
 			}
-			if maxC > numFlows-1 {
-				t.Errorf("distribution: one listener handled %d of %d connections (counts=%v); expected at most %d per listener", maxC, numFlows, counts, numFlows-1)
+			// Compare against the observed total rather than numFlows: the
+			// metrics counter is bumped per accept and can exceed numFlows
+			// when a flow retried. The contract is "no listener monopolised
+			// everything", i.e. maxC < total.
+			if maxC >= total {
+				t.Errorf("distribution: one listener handled all %d observed connections (counts=%v, numFlows=%d); expected another listener to handle at least one", total, counts, numFlows)
 			}
 
 			// Assertion: neither listener subprocess emitted an error-level log

--- a/e2e/multi_test.go
+++ b/e2e/multi_test.go
@@ -20,20 +20,19 @@ import (
 // across multiple listeners on the same hyco is NOT specified as round-robin):
 //
 //   - all N connections through the sender round-trip data correctly;
+//   - distribution: every listener handles at least 1 connection AND
+//     no single listener handles all N (i.e. 0 ≤ min and max ≤ N-1).
+//     Empirically observed splits range from 1:7 to 6:2 with N=8, so
+//     this bound permits the full known variance while still catching
+//     pathological dropout (listener handling 0 connections, which
+//     would indicate a routing or registration bug);
 //   - neither listener subprocess emits a log line matching `level=error`.
 //
-// Logged but NOT asserted:
-//
-//   - per-listener aztunnel_connections_total via scrapeMetrics. A strong skew
-//     (e.g. one listener handles 0 of N) is a meaningful signal for humans
-//     reading the test log, but is not a hard assertion because Azure's
-//     selection is not guaranteed to be balanced — especially at small N.
-//
-// Strict distribution assertions belong in a mock-backed compatibility matrix
-// (Phase 2 of the e2e enhancements plan), where listener selection is
-// controllable. See plan.md in the session workspace for context.
+// Strict distribution assertions (e.g. expected round-robin) belong in a
+// mock-backed compatibility matrix where listener selection is controllable.
 func TestMultiListenerPortForwardSmoke(t *testing.T) {
-	env := requireRelayEnv(t)
+	t.Parallel()
+	env := requireDedicatedHyco(t)
 
 	const numListeners = 2
 	const numFlows = 8
@@ -107,10 +106,28 @@ func TestMultiListenerPortForwardSmoke(t *testing.T) {
 				float64(numFlows), 15*time.Second)
 
 			// Log per-listener counts so a human reading the test output can
-			// see distribution. Not asserted — see function comment.
+			// see distribution, and assert the bounded shape: every listener
+			// handled at least 1 flow, and no single listener handled all
+			// numFlows. See the function comment for the rationale.
+			counts := make([]int, len(listenerMetricsAddrs))
 			for i, addr := range listenerMetricsAddrs {
-				count := sumMetric(scrapeMetricsBest(addr), "aztunnel_connections_total")
-				t.Logf("listener %d (%s) handled %v connections", i, addr, count)
+				counts[i] = int(sumMetric(scrapeMetricsBest(addr), "aztunnel_connections_total"))
+				t.Logf("listener %d (%s) handled %d connections", i, addr, counts[i])
+			}
+			minC, maxC := counts[0], counts[0]
+			for _, c := range counts[1:] {
+				if c < minC {
+					minC = c
+				}
+				if c > maxC {
+					maxC = c
+				}
+			}
+			if minC < 1 {
+				t.Errorf("distribution: some listener handled 0 connections (counts=%v); expected every listener to handle at least 1 of %d flows", counts, numFlows)
+			}
+			if maxC > numFlows-1 {
+				t.Errorf("distribution: one listener handled %d of %d connections (counts=%v); expected at most %d per listener", maxC, numFlows, counts, numFlows-1)
 			}
 
 			// Assertion: neither listener subprocess emitted an error-level log

--- a/e2e/parity_bench_test.go
+++ b/e2e/parity_bench_test.go
@@ -15,11 +15,20 @@ import (
 // characterising the relay's connect-latency and short-session-
 // throughput dimensions on a real namespace.
 //
-// Only one auth method is exercised — whichever availableAuths
+// Only one auth method is exercised — whichever availableAuthNames
 // returns first — to keep the run time bounded. Run with E2E_AUTH=sas
 // or E2E_AUTH=entra to pin the method, which is important for
 // benchstat name-matching across BASE and HEAD invocations of
 // scripts/bench-compare.sh.
+//
+// All sub-benches share a single process-leased hyco pair
+// (leaseSharedHyco, drained at TestMain exit). This is the only
+// place in the suite where multiple Backend.Setup calls reuse the
+// same pair: each sub-bench's listeners and senders are still tied
+// to their own scenario t.Cleanup chain (so processes are reaped
+// between sub-benches), but the ARM Provision cost is paid once
+// for the whole benchmark run. This keeps -count=N benchstat
+// invocations from amplifying the provisioning tail by N×.
 //
 // Standard invocation (each iteration involves real relay round-
 // trips, so -benchtime=10x usually beats the default -benchtime=1s):
@@ -27,11 +36,10 @@ import (
 //	go test -tags=e2e -run='^$' -bench=. -benchmem -count=5 \
 //	    -benchtime=10x -timeout=60m ./e2e/...
 func BenchmarkParity_Azure(b *testing.B) {
-	env := requireRelayEnv(b)
-	auths := availableAuths(b, env)
-	auth := auths[0]
-	b.Run(auth.name, func(b *testing.B) {
-		backend := &azureBackend{env: env, auth: auth}
+	requireProvider(b)
+	name := availableAuthNames(b)[0]
+	b.Run(name, func(b *testing.B) {
+		backend := &azureBackend{authName: name, acquireEnv: leaseSharedHyco}
 		relayparity.RunBenchSuite(b, backend)
 	})
 }

--- a/e2e/parity_test.go
+++ b/e2e/parity_test.go
@@ -13,12 +13,20 @@ import (
 // SAS). The same scenarios run against the in-process MockBackend in
 // mockrelay/testharness/parity — any divergence between this test and that one is
 // a behavioural gap to fix in the mock.
+//
+// TestParity_Azure does NOT call t.Parallel() because AssertNoLeaks
+// (registered at the top of every scenario) samples process-wide
+// goroutine + FD counts and would falsely fail if scenarios ran in
+// parallel. Each scenario still gets isolation via per-Setup hyco
+// provisioning inside azureBackend.Setup — provisioning runs serially
+// at the parity-suite level, which is fine because the Provider's
+// concurrency cap is not the bottleneck here.
 func TestParity_Azure(t *testing.T) {
-	env := requireRelayEnv(t)
-	for _, auth := range availableAuths(t, env) {
-		auth := auth
-		t.Run(auth.name, func(t *testing.T) {
-			b := &azureBackend{env: env, auth: auth}
+	requireProvider(t)
+	for _, name := range availableAuthNames(t) {
+		name := name
+		t.Run(name, func(t *testing.T) {
+			b := &azureBackend{authName: name, acquireEnv: requireDedicatedHyco}
 			relayparity.RunCoreSuite(t, b)
 			relayparity.RunTopologySuite(t, b)
 			relayparity.RunReliabilitySuite(t, b)

--- a/e2e/testmain_test.go
+++ b/e2e/testmain_test.go
@@ -6,41 +6,63 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strconv"
 	"testing"
 	"time"
 
 	"github.com/philsphicas/aztunnel/e2e/azrelay"
 )
 
-// TestMain provisions per-invocation Azure Relay hybrid connections before
-// any test runs, and tears them down on exit. Per-invocation isolation is
-// what lets multiple CI pipelines (and concurrent local invocations) share
-// a single relay namespace without cross-talk.
+// relayProvider is the process-scoped factory used by
+// requireDedicatedHyco to hand out fresh per-test hyco pairs. nil
+// when E2E_RELAY_NAME is unset, in which case every helper that
+// requires Azure routes to t.Skip via requireProvider.
 //
-// The contract with individual tests is the existing E2E_* environment
-// variables. helpers_test.go and every test read those via os.Getenv;
-// TestMain sets them with os.Setenv after provisioning, so no test code
-// needs to change.
+// Lifecycle: constructed once at TestMain entry, no explicit
+// teardown. The Provider holds only an *armrelay.HybridConnectionsClient
+// (GC-safe) and a buffered channel (GC-safe). Individual PairTokens
+// it hands out own their own Teardown via t.Cleanup in
+// requireDedicatedHyco.
+var relayProvider *azrelay.Provider
+
+// sharedHycoToken keeps the legacy pre-provisioned pair alive for
+// the duration of the run so tests that have not yet been migrated
+// to requireDedicatedHyco can still read the E2E_* environment
+// variables and use the same pair across the suite. Phase 3 of the
+// per-test-isolation work will remove this pre-provisioning along
+// with the legacy env-var reads in requireRelayEnv.
+var sharedHycoToken *azrelay.PairToken
+
+// TestMain prepares the e2e suite by constructing the relay Provider
+// (which fronts a configurable-concurrency semaphore for per-test
+// provisioning) and provisioning one shared hyco pair for legacy
+// callers. The shared pair's connection metadata is exported through
+// the existing E2E_* environment variables; the per-test Provider is
+// reached via requireDedicatedHyco / requireProvider helpers.
 //
-// Required env vars for provisioning:
+// Required env vars:
 //
-//   - E2E_RELAY_NAME       Azure Relay namespace name
-//   - E2E_RESOURCE_GROUP   Resource group containing the namespace
-//   - AZURE_SUBSCRIPTION_ID Subscription ID for ARM API calls
+//   - E2E_RELAY_NAME            Azure Relay namespace name
+//   - E2E_RESOURCE_GROUP        Resource group containing the namespace
+//   - AZURE_SUBSCRIPTION_ID     Subscription ID for ARM API calls
 //
-// If E2E_RELAY_NAME is empty, provisioning is skipped and tests fall
-// through to their existing t.Skip behavior in requireRelayEnv. This
-// preserves the historic ergonomics for contributors running `go test`
-// without an Azure account.
+// Optional env var:
+//
+//   - E2E_PROVISIONER_CONCURRENCY  cap on in-flight Provision calls
+//     across all t.Parallel test goroutines (default 4). Raise only
+//     when CI data shows headroom under the namespace-level 429
+//     envelope.
+//
+// If E2E_RELAY_NAME is unset, provisioning is skipped and tests fall
+// through to t.Skip via requireRelayEnv / requireProvider. This
+// preserves the historic ergonomics for contributors running
+// `go test` without an Azure account.
 func TestMain(m *testing.M) {
 	os.Exit(testMain(m))
 }
 
 func testMain(m *testing.M) int {
 	if os.Getenv("E2E_RELAY_NAME") == "" {
-		// No relay configured. Surface this prominently so a developer
-		// running `make e2e` without first sourcing the env vars does
-		// not mistake an all-skipped run for an all-passing run.
 		fmt.Fprintln(os.Stderr, "==> e2e: E2E_RELAY_NAME is unset — TestMain will not provision hybrid connections")
 		fmt.Fprintln(os.Stderr, "==> e2e: every test will be SKIPPED. Run `eval \"$(make e2e-infra-env)\"` first, or set E2E_RELAY_NAME explicitly.")
 		return m.Run()
@@ -53,29 +75,34 @@ func testMain(m *testing.M) int {
 			"  set AZURE_SUBSCRIPTION_ID and E2E_RESOURCE_GROUP, or unset E2E_RELAY_NAME to skip e2e tests")
 	}
 
-	prov, err := azrelay.New(azrelay.Config{
+	conc := readConcurrencyEnv()
+
+	p, err := azrelay.NewProvider(azrelay.Config{
 		SubscriptionID: sub,
 		ResourceGroup:  rg,
 		Namespace:      os.Getenv("E2E_RELAY_NAME"),
+		Concurrency:    conc,
 	})
 	if err != nil {
-		fatal("azrelay.New: %v", err)
+		fatal("azrelay.NewProvider: %v", err)
 	}
+	relayProvider = p
 
-	entra, sas := prov.HycoNames()
-	fmt.Fprintf(os.Stderr, "==> provisioning hybrid connections in %s/%s: %s, %s\n", rg, os.Getenv("E2E_RELAY_NAME"), entra, sas)
-
+	// Phase-2 transitional: provision one shared hyco pair so tests
+	// that still call requireRelayEnv (i.e. have not migrated to
+	// requireDedicatedHyco) continue to read working E2E_* env vars.
+	// Phase 3 removes both this block and the legacy env-var path.
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
-	result, err := prov.Provision(ctx)
+	tok, err := relayProvider.Provision(ctx)
 	cancel()
 	if err != nil {
-		fatal("provision: %v", err)
+		fatal("provision shared hyco pair: %v", err)
 	}
-
-	// Export the test contract. We unconditionally overwrite any existing
-	// value because TestMain's per-invocation hycos take precedence over
-	// any stale env vars the caller may have set from previous runs.
-	for k, v := range result.EnvVars() {
+	sharedHycoToken = tok
+	entra, sas := tok.HycoNames()
+	fmt.Fprintf(os.Stderr, "==> shared hyco pair provisioned in %s/%s: %s, %s (concurrency=%d)\n",
+		rg, os.Getenv("E2E_RELAY_NAME"), entra, sas, conc)
+	for k, v := range tok.Result().EnvVars() {
 		if err := os.Setenv(k, v); err != nil {
 			fatal("setenv %s: %v", k, err)
 		}
@@ -85,13 +112,30 @@ func testMain(m *testing.M) int {
 
 	teardownCtx, teardownCancel := context.WithTimeout(context.Background(), 90*time.Second)
 	defer teardownCancel()
-	if err := prov.Teardown(teardownCtx); err != nil {
-		// Log but do not fail the test run on teardown errors — the
-		// janitor workflow will clean up anything we miss.
-		fmt.Fprintf(os.Stderr, "warning: teardown: %v\n", err)
+	if err := sharedHycoToken.Teardown(teardownCtx); err != nil {
+		// Log but do not fail the run on teardown errors — the
+		// janitor workflow will reap anything we miss.
+		fmt.Fprintf(os.Stderr, "warning: shared hyco teardown: %v\n", err)
 	}
 
 	return code
+}
+
+// readConcurrencyEnv parses E2E_PROVISIONER_CONCURRENCY. Anything
+// invalid or non-positive falls back to azrelay's default so a
+// typo cannot accidentally serialise or stampede the provisioner.
+func readConcurrencyEnv() int {
+	raw := os.Getenv("E2E_PROVISIONER_CONCURRENCY")
+	if raw == "" {
+		return azrelay.DefaultProvisionerConcurrency
+	}
+	n, err := strconv.Atoi(raw)
+	if err != nil || n <= 0 {
+		fmt.Fprintf(os.Stderr, "==> e2e: ignoring invalid E2E_PROVISIONER_CONCURRENCY=%q (using default %d)\n",
+			raw, azrelay.DefaultProvisionerConcurrency)
+		return azrelay.DefaultProvisionerConcurrency
+	}
+	return n
 }
 
 func fatal(format string, args ...any) {

--- a/e2e/testmain_test.go
+++ b/e2e/testmain_test.go
@@ -3,12 +3,10 @@
 package e2e
 
 import (
-	"context"
 	"fmt"
 	"os"
 	"strconv"
 	"testing"
-	"time"
 
 	"github.com/philsphicas/aztunnel/e2e/azrelay"
 )
@@ -25,20 +23,11 @@ import (
 // requireDedicatedHyco.
 var relayProvider *azrelay.Provider
 
-// sharedHycoToken keeps the legacy pre-provisioned pair alive for
-// the duration of the run so tests that have not yet been migrated
-// to requireDedicatedHyco can still read the E2E_* environment
-// variables and use the same pair across the suite. Phase 3 of the
-// per-test-isolation work will remove this pre-provisioning along
-// with the legacy env-var reads in requireRelayEnv.
-var sharedHycoToken *azrelay.PairToken
-
-// TestMain prepares the e2e suite by constructing the relay Provider
-// (which fronts a configurable-concurrency semaphore for per-test
-// provisioning) and provisioning one shared hyco pair for legacy
-// callers. The shared pair's connection metadata is exported through
-// the existing E2E_* environment variables; the per-test Provider is
-// reached via requireDedicatedHyco / requireProvider helpers.
+// TestMain constructs the process-scoped relay Provider so every
+// test can call requireDedicatedHyco to provision its own private
+// hyco pair. There is no shared pre-provisioned pair — each test
+// owns its hyco lifetime end-to-end, which lets the suite run with
+// t.Parallel().
 //
 // Required env vars:
 //
@@ -53,8 +42,8 @@ var sharedHycoToken *azrelay.PairToken
 //     when CI data shows headroom under the namespace-level 429
 //     envelope.
 //
-// If E2E_RELAY_NAME is unset, provisioning is skipped and tests fall
-// through to t.Skip via requireRelayEnv / requireProvider. This
+// If E2E_RELAY_NAME is unset, the Provider is not constructed and
+// every test falls through to t.Skip via requireProvider. This
 // preserves the historic ergonomics for contributors running
 // `go test` without an Azure account.
 func TestMain(m *testing.M) {
@@ -63,7 +52,7 @@ func TestMain(m *testing.M) {
 
 func testMain(m *testing.M) int {
 	if os.Getenv("E2E_RELAY_NAME") == "" {
-		fmt.Fprintln(os.Stderr, "==> e2e: E2E_RELAY_NAME is unset — TestMain will not provision hybrid connections")
+		fmt.Fprintln(os.Stderr, "==> e2e: E2E_RELAY_NAME is unset — TestMain will not construct a Provider")
 		fmt.Fprintln(os.Stderr, "==> e2e: every test will be SKIPPED. Run `eval \"$(make e2e-infra-env)\"` first, or set E2E_RELAY_NAME explicitly.")
 		return m.Run()
 	}
@@ -87,38 +76,10 @@ func testMain(m *testing.M) int {
 		fatal("azrelay.NewProvider: %v", err)
 	}
 	relayProvider = p
+	fmt.Fprintf(os.Stderr, "==> e2e: relay Provider ready (namespace=%s/%s, concurrency=%d)\n",
+		rg, os.Getenv("E2E_RELAY_NAME"), conc)
 
-	// Phase-2 transitional: provision one shared hyco pair so tests
-	// that still call requireRelayEnv (i.e. have not migrated to
-	// requireDedicatedHyco) continue to read working E2E_* env vars.
-	// Phase 3 removes both this block and the legacy env-var path.
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
-	tok, err := relayProvider.Provision(ctx)
-	cancel()
-	if err != nil {
-		fatal("provision shared hyco pair: %v", err)
-	}
-	sharedHycoToken = tok
-	entra, sas := tok.HycoNames()
-	fmt.Fprintf(os.Stderr, "==> shared hyco pair provisioned in %s/%s: %s, %s (concurrency=%d)\n",
-		rg, os.Getenv("E2E_RELAY_NAME"), entra, sas, conc)
-	for k, v := range tok.Result().EnvVars() {
-		if err := os.Setenv(k, v); err != nil {
-			fatal("setenv %s: %v", k, err)
-		}
-	}
-
-	code := m.Run()
-
-	teardownCtx, teardownCancel := context.WithTimeout(context.Background(), 90*time.Second)
-	defer teardownCancel()
-	if err := sharedHycoToken.Teardown(teardownCtx); err != nil {
-		// Log but do not fail the run on teardown errors — the
-		// janitor workflow will reap anything we miss.
-		fmt.Fprintf(os.Stderr, "warning: shared hyco teardown: %v\n", err)
-	}
-
-	return code
+	return m.Run()
 }
 
 // readConcurrencyEnv parses E2E_PROVISIONER_CONCURRENCY. Anything

--- a/e2e/testmain_test.go
+++ b/e2e/testmain_test.go
@@ -64,6 +64,12 @@ func testMain(m *testing.M) int {
 		fatal("pre-build aztunnel: %v", err)
 	}
 
+	// Drain the shared bench hyco lease on every exit path, including
+	// panics that the testing framework recovers from. The defer is
+	// a no-op when no benchmark called leaseSharedHyco (i.e. for the
+	// common `go test` invocation that runs only tests).
+	defer drainBenchLease()
+
 	if os.Getenv("E2E_RELAY_NAME") == "" {
 		fmt.Fprintln(os.Stderr, "==> e2e: E2E_RELAY_NAME is unset — TestMain will not construct a Provider")
 		fmt.Fprintln(os.Stderr, "==> e2e: every test will be SKIPPED. Run `eval \"$(make e2e-infra-env)\"` first, or set E2E_RELAY_NAME explicitly.")

--- a/e2e/testmain_test.go
+++ b/e2e/testmain_test.go
@@ -51,6 +51,19 @@ func TestMain(m *testing.M) {
 }
 
 func testMain(m *testing.M) int {
+	// Pre-build cmd/aztunnel before any test runs. The build is
+	// reused via sync.Once, but evaluating it lazily inside a test
+	// races against any per-test context deadline the test has
+	// already set on its exec.CommandContext (e.g. the 5s budget in
+	// TestMissingRequiredArgs). On a cold CI machine the cmd/aztunnel
+	// build is well over that budget, so the first test to call
+	// aztunnelBinary would see its exec immediately fail with a
+	// deadline-exceeded error and empty stderr. Pay the build cost
+	// once, here, before m.Run().
+	if err := buildAztunnelBinary(); err != nil {
+		fatal("pre-build aztunnel: %v", err)
+	}
+
 	if os.Getenv("E2E_RELAY_NAME") == "" {
 		fmt.Fprintln(os.Stderr, "==> e2e: E2E_RELAY_NAME is unset — TestMain will not construct a Provider")
 		fmt.Fprintln(os.Stderr, "==> e2e: every test will be SKIPPED. Run `eval \"$(make e2e-infra-env)\"` first, or set E2E_RELAY_NAME explicitly.")

--- a/e2e/testmain_test.go
+++ b/e2e/testmain_test.go
@@ -3,10 +3,12 @@
 package e2e
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"strconv"
 	"testing"
+	"time"
 
 	"github.com/philsphicas/aztunnel/e2e/azrelay"
 )
@@ -18,10 +20,30 @@ import (
 //
 // Lifecycle: constructed once at TestMain entry, no explicit
 // teardown. The Provider holds only an *armrelay.HybridConnectionsClient
-// (GC-safe) and a buffered channel (GC-safe). Individual PairTokens
-// it hands out own their own Teardown via t.Cleanup in
-// requireDedicatedHyco.
+// (GC-safe), a buffered channel (GC-safe), and a reference to the
+// process-scoped *azrelay.RunRules (whose lifetime is owned by
+// TestMain — see runRules below). Individual PairTokens it hands out
+// own their own Teardown via t.Cleanup in requireDedicatedHyco.
 var relayProvider *azrelay.Provider
+
+// runRules holds the two namespace-scoped SAS authorization rules
+// (Listen-only + Send-only) provisioned once at TestMain startup and
+// shared by every PairToken's Result. Teardown is deferred from
+// testMain so the rules are released on every normal exit path; the
+// janitor reaps anything we leak (e.g. on os.Exit before defers).
+var runRules *azrelay.RunRules
+
+// runRuleAcquireTimeout bounds the namespace-rule provisioning step
+// in TestMain. Two CreateOrUpdateAuthorizationRule + two ListKeys
+// + the 2 s data-plane settle; with the SDK's 6-retry tail factored
+// in, the worst-case observed wall-clock is well under a minute. 90 s
+// gives comfortable headroom for a regional blip without letting a
+// stuck control plane hang the suite.
+const runRuleAcquireTimeout = 90 * time.Second
+
+// runRuleTeardownTimeout bounds the deferred Teardown call. Two
+// DeleteAuthorizationRule round-trips against the namespace.
+const runRuleTeardownTimeout = 60 * time.Second
 
 // TestMain constructs the process-scoped relay Provider so every
 // test can call requireDedicatedHyco to provision its own private
@@ -64,15 +86,12 @@ func testMain(m *testing.M) int {
 		fatal("pre-build aztunnel: %v", err)
 	}
 
-	// Drain the shared bench hyco lease on every exit path, including
-	// panics that the testing framework recovers from. The defer is
-	// a no-op when no benchmark called leaseSharedHyco (i.e. for the
-	// common `go test` invocation that runs only tests).
-	defer drainBenchLease()
-
 	if os.Getenv("E2E_RELAY_NAME") == "" {
 		fmt.Fprintln(os.Stderr, "==> e2e: E2E_RELAY_NAME is unset — TestMain will not construct a Provider")
-		fmt.Fprintln(os.Stderr, "==> e2e: every test will be SKIPPED. Run `eval \"$(make e2e-infra-env)\"` first, or set E2E_RELAY_NAME explicitly.")
+		fmt.Fprintln(os.Stderr, "==> e2e: every Azure-dependent test will be SKIPPED (CLI-only tests still run). Run `eval \"$(make e2e-infra-env)\"` first, or set E2E_RELAY_NAME explicitly.")
+		// drainBenchLease is a no-op when no benchmark could lease;
+		// no Provider was constructed so leaseSharedHyco cannot have
+		// run. No need to defer it on this skip path.
 		return m.Run()
 	}
 
@@ -85,14 +104,61 @@ func testMain(m *testing.M) int {
 
 	conc := readConcurrencyEnv()
 
-	p, err := azrelay.NewProvider(azrelay.Config{
+	cfg := azrelay.Config{
 		SubscriptionID: sub,
 		ResourceGroup:  rg,
 		Namespace:      os.Getenv("E2E_RELAY_NAME"),
 		Concurrency:    conc,
-	})
+	}
+
+	// Acquire the run-scoped namespace SAS rules. Two rules
+	// (e2e-run-<hex>-listener with Listen, e2e-run-<hex>-sender with
+	// Send) are created once here and stamped onto every PairToken
+	// Result by Provider.Provision; per-test provisioning no longer
+	// touches authorizationRules. Failures here are fatal — without
+	// the rules the SAS auth path can't function. No defers earlier
+	// than this point need to skip on the fatal path because nothing
+	// has been provisioned yet.
+	acquireCtx, acquireCancel := context.WithTimeout(context.Background(), runRuleAcquireTimeout)
+	rr, err := azrelay.AcquireRunRules(acquireCtx, cfg)
+	acquireCancel()
 	if err != nil {
-		fatal("azrelay.NewProvider: %v", err)
+		fatal("azrelay.AcquireRunRules: %v", err)
+	}
+	runRules = rr
+	fmt.Fprintf(os.Stderr, "==> e2e: run rules ready (listener=%s, sender=%s)\n",
+		rr.ListenerName, rr.SenderName)
+
+	// Defer rule teardown FIRST so it runs LAST on the LIFO stack —
+	// every subsequently-deferred cleanup (e.g. drainBenchLease,
+	// below) gets to use the SAS rules while it still tears down
+	// in-flight state. The janitor reaps anything we leak (os.Exit
+	// paths skip defers).
+	defer func() {
+		ctx, cancel := context.WithTimeout(context.Background(), runRuleTeardownTimeout)
+		defer cancel()
+		if err := rr.Teardown(ctx); err != nil {
+			fmt.Fprintf(os.Stderr, "==> e2e: teardown run rules %s/%s: %v\n",
+				rr.ListenerName, rr.SenderName, err)
+		}
+	}()
+
+	// Drain the shared bench hyco lease on every exit path, including
+	// panics that the testing framework recovers from. Registered
+	// AFTER the run-rule teardown defer so it runs BEFORE rule
+	// teardown (Go defers are LIFO) — keeps the SAS rules alive for
+	// any hyco-cleanup-time data-plane work the benchmark teardown
+	// path may grow in the future. Today tok.Teardown is ARM-only,
+	// so the order is currently not load-bearing.
+	defer drainBenchLease()
+
+	cfg.RunRules = rr
+	p, err := azrelay.NewProvider(cfg)
+	if err != nil {
+		// Non-fatal: report and return non-zero so the deferred
+		// teardown runs. fatal() (os.Exit) would skip it.
+		fmt.Fprintf(os.Stderr, "TestMain: azrelay.NewProvider: %v\n", err)
+		return 1
 	}
 	relayProvider = p
 	fmt.Fprintf(os.Stderr, "==> e2e: relay Provider ready (namespace=%s/%s, concurrency=%d)\n",


### PR DESCRIPTION
Closes #49.

## What this changes

Every e2e test now provisions its own pair of Azure Relay hybrid connections on demand, instead of sharing the two pre-provisioned pairs (`E2E_HYCO_ENTRA`, `E2E_HYCO_SAS`) that the suite used to expect from the environment. `TestMain` constructs an `azrelay.Provider` once at suite startup; each test calls `requireDedicatedHyco(t)`, which acquires a pair from the provider and registers `t.Cleanup` to tear it down. With isolated hycos, listener/sender flows from one test can't collide with another's, and the suite is free to use `t.Parallel()`.

SAS authorization rules are decoupled from hybrid connections: each `go test` invocation creates two namespace-scoped rules (`e2e-run-<hex>-listener` with Listen-only, `e2e-run-<hex>-sender` with Send-only) once in `TestMain` and shares them across every per-test pair. Per-test provisioning no longer mutates `authorizationRules` at all.

## How it works

- `e2e/azrelay.AcquireRunRules(ctx, cfg)` provisions the two namespace SAS rules and reads their primary keys once at suite startup. `RunRules.Teardown(ctx)` deletes both rules; both halves use the existing 40901-conflict retry envelope. A small data-plane settle is paid once per acquisition, not per pair.
- `e2e/azrelay.Provider` provisions a hyco pair on demand and returns a `PairToken` whose `Teardown(ctx)` is idempotent and bound to the caller's deadline. Per-pair `Provision` only creates the two hycos and stamps the run-scoped rule keys onto the returned `Result`.
- `requireDedicatedHyco(t)` is the contract every test calls: it acquires a pair from the provider and registers `t.Cleanup` to tear it down. Functional tests then call `t.Parallel()`.
- The parity suite calls the same helper from `Backend.Setup`, giving every scenario a fresh hyco pair. Parity stays serial because `AssertNoLeaks` is process-global, but each scenario is isolated.
- `BenchmarkParity_Azure` shares a single pair leased on first use and drained from `TestMain` via `defer drainBenchLease()`, so `benchstat -count=N` runs don't amplify ARM provisioning by `N`.
- A configurable concurrency cap (`E2E_PROVISIONER_CONCURRENCY`, default 4) gates both provision and teardown, keeping namespace-level ARM traffic inside the Relay 429 envelope. The azcore pipeline's `MaxRetries=6` / `MaxRetryDelay=60s` absorbs brief throttling bursts via `Retry-After`.
- Hyco names continue to match `^e2e-(entra|sas)-[0-9a-f]{12}$`. Run rules match `^e2e-run-[0-9a-f]{12}-(listener|sender)$`. The orphan janitor (`.github/workflows/e2e-janitor.yml`) sweeps both alongside one another using the same `--max-age` rule.

## Why two separate rules

`TestWrongSASClaim` asserts that the listener key cannot send and the sender key cannot listen. A single combined Listen+Send rule would silently pass that test, regressing the SAS-claim contract. Two rules at namespace scope preserve the contract while still hoisting rule lifetime out of the per-test path.

## What contributors see

`make e2e-infra-setup` only needs to create the namespace + (empty) resource group now; the per-test hycos and per-run rules are created on the fly. `eval "$(make e2e-infra-env)"` still exports the same env vars (`E2E_RELAY_NAME`, `E2E_RESOURCE_GROUP`, `AZURE_SUBSCRIPTION_ID`) — there are no `E2E_HYCO_*` or `E2E_SAS_*` vars anymore. `e2e/README.md` documents the new model.

## Wall-clock

CI variance on the e2e backend itself dwarfs the parallelization gain in any single run: main has ranged 6–12 min across the last week on identical fixtures, this branch 8–17 min. The point of the change is per-test isolation; the wall-clock impact is in the noise and worth tracking over a longer baseline.

## ARM control-plane impact

Per-test provisioning multiplies hyco-PUT/DELETE traffic by ~15×, but each test no longer issues four authorization-rule mutations — those collapse to a constant four per `go test` invocation (two creates + two deletes). For a ~77-test run, that drops total rule-mutation count from ~308 to 4. Namespace 429 headroom comfortably absorbs the remaining traffic.

## Risk surface

- **Namespace 429s on hyco PUT/DELETE**: mitigated by the concurrency cap + SDK pipeline retries.
- **Authorization-rule cap (12/namespace)**: the default `RootManageSharedAccessKey` rule consumes one slot, leaving 11 — so two rules per `go test` invocation supports up to five concurrent runs in the same namespace before the cap bites. CI is single-process so this is plenty in practice.
- **Provisioning tail latency**: hyco creates occasionally take 10+ s; the `t.Parallel` wave overlaps them.
- **Janitor compatibility**: orphan rules are reaped by the same workflow as orphan hycos.


