### PR TITLE
chore: strip PR-number references from tests + stream make e2e output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,8 @@ fmt-check: ## Check formatting (same as CI)
 	npx --yes prettier --check .
 
 e2e: build ## Run end-to-end tests (requires Azure Relay credentials)
-	go test -tags=e2e -timeout=20m -v ./e2e/...
+	go test -tags=e2e -timeout=20m -v ./e2e/azrelay/
+	go test -tags=e2e -timeout=20m -v ./e2e/
 
 e2e-docker: ## Run container-to-container e2e tests
 	@status=0; \

--- a/cmd/aztunnel/arc_connect_test.go
+++ b/cmd/aztunnel/arc_connect_test.go
@@ -13,7 +13,7 @@ import (
 // whether to enable the first-connection explanatory logging. Both
 // `arc connect` and `arc port-forward` call this on the initial
 // GetRelayCredentials error; misclassifying it would silently disable
-// (or incorrectly enable) the UX path covered by the rest of this PR.
+// (or incorrectly enable) the explanatory-logging UX path.
 func TestIsHybridConnectivitySetupErr(t *testing.T) {
 	tests := []struct {
 		name string

--- a/e2e/azrelay/provisioner_test.go
+++ b/e2e/azrelay/provisioner_test.go
@@ -346,8 +346,8 @@ func TestRetryOnAuthRuleConflict_NonConflictReturnsImmediately(t *testing.T) {
 }
 
 // A 429 with a different ErrorCode (e.g. SubscriptionThrottle) must not be
-// retried by this loop — the issue is explicit that we only retry the
-// specific 40901 class.
+// retried by this loop — the retry contract is explicit: only the
+// specific 40901 class is retried.
 func TestRetryOnAuthRuleConflict_Generic429NotRetried(t *testing.T) {
 	calls := 0
 	generic := &azcore.ResponseError{

--- a/e2e/parity_bench_test.go
+++ b/e2e/parity_bench_test.go
@@ -12,7 +12,8 @@ import (
 // against a real Azure Relay namespace. Pair with the mock variant
 // (BenchmarkParity_Mock in mockrelay/testharness/parity) for fast
 // iteration; the Azure variant produces source-of-truth numbers for
-// characterising PR #47.
+// characterising the relay's connect-latency and short-session-
+// throughput dimensions on a real namespace.
 //
 // Only one auth method is exercised — whichever availableAuths
 // returns first — to keep the run time bounded. Run with E2E_AUTH=sas

--- a/internal/testharness/relayparity/backend.go
+++ b/internal/testharness/relayparity/backend.go
@@ -164,7 +164,8 @@ type Sender struct {
 type Tunnel struct {
 	// SenderAddr is the host:port clients dial for the first (or
 	// only) sender. Always equal to SenderAddrs[0]. Kept as a top-
-	// level field so the four #50 scenarios compile unchanged.
+	// level field so the original single-sender scenarios compile
+	// unchanged.
 	SenderAddr string
 
 	// SenderAddrs holds every sender's bind address in the order

--- a/internal/testharness/relayparity/bench.go
+++ b/internal/testharness/relayparity/bench.go
@@ -15,11 +15,11 @@ import (
 // b. Mirrors RunCoreSuite for tests: a single entry point keeps the
 // per-backend bench_test.go files trivial.
 //
-// The sub-benches measure the exact dimensions PR #47 (connection
-// muxing) is supposed to improve, plus a control benchmark
-// (SteadyThroughput) that should NOT regress under mux. Run with
-// `-count=5 -benchmem` and feed both outputs into benchstat to
-// quantify the change.
+// The sub-benches measure the connection-setup and concurrent-
+// connect dimensions of the relay path, plus a control benchmark
+// (SteadyThroughput) that should NOT regress under architectural
+// changes. Run with `-count=5 -benchmem` and feed both outputs into
+// benchstat to quantify the change.
 //
 // Each sub-bench stands up its own topology via backend.Setup(b, ...)
 // and tears it down through t.Cleanup. AssertNoLeaks is deliberately
@@ -54,12 +54,13 @@ func RunBenchSuite(b *testing.B, backend Backend) {
 //
 //	Dial → write 1 byte → read 1 byte echoed back → close.
 //
-// Single connection per iteration, no concurrency. The headline #47
-// metric: each iteration pays one full relay rendezvous round-trip
-// (~1–2 s on Azure today; expected to drop to milliseconds with mux).
+// Single connection per iteration, no concurrency. The headline
+// connect-latency metric: each iteration pays one full relay
+// rendezvous round-trip (~1–2 s on Azure today).
 //
 // Run against both modes (port-forward, SOCKS5) because the SOCKS5
-// path adds a handshake that may behave differently under mux.
+// path adds a per-connection handshake that may carry different
+// setup costs than raw port-forward.
 func benchConnectLatencySerial(b *testing.B, backend Backend, mode SenderMode) {
 	b.Helper()
 	echo := StartPlainEcho(b)
@@ -99,9 +100,9 @@ func benchConnectLatencySerial(b *testing.B, backend Backend, mode SenderMode) {
 
 // benchConcurrentConnect measures the wall time of opening n
 // concurrent connections, each of which round-trips 1 byte, per
-// iteration. Surfaces the concurrency-amplified setup cost: pre-#47
-// every flow waits its turn through the listener's serial rendezvous;
-// post-#47 they should fan out cheaply.
+// iteration. Surfaces the concurrency-amplified setup cost: when
+// flows share a single listener they queue at rendezvous; lower
+// results indicate connection setup can fan out cheaply instead.
 //
 // Each iteration owns n goroutines; b.N controls how many iterations
 // run. Worker errors are collected and surfaced from the benchmark
@@ -153,13 +154,14 @@ func benchConcurrentConnect(b *testing.B, backend Backend, n int) {
 }
 
 // benchShortSessionRate measures ops/sec of the
-// open → write 1 KB → read 1 KB → close cycle. The workload PR #47
-// explicitly cites as "intolerable" without mux.
+// open → write 1 KB → read 1 KB → close cycle. The canonical
+// short-session workload — sustained rate of fresh connections,
+// each carrying a small payload.
 //
 // numSenders controls how many sender binds receive the load round-
 // robin. The single-sender variant is the strict baseline; the
-// multi-sender variant probes whether scaling out senders is a
-// workaround for the missing mux.
+// multi-sender variant probes whether scaling out senders compensates
+// for serial per-sender rendezvous.
 //
 // b.SetBytes(1024) makes MB/s appear alongside ns/op for benchstat,
 // counting payload bytes written per iteration.
@@ -210,10 +212,10 @@ func benchShortSessionRate(b *testing.B, backend Backend, numSenders int) {
 // connection is dialed once before the timer starts and reused for
 // every iteration so setup cost is excluded.
 //
-// This is the control benchmark: it should NOT regress under mux.
-// Writes and reads run concurrently to avoid socket-buffer deadlock,
-// and each iteration drains exactly transferSize bytes before
-// starting the next.
+// This is the control benchmark: it should NOT regress under
+// architectural changes. Writes and reads run concurrently to avoid
+// socket-buffer deadlock, and each iteration drains exactly
+// transferSize bytes before starting the next.
 func benchSteadyThroughput(b *testing.B, backend Backend) {
 	b.Helper()
 	echo := StartPlainEcho(b)

--- a/internal/testharness/relayparity/reliability.go
+++ b/internal/testharness/relayparity/reliability.go
@@ -17,12 +17,12 @@ import (
 // scenarios against b. Each runs as a sub-test of the caller's t and
 // must pass against both the in-process mock backend and the real
 // Azure backend — this is the "behavior is the same shape on both
-// sides of the relay" gate from #55.
+// sides of the relay" parity gate.
 //
 // ScenarioHalfClose_RequestResponse is registered here for shape
-// (i.e. the test name shows up in output) but t.Skip()s with a reason
-// that names PR #47. Removing the skip is part of #47's acceptance
-// criteria.
+// (i.e. the test name shows up in output) but t.Skip()s until the
+// bridge propagates half-close. The skip exists so the suite stays
+// green while that capability is missing.
 func RunReliabilitySuite(t *testing.T, b Backend) {
 	t.Helper()
 	scenarios := []struct {
@@ -69,7 +69,7 @@ const slowConsumerTestDuration = 8 * time.Second
 // because nothing is listening — produced by binding then immediately
 // closing a listener.
 //
-// SOCKS5 reply parity (issue #55): aztunnel propagates the
+// SOCKS5 reply parity: aztunnel propagates the
 // listener-side connect-error classification through
 // ConnectResponse.Code so the SOCKS5 sender returns the matching REP
 // byte instead of the historical "always RepHostUnreachable" default.
@@ -103,8 +103,8 @@ func ScenarioErrorPropagation_TargetRefused(t *testing.T, b Backend) {
 	// once the relay → listener handshake propagates the failure
 	// back. We assert non-nil error within the budget; the exact
 	// error class differs across backends (EOF on mock vs. RST on
-	// some Azure paths), which is why the issue scope says "don't
-	// assert exact error type".
+	// some Azure paths), which is why the scenario does not assert
+	// on exact error type.
 	target2 := refusedAddr(t)
 	tunPF := b.Setup(t, SetupOptions{
 		NumListeners:   1,
@@ -129,7 +129,8 @@ func ScenarioErrorPropagation_TargetRefused(t *testing.T, b Backend) {
 // never receives SYN-ACK, classified as CodeTimeout → mapped to
 // RepHostUnreachable (0x04). Some networks instead emit ICMP
 // host/network unreachable, surfacing as 0x03 or 0x04 directly. The
-// assertion accepts either, matching the issue spec.
+// assertion accepts either, since both are valid responses for an
+// unreachable target.
 func ScenarioErrorPropagation_TargetUnreachable(t *testing.T, b Backend) {
 	t.Helper()
 	AssertNoLeaks(t)
@@ -256,9 +257,9 @@ func ScenarioErrorPropagation_TargetHangs(t *testing.T, b Backend) {
 //   - At least some bytes flowed (>= 1 KiB) — sanity that the test
 //     isn't reporting a no-op as success.
 //
-// SlowConsumerMemBound is the SAME constant for mock and Azure
-// (issue #55 acceptance criterion); the comparability of the two
-// backends under the same bound is the parity claim.
+// SlowConsumerMemBound is the SAME constant for mock and Azure;
+// the comparability of the two backends under the same bound is
+// the parity claim.
 func ScenarioSlowConsumer_BackPressure(t *testing.T, b Backend) {
 	t.Helper()
 	AssertNoLeaks(t)
@@ -393,15 +394,12 @@ sampling:
 // bridge.go), so a client that does CloseWrite to signal "I'm done
 // writing, please send the response" loses its response stream.
 //
-// PR #47 reworks the bridge to honour half-close. When that PR
-// merges, removing the t.Skip below and watching this scenario pass
-// is its acceptance criterion (issue #55 spec).
-//
-// The body is fully written so the skip is the only code path that
-// changes when #47 lands.
+// The body is fully written; only the t.Skip itself gates this
+// scenario — when the bridge supports half-close, deleting the skip
+// is sufficient to enable it.
 func ScenarioHalfClose_RequestResponse(t *testing.T, b Backend) {
 	t.Helper()
-	t.Skip("blocked on PR #47 (stream multiplexing): current bridge tears down both directions on EOF; removing this skip is part of #47's acceptance criteria")
+	t.Skip("current bridge tears down both directions on EOF instead of preserving the response stream after client CloseWrite")
 
 	AssertNoLeaks(t)
 
@@ -633,10 +631,10 @@ func (s *slowDrainTarget) closeAcceptedConns() {
 // requestResponseTarget is a TCP server that, on each accepted conn,
 // reads until EOF, compares the received bytes against an expected
 // request, and only writes its response when the request matches.
-// Used by the half-close scenario (currently skipped); when PR #47
-// lands and the bridge propagates EOF in one direction only, this
-// exercises the full request-then-response contract — both directions
-// must deliver intact payloads, not just an EOF + reply.
+// Used by the half-close scenario (currently skipped); on a bridge
+// that propagates EOF in one direction only, this exercises the
+// full request-then-response contract — both directions must
+// deliver intact payloads, not just an EOF + reply.
 type requestResponseTarget struct {
 	ln       net.Listener
 	request  string
@@ -670,8 +668,8 @@ func (rr *requestResponseTarget) Addr() string { return rr.ln.Addr().String() }
 
 // Received returns the last bytes the target read from a client and
 // any mismatch error recorded when the bytes diverged from the
-// expected request. Intended for diagnostic assertions in the
-// scenario body once PR #47 unskips this test.
+// expected request. Intended for diagnostic assertions when the
+// half-close scenario runs.
 func (rr *requestResponseTarget) Received() ([]byte, error) {
 	rr.mu.Lock()
 	defer rr.mu.Unlock()
@@ -725,9 +723,8 @@ func (rr *requestResponseTarget) stop() {
 // expectPortForwardFails dials addr (a port-forward sender bind),
 // attempts a tiny write+read, and asserts the operation does not
 // hang past timeout and produces an error. It does not assert on the
-// exact error type — the issue spec calls that "backend-specific"
-// (mock surfaces EOF; Azure subprocesses sometimes surface RST or
-// short read first).
+// exact error type — that's backend-specific (mock surfaces EOF;
+// Azure subprocesses sometimes surface RST or short read first).
 func expectPortForwardFails(senderAddr string, timeout time.Duration) error {
 	conn, err := net.DialTimeout("tcp", senderAddr, timeout)
 	if err != nil {

--- a/internal/testharness/relayparity/scenarios.go
+++ b/internal/testharness/relayparity/scenarios.go
@@ -21,9 +21,9 @@ import (
 // topology and tears it down before the next starts.
 //
 // Scenarios in the core suite are required to pass on current main.
-// Behaviors that PR #47 (mux) is expected to change (e.g. half-close
-// propagation) live outside the core suite so this gate stays green
-// pre- and post-#47.
+// Behaviors that depend on capabilities the bridge does not yet
+// implement (e.g. half-close propagation) live outside the core
+// suite so this gate stays green regardless of bridge architecture.
 func RunCoreSuite(t *testing.T, b Backend) {
 	t.Helper()
 	scenarios := []struct {
@@ -99,7 +99,7 @@ func ScenarioEcho_SOCKS5(t *testing.T, b Backend) {
 // index in big-endian; the remaining 1020 bytes are deterministic
 // filler. Read-back must arrive in the same order, identical bytes.
 //
-// Catches reordering or interleaving inside the bridge / future mux.
+// Catches reordering or interleaving inside the bridge.
 func ScenarioOrdering_PortForward(t *testing.T, b Backend) {
 	t.Helper()
 	AssertNoLeaks(t)

--- a/mockrelay/testharness/parity/mock_backend.go
+++ b/mockrelay/testharness/parity/mock_backend.go
@@ -61,11 +61,11 @@ func (*MockBackend) Setup(t testing.TB, opts relayparity.SetupOptions) *relaypar
 	}
 
 	host, clientOpts := startMockRelay(t)
-	// Cleanup ordering carry-over from PR #50 review: startMockRelay's
-	// own t.Cleanup registers srv.Close. Register cancel+wg.Wait AFTER
-	// it so LIFO teardown runs cancel first → drains the listener /
-	// sender goroutines → THEN closes the mock relay. This stops the
-	// "listener exited: <error>" log lines that fired when the relay
+	// Cleanup ordering: startMockRelay's own t.Cleanup registers
+	// srv.Close. Register cancel+wg.Wait AFTER it so LIFO teardown
+	// runs cancel first → drains the listener / sender goroutines
+	// → THEN closes the mock relay. This stops the "listener
+	// exited: <error>" log lines that fired when the relay
 	// disappeared while listeners were still running.
 	ctx, cancel := context.WithCancel(context.Background())
 	var wg sync.WaitGroup


### PR DESCRIPTION
Two unrelated cleanups to test infrastructure.

## Test source describes behavior, not git history

Test comments and the user-visible `t.Skip` on `ScenarioHalfClose_RequestResponse` no longer reference PR numbers, issue numbers, or future work. The skip line now reads:

```
--- SKIP: TestParity_Azure/entra/HalfClose_RequestResponse (0.00s)
    reliability.go:404: current bridge tears down both directions on EOF instead of preserving the response stream after client CloseWrite
```

— a description of the bridge's current behavior and the contract it violates. Equivalent rewrites land across the parity test harness, parity benchmarks, mock-backend setup, and a handful of sibling tests, dropping both literal PR/issue numbers (`#47`, `#50`, `#55`) and TODO-style wording (`the issue spec`, `missing mux`, `future mux`, `under mux`, `once X is unskipped`, `the rest of this PR`).

No test behavior changes — no skips removed, no gates added, no test names altered. The half-close scenario stays skipped; only its message and the comments around it change.

## `make e2e` streams output live

`go test` buffers each binary's combined stdout+stderr until that binary exits when it runs multiple packages in one invocation. The previous `./e2e/...` target matched two packages (`e2e` + `e2e/azrelay`), so the slow `e2e` package produced zero terminal output for ~16 minutes.

Splitting into two single-package invocations restores live streaming with no behavior change:

```make
e2e: build ## Run end-to-end tests (requires Azure Relay credentials)
	go test -tags=e2e -timeout=20m -v ./e2e/azrelay/
	go test -tags=e2e -timeout=20m -v ./e2e/
```

`azrelay` first (~0.1s) so the fast feedback lands before the slow package starts; `make` stops on the first failing target.
