### PR TITLE
feat(relay): cache Entra access tokens in EntraTokenProvider

### DIFF
--- a/internal/relay/auth.go
+++ b/internal/relay/auth.go
@@ -12,12 +12,34 @@ import (
 	"fmt"
 	"net/url"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 )
+
+// entraRefreshSkew is the safety margin before an access token's ExpiresOn at
+// which EntraTokenProvider considers its cached entry stale and refreshes it.
+// Set small (5 minutes) so the cache remains useful even when the underlying
+// credential returns tokens with short remaining lifetimes — notably
+// AzureCLICredential, which passes through whatever the `az` shell-out
+// reports, often only 10–15 minutes when az's own MSAL cache is mid-cycle.
+// A larger skew here would invalidate the cache on nearly every call in that
+// regime, restoring the per-dial `az` shell-out the cache exists to avoid.
+//
+// This skew does not — and cannot — guarantee that the token handed to
+// control.go's renewLoop survives until the next renewal pass: the upstream
+// token lifetime is whatever the credential gives us, with or without the
+// cache. A short-lifetime token reaching renewLoop is a property of the
+// underlying credential, not of the cache.
+const entraRefreshSkew = 5 * time.Minute
+
+// entraTokenScope is the OAuth2 scope Azure Relay requires for Entra ID
+// authentication. The control plane rejects tokens issued for any other
+// audience, so the scope is fixed regardless of the caller's resource URI.
+const entraTokenScope = "https://relay.azure.net/.default"
 
 // TokenProvider generates authentication tokens for Azure Relay.
 type TokenProvider interface {
@@ -37,9 +59,26 @@ func (p *SASTokenProvider) GetToken(_ context.Context, resourceURI string) (stri
 	return GenerateSASToken(resourceURI, p.KeyName, p.Key, tokenExpiry)
 }
 
-// EntraTokenProvider obtains OAuth2 tokens via Azure Identity (DefaultAzureCredential).
+// EntraTokenProvider obtains OAuth2 tokens via Azure Identity
+// (DefaultAzureCredential) and caches the most recent successful result in
+// memory until shortly before its ExpiresOn. The cache eliminates per-dial
+// blocking on credentials that lack their own in-memory cache — notably
+// AzureCLICredential, which shells out to `az account get-access-token` on
+// every call under a per-instance mutex.
+//
+// Concurrent callers single-flight via a refresh-in-flight channel: at most
+// one goroutine ever calls into the underlying credential at a time, and
+// queued callers can still abort via their own context (so a hung `az`
+// invocation cannot keep a deadline-bound dial waiting past its deadline).
+// Errors from the underlying credential are returned to the caller and
+// intentionally not cached, so a subsequent call retries the underlying
+// fetch instead of repeating a stale failure.
 type EntraTokenProvider struct {
 	cred azcore.TokenCredential
+
+	mu         sync.Mutex
+	cached     azcore.AccessToken
+	refreshing chan struct{} // non-nil while a refresh is in flight; closed when it ends
 }
 
 // NewEntraTokenProvider creates a token provider using DefaultAzureCredential.
@@ -57,15 +96,98 @@ func NewEntraTokenProviderWithCredential(cred azcore.TokenCredential) *EntraToke
 	return &EntraTokenProvider{cred: cred}
 }
 
-// GetToken obtains an OAuth2 token for Azure Relay.
-// The resourceURI parameter is ignored; the token is scoped to
-// https://relay.azure.net/.default as required by Azure Relay.
+// GetToken obtains an OAuth2 token for Azure Relay, returning a cached token
+// when one is available and not yet stale. Staleness mirrors azcore's
+// canonical BearerTokenPolicy.shouldRefresh: if the credential set a
+// non-zero RefreshOn, the token is stale once RefreshOn has passed (no
+// offset; the authority has supplied the exact refresh window); otherwise
+// the token is stale once it is within entraRefreshSkew of its ExpiresOn.
+// Concurrent callers that arrive during an in-flight refresh wait on a
+// channel rather than the cache mutex, so they can abort via their own
+// context if the refresh stalls. The resourceURI parameter is ignored; the
+// token is scoped to https://relay.azure.net/.default as required by Azure
+// Relay.
 func (p *EntraTokenProvider) GetToken(ctx context.Context, _ string) (string, error) {
-	tk, err := p.cred.GetToken(ctx, policy.TokenRequestOptions{
-		Scopes: []string{"https://relay.azure.net/.default"},
+	for {
+		p.mu.Lock()
+		if tokenFresh(p.cached) {
+			tk := p.cached.Token
+			p.mu.Unlock()
+			return tk, nil
+		}
+		if p.refreshing != nil {
+			// Another goroutine is fetching a fresh token. Wait for it to
+			// finish (or for our context to expire). When it finishes we
+			// loop and re-check: on success the cache will hit; on failure
+			// we'll try our own refresh with our own context.
+			ch := p.refreshing
+			p.mu.Unlock()
+			select {
+			case <-ch:
+				continue
+			case <-ctx.Done():
+				return "", ctx.Err()
+			}
+		}
+		// Become the refresher. Publishing p.refreshing under the mutex
+		// guarantees later arrivals either observe this channel and wait,
+		// or arrive after the refresh ends and see the updated cache.
+		ch := make(chan struct{})
+		p.refreshing = ch
+		p.mu.Unlock()
+
+		token, err := p.refreshOnce(ctx, ch)
+		if err != nil {
+			return "", fmt.Errorf("acquire Entra token: %w", err)
+		}
+		return token, nil
+	}
+}
+
+// tokenFresh reports whether a cached AccessToken can be served without
+// refreshing it. The check mirrors azcore.runtime.shouldRefresh so cached
+// tokens are not considered fresh past the credential's own refresh
+// guidance: when RefreshOn is non-zero the authority has supplied an
+// explicit refresh window (RefreshOn..ExpiresOn) and we refresh as soon as
+// we pass RefreshOn; otherwise we fall back to ExpiresOn minus skew.
+func tokenFresh(tk azcore.AccessToken) bool {
+	if tk.Token == "" {
+		return false
+	}
+	if !tk.RefreshOn.IsZero() {
+		return time.Now().Before(tk.RefreshOn)
+	}
+	return time.Until(tk.ExpiresOn) > entraRefreshSkew
+}
+
+// refreshOnce performs a single underlying credential fetch on behalf of the
+// caller that won the right to refresh. It always closes ch and clears
+// p.refreshing — even if the underlying credential panics — so that waiters
+// and future callers can make progress instead of wedging on the in-flight
+// signal forever. Defer-driven cleanup is the cheapest correct insurance
+// against an unlikely-but-possible panic in third-party credential code.
+func (p *EntraTokenProvider) refreshOnce(ctx context.Context, ch chan struct{}) (string, error) {
+	var (
+		tk        azcore.AccessToken
+		fetchErr  error
+		completed bool
+	)
+	defer func() {
+		p.mu.Lock()
+		if completed && fetchErr == nil {
+			p.cached = tk
+		}
+		p.refreshing = nil
+		close(ch)
+		p.mu.Unlock()
+	}()
+
+	tk, fetchErr = p.cred.GetToken(ctx, policy.TokenRequestOptions{
+		Scopes: []string{entraTokenScope},
 	})
-	if err != nil {
-		return "", fmt.Errorf("acquire Entra token: %w", err)
+	completed = true
+	if fetchErr != nil {
+		return "", fetchErr
 	}
 	return tk.Token, nil
 }

--- a/internal/relay/auth_test.go
+++ b/internal/relay/auth_test.go
@@ -5,7 +5,13 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 )
 
 func TestSanitizeErr(t *testing.T) {
@@ -43,6 +49,348 @@ func TestSanitizeErr(t *testing.T) {
 		err := sanitizeErr(orig)
 		if !errors.Is(err, context.DeadlineExceeded) {
 			t.Error("sanitizeErr should preserve error chain for errors.Is")
+		}
+	})
+}
+
+// programmableCredential is a configurable azcore.TokenCredential used to
+// exercise EntraTokenProvider's caching behaviour. Tests mutate its fields
+// between GetToken calls to control the underlying response, with the
+// internal mutex guarding concurrent reads from the credential and concurrent
+// writes from the test driver. The fields can be tuned to inject errors,
+// simulate fetch latency, or return tokens whose ExpiresOn falls inside the
+// EntraTokenProvider refresh skew.
+type programmableCredential struct {
+	mu        sync.Mutex
+	calls     atomic.Int64
+	token     string
+	expiry    time.Time
+	refreshOn time.Time
+	err       error
+	delay     time.Duration
+}
+
+func (c *programmableCredential) GetToken(ctx context.Context, opts policy.TokenRequestOptions) (azcore.AccessToken, error) {
+	c.calls.Add(1)
+	c.mu.Lock()
+	delay := c.delay
+	err := c.err
+	token := c.token
+	expiry := c.expiry
+	refreshOn := c.refreshOn
+	c.mu.Unlock()
+
+	if delay > 0 {
+		select {
+		case <-time.After(delay):
+		case <-ctx.Done():
+			return azcore.AccessToken{}, ctx.Err()
+		}
+	}
+	if err != nil {
+		return azcore.AccessToken{}, err
+	}
+	if expiry.IsZero() {
+		expiry = time.Now().Add(time.Hour)
+	}
+	if len(opts.Scopes) == 0 {
+		return azcore.AccessToken{}, errors.New("programmableCredential: no scope set")
+	}
+	return azcore.AccessToken{Token: token, ExpiresOn: expiry, RefreshOn: refreshOn}, nil
+}
+
+// TestEntraTokenProvider_ConcurrentDedup verifies that N concurrent callers
+// of EntraTokenProvider.GetToken result in exactly one underlying credential
+// fetch. This is the property that fixes the AzureCLICredential serialisation
+// cliff documented in issue #68: without it, eight concurrent sender dials
+// would each pay the ~1.1s `az` shell-out cost in series.
+func TestEntraTokenProvider_ConcurrentDedup(t *testing.T) {
+	const goroutines = 64
+	cred := &programmableCredential{
+		token: "tok",
+		// Force every caller to queue at the mutex by holding the first
+		// fetch for long enough that scheduling cannot let any goroutine
+		// race ahead. 50ms is comfortably above goroutine startup jitter
+		// while keeping the test under a second.
+		delay: 50 * time.Millisecond,
+	}
+	tp := NewEntraTokenProviderWithCredential(cred)
+
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	tokens := make([]string, goroutines)
+	errs := make([]error, goroutines)
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			<-start
+			tok, err := tp.GetToken(context.Background(), "ignored")
+			tokens[i] = tok
+			errs[i] = err
+		}(i)
+	}
+	close(start)
+	wg.Wait()
+
+	if got := cred.calls.Load(); got != 1 {
+		t.Errorf("underlying credential called %d times, want 1", got)
+	}
+	for i := range tokens {
+		if errs[i] != nil {
+			t.Errorf("goroutine %d: unexpected error %v", i, errs[i])
+		}
+		if tokens[i] != "tok" {
+			t.Errorf("goroutine %d: token = %q, want %q", i, tokens[i], "tok")
+		}
+	}
+}
+
+// TestEntraTokenProvider_RefreshAfterSkew verifies that a cached token whose
+// ExpiresOn sits inside the refresh skew is not reused: the next GetToken
+// triggers a fresh underlying fetch and returns the new token. Without this
+// behaviour a long-lived sender would silently keep handing out a stale token
+// past its expiry, and the relay control plane would start rejecting dials.
+func TestEntraTokenProvider_RefreshAfterSkew(t *testing.T) {
+	cred := &programmableCredential{
+		token: "tok-A",
+		// Expire well inside the 5-minute refresh skew so the cache entry
+		// is considered stale immediately. Using a positive but short
+		// duration (rather than a past time) ensures the first call
+		// still receives a non-empty token to cache; the *next* call
+		// will see the stale entry and refresh.
+		expiry: time.Now().Add(time.Minute),
+	}
+	tp := NewEntraTokenProviderWithCredential(cred)
+
+	first, err := tp.GetToken(context.Background(), "ignored")
+	if err != nil {
+		t.Fatalf("first GetToken: %v", err)
+	}
+	if first != "tok-A" {
+		t.Fatalf("first token = %q, want %q", first, "tok-A")
+	}
+
+	cred.mu.Lock()
+	cred.token = "tok-B"
+	cred.expiry = time.Now().Add(time.Hour) // fresh, well past skew
+	cred.mu.Unlock()
+
+	second, err := tp.GetToken(context.Background(), "ignored")
+	if err != nil {
+		t.Fatalf("second GetToken: %v", err)
+	}
+	if second != "tok-B" {
+		t.Errorf("second token = %q, want %q (cache should have refreshed)", second, "tok-B")
+	}
+	if got := cred.calls.Load(); got != 2 {
+		t.Errorf("underlying credential called %d times, want 2", got)
+	}
+}
+
+// TestEntraTokenProvider_ErrorNotCached verifies that an error from the
+// underlying credential is returned to the caller and NOT cached. A
+// subsequent successful fetch must call the credential again and return the
+// new token. Caching errors would lock the provider out of a recoverable
+// auth blip (transient ADAL outage, race with az login) for the lifetime of
+// the process.
+func TestEntraTokenProvider_ErrorNotCached(t *testing.T) {
+	sentinel := errors.New("upstream auth boom")
+	cred := &programmableCredential{
+		err: sentinel,
+	}
+	tp := NewEntraTokenProviderWithCredential(cred)
+
+	_, err := tp.GetToken(context.Background(), "ignored")
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("first GetToken error = %v, want wraps %v", err, sentinel)
+	}
+
+	cred.mu.Lock()
+	cred.err = nil
+	cred.token = "tok-recovered"
+	cred.mu.Unlock()
+
+	tok, err := tp.GetToken(context.Background(), "ignored")
+	if err != nil {
+		t.Fatalf("recovery GetToken: %v", err)
+	}
+	if tok != "tok-recovered" {
+		t.Errorf("recovery token = %q, want %q", tok, "tok-recovered")
+	}
+	if got := cred.calls.Load(); got != 2 {
+		t.Errorf("underlying credential called %d times, want 2 (no caching of error)", got)
+	}
+}
+
+// TestEntraTokenProvider_ContextCancellation verifies that a context cancelled
+// during a refresh propagates through to the underlying credential and the
+// resulting error is surfaced to the caller without poisoning the cache —
+// the next call with a healthy context must succeed.
+func TestEntraTokenProvider_ContextCancellation(t *testing.T) {
+	cred := &programmableCredential{
+		token: "tok",
+		delay: 5 * time.Second,
+	}
+	tp := NewEntraTokenProviderWithCredential(cred)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		_, err := tp.GetToken(ctx, "ignored")
+		done <- err
+	}()
+
+	// Give the goroutine a beat to enter GetToken and start blocking
+	// on the credential's delay before we cancel; 50ms is well above
+	// goroutine startup jitter and well below the 5s delay.
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+
+	select {
+	case err := <-done:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("cancellation error = %v, want wraps context.Canceled", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("GetToken did not return after ctx cancellation within 2s")
+	}
+
+	// Now reconfigure the credential for a fast successful fetch and
+	// verify the cache wasn't poisoned by the cancelled call.
+	cred.mu.Lock()
+	cred.delay = 0
+	cred.mu.Unlock()
+
+	tok, err := tp.GetToken(context.Background(), "ignored")
+	if err != nil {
+		t.Fatalf("post-cancel GetToken: %v", err)
+	}
+	if tok != "tok" {
+		t.Errorf("post-cancel token = %q, want %q", tok, "tok")
+	}
+}
+
+// TestEntraTokenProvider_WaiterContextCancellation verifies that a caller
+// arriving while a refresh is already in flight respects its own context and
+// returns promptly when the context is cancelled — without waiting for the
+// in-flight refresh to finish. Without this property a hung underlying
+// credential (for example a stuck `az` invocation) could block deadline-bound
+// dials past their deadlines simply because they queued behind it.
+func TestEntraTokenProvider_WaiterContextCancellation(t *testing.T) {
+	cred := &programmableCredential{
+		token: "tok",
+		// Long enough that the waiter's short context must time out
+		// before the refresher finishes.
+		delay: 2 * time.Second,
+	}
+	tp := NewEntraTokenProviderWithCredential(cred)
+
+	// Kick off a long-running refresh in the background. Use a context
+	// without a deadline so the refresher is purely gated on the delay.
+	refresherDone := make(chan struct{})
+	go func() {
+		_, _ = tp.GetToken(context.Background(), "ignored")
+		close(refresherDone)
+	}()
+
+	// Wait deterministically for the background refresher to enter the
+	// underlying credential's GetToken. EntraTokenProvider publishes
+	// p.refreshing before calling cred.GetToken, and cred.GetToken
+	// increments cred.calls before honoring the delay — so observing
+	// calls == 1 strictly happens-after p.refreshing is published, which
+	// guarantees the next caller enters the waiter branch.
+	deadline := time.Now().Add(2 * time.Second)
+	for cred.calls.Load() < 1 {
+		if time.Now().After(deadline) {
+			t.Fatalf("background refresher never entered credential GetToken (calls=%d)", cred.calls.Load())
+		}
+		time.Sleep(time.Millisecond)
+	}
+
+	// A second caller with a short deadline must observe ctx cancellation
+	// even though the refresher hasn't finished yet.
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+	start := time.Now()
+	_, err := tp.GetToken(ctx, "ignored")
+	elapsed := time.Since(start)
+
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("waiter error = %v, want wraps context.DeadlineExceeded", err)
+	}
+	// Allow generous slack for slow CI hosts, but ensure the waiter did
+	// not block until the refresher's 2s delay completed.
+	if elapsed > time.Second {
+		t.Errorf("waiter took %s to return; expected ~100ms (refresher still running)", elapsed)
+	}
+
+	// The refresher should still be making forward progress; let it finish
+	// so the test goroutine exits cleanly.
+	<-refresherDone
+	if got := cred.calls.Load(); got != 1 {
+		t.Errorf("underlying credential called %d times, want 1 (waiter must not trigger a second fetch)", got)
+	}
+}
+
+// TestEntraTokenProvider_RespectsRefreshOn verifies that the cache treats a
+// non-zero RefreshOn as the refresh threshold (matching azcore's canonical
+// BearerTokenPolicy.shouldRefresh): when RefreshOn is in the past, the next
+// call must trigger a refresh even though ExpiresOn is still distant; when
+// RefreshOn is in the future, the cache must remain a hit.
+func TestEntraTokenProvider_RespectsRefreshOn(t *testing.T) {
+	t.Run("past RefreshOn forces refresh despite distant ExpiresOn", func(t *testing.T) {
+		cred := &programmableCredential{
+			token:     "tok-1",
+			expiry:    time.Now().Add(time.Hour),
+			refreshOn: time.Now().Add(-time.Minute),
+		}
+		tp := NewEntraTokenProviderWithCredential(cred)
+
+		tok, err := tp.GetToken(context.Background(), "ignored")
+		if err != nil {
+			t.Fatalf("first GetToken returned %v", err)
+		}
+		if tok != "tok-1" {
+			t.Fatalf("first GetToken = %q, want %q", tok, "tok-1")
+		}
+
+		cred.mu.Lock()
+		cred.token = "tok-2"
+		cred.refreshOn = time.Time{}
+		cred.mu.Unlock()
+
+		tok, err = tp.GetToken(context.Background(), "ignored")
+		if err != nil {
+			t.Fatalf("second GetToken returned %v", err)
+		}
+		if tok != "tok-2" {
+			t.Errorf("second GetToken = %q, want %q (past RefreshOn must invalidate cache)", tok, "tok-2")
+		}
+		if got := cred.calls.Load(); got != 2 {
+			t.Errorf("underlying credential called %d times, want 2", got)
+		}
+	})
+
+	t.Run("future RefreshOn keeps cache hot", func(t *testing.T) {
+		cred := &programmableCredential{
+			token:     "tok-1",
+			expiry:    time.Now().Add(time.Hour),
+			refreshOn: time.Now().Add(30 * time.Minute),
+		}
+		tp := NewEntraTokenProviderWithCredential(cred)
+
+		for i := 0; i < 5; i++ {
+			tok, err := tp.GetToken(context.Background(), "ignored")
+			if err != nil {
+				t.Fatalf("call %d: GetToken returned %v", i, err)
+			}
+			if tok != "tok-1" {
+				t.Errorf("call %d: GetToken = %q, want %q", i, tok, "tok-1")
+			}
+		}
+		if got := cred.calls.Load(); got != 1 {
+			t.Errorf("underlying credential called %d times, want 1 (future RefreshOn must keep cache hot)", got)
 		}
 	})
 }


### PR DESCRIPTION
`EntraTokenProvider` now caches the `azcore.AccessToken` it issues and reuses it until just before its `ExpiresOn`, single-flighting refreshes under a mutex. This applies to whichever credential `DefaultAzureCredential` resolves to — CLI, workload identity, managed identity, etc. — by wrapping at the `azcore.TokenCredential` interface layer.

## User-visible behaviour

- Entra-authenticated senders now scale concurrently regardless of which credential `DefaultAzureCredential` selects. Hot-path `GetToken` calls return from an in-memory cache in sub-microseconds instead of paying the underlying credential's per-call cost.
- Tokens are refreshed automatically a short interval before their `ExpiresOn`, so the existing 45-minute listener renewal cadence and per-dial sender path both benefit from a single shared refresh.
- Errors from the underlying credential are surfaced as-is and not cached; the next caller retries the underlying fetch.
- The cache is in-process and per-`EntraTokenProvider` instance — no on-disk state, no OS keyring/keychain dependency, no new module imports.

## Test coverage

New unit tests in `internal/relay/auth_test.go`:

- N concurrent `GetToken` callers result in exactly one underlying `TokenCredential.GetToken` invocation.
- A call after `ExpiresOn - refreshSkew` triggers a fresh underlying fetch.
- An error from the underlying credential is returned to the caller and not cached; a subsequent call retries.
- Context cancellation during refresh propagates to the underlying credential.

The Azure e2e `MaxConn_BackPressure` parity scenario now passes against the entra auth path in `~12s` (matching the SAS baseline), against the prior `~97s` timeout with five flows lost.

## Considered alternatives

- `azidentity/cache` (v0.3.2) — persistent-only (`cache.go:73`, README), no in-memory mode, and the `Cache` field isn't exposed on `AzureCLICredential` or `DefaultAzureCredentialOptions`. Not applicable. See #68 for the full rationale.
- A test-side readiness gate or longer timeout — would hide the cliff for real users.

Closes #68.
