### PR TITLE
feat(mockrelay): add fault-injection knobs for testing

### DIFF
--- a/mockrelay/server/control.go
+++ b/mockrelay/server/control.go
@@ -63,6 +63,15 @@ func (s *Server) handleListen(w http.ResponseWriter, r *http.Request, entity str
 		http.Error(w, "unauthorized", http.StatusUnauthorized)
 		return
 	}
+	// Fault injection: optionally reject the next authenticated control
+	// dial with 503 to exercise the listener's control-dial failure
+	// code path. Single-shot; we check after auth so unauthenticated
+	// probes cannot consume the fault.
+	if s.faults.rejectControlDial.CompareAndSwap(true, false) {
+		s.log.Debug("fault: rejecting control dial", "entity", entity)
+		http.Error(w, "service unavailable (fault injection)", http.StatusServiceUnavailable)
+		return
+	}
 	activity := make(chan struct{}, 1)
 	notify := func() {
 		select {
@@ -164,6 +173,15 @@ func (s *Server) handleListen(w http.ResponseWriter, r *http.Request, entity str
 		}
 		if msg.RenewToken != nil {
 			s.log.Debug("listener renewed token", "entity", entity)
+			// Fault injection: close the control WS as soon as we
+			// observe a renewToken. Single-shot. The listener's
+			// renewLoop / pingLoop will surface this as a forced
+			// reconnect on its next read or write.
+			if s.faults.closeControlOnRenew.CompareAndSwap(true, false) {
+				s.log.Debug("fault: closing control on renew", "entity", entity)
+				_ = ws.Close(websocket.StatusGoingAway, "fault: close on renew")
+				return
+			}
 			continue
 		}
 		s.log.Debug("listener sent unrecognized control message", "entity", entity, "len", len(data))

--- a/mockrelay/server/fault_test.go
+++ b/mockrelay/server/fault_test.go
@@ -1,0 +1,340 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/coder/websocket"
+)
+
+// silentServer constructs a Server whose log output is dropped.
+// Fault-injection tests deliberately provoke server-side warnings
+// that would otherwise pollute `go test -v` output.
+func silentServer(t *testing.T, opts ...Option) *Server {
+	t.Helper()
+	cfg := Config{
+		Logger:   slog.New(slog.NewTextHandler(io.Discard, nil)),
+		SkipAuth: true,
+	}
+	s, err := NewServerForTesting(cfg, opts...)
+	if err != nil {
+		t.Fatalf("NewServerForTesting: %v", err)
+	}
+	return s
+}
+
+// newTestPending returns a fully-initialized pendingRendezvous. The
+// fault-injection tests register one of these directly on the hub so
+// they can drive handleAccept without standing up a real sender.
+func newTestPending() *pendingRendezvous {
+	return &pendingRendezvous{
+		ready:      make(chan struct{}),
+		bridgeDone: make(chan struct{}),
+		senderTook: make(chan struct{}),
+	}
+}
+
+// dialAccept dials the accept-side rendezvous endpoint for an entity
+// and id that the caller has already registered on the hub.
+func dialAccept(t *testing.T, ctx context.Context, srvURL, entity, id string) *websocket.Conn {
+	t.Helper()
+	wsURL := strings.Replace(srvURL, "http://", "ws://", 1) + "/$hc/" + entity + "?sb-hc-action=accept&id=" + id
+	ws, _, err := websocket.Dial(ctx, wsURL, nil)
+	if err != nil {
+		t.Fatalf("dial accept: %v", err)
+	}
+	return ws
+}
+
+// TestFaultInjection_CloseControlOnRenew verifies that
+// WithCloseControlOnRenew closes the listener control channel on the
+// next inbound renewToken message.
+func TestFaultInjection_CloseControlOnRenew(t *testing.T) {
+	s := silentServer(t, WithCloseControlOnRenew())
+	srv := httptest.NewServer(s.Handler())
+	defer srv.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	ws, _ := dialListener(t, ctx, srv.URL, "renew-entity")
+	defer ws.CloseNow() //nolint:errcheck // best-effort cleanup
+
+	renew, err := json.Marshal(map[string]any{
+		"renewToken": map[string]string{"token": "irrelevant-for-mock"},
+	})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if err := ws.Write(ctx, websocket.MessageText, renew); err != nil {
+		t.Fatalf("write renew: %v", err)
+	}
+
+	readCtx, readCancel := context.WithTimeout(ctx, 2*time.Second)
+	defer readCancel()
+	_, _, err = ws.Read(readCtx)
+	if err == nil {
+		t.Fatalf("read after renew returned nil; want close error")
+	}
+	var ce websocket.CloseError
+	if !errors.As(err, &ce) {
+		t.Fatalf("read error not a websocket.CloseError: %v", err)
+	}
+	if ce.Code != websocket.StatusGoingAway {
+		t.Errorf("close code = %d, want %d (StatusGoingAway)", ce.Code, websocket.StatusGoingAway)
+	}
+}
+
+// TestFaultInjection_CloseCodeOnAccept_1011 verifies that the accept-
+// side WS emits the 1011 (server error) close code when the knob is
+// armed with that value.
+func TestFaultInjection_CloseCodeOnAccept_1011(t *testing.T) {
+	assertCloseCodeOnAccept(t, 1011)
+}
+
+// TestFaultInjection_CloseCodeOnAccept_4400 verifies a 4xxx app-
+// defined close code, exercising the same path with a different
+// numeric value to catch a hard-coded constant.
+func TestFaultInjection_CloseCodeOnAccept_4400(t *testing.T) {
+	assertCloseCodeOnAccept(t, 4400)
+}
+
+func assertCloseCodeOnAccept(t *testing.T, code int) {
+	t.Helper()
+	s := silentServer(t, WithCloseCodeOnAccept(code))
+	srv := httptest.NewServer(s.Handler())
+	defer srv.Close()
+
+	const (
+		entity = "accept-entity"
+		id     = "deadbeefcafef00ddeadbeefcafef00d"
+	)
+	pending := newTestPending()
+	s.hub.addPending(entity, id, pending)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	ws := dialAccept(t, ctx, srv.URL, entity, id)
+	defer ws.CloseNow() //nolint:errcheck // best-effort cleanup
+
+	readCtx, readCancel := context.WithTimeout(ctx, 2*time.Second)
+	defer readCancel()
+	_, _, err := ws.Read(readCtx)
+	if err == nil {
+		t.Fatalf("read on accept WS returned nil; want close error")
+	}
+	var ce websocket.CloseError
+	if !errors.As(err, &ce) {
+		t.Fatalf("read error not a websocket.CloseError: %v", err)
+	}
+	if int(ce.Code) != code {
+		t.Errorf("close code = %d, want %d", ce.Code, code)
+	}
+
+	// The fault aborts the pending entry; ready must be closed.
+	select {
+	case <-pending.ready:
+	default:
+		t.Errorf("pending.ready not closed after accept fault")
+	}
+	if pending.listenerWS != nil {
+		t.Errorf("pending.listenerWS = %v, want nil (abort path)", pending.listenerWS)
+	}
+}
+
+// TestFaultInjection_CloseCodeOnAccept_Rejected verifies that
+// WithCloseCodeOnAccept rejects every close code coder/websocket
+// would refuse to put on the wire: the four explicitly reserved
+// codes (1004/1005/1006/1015) and the protocol-reserved range
+// 1016-2999. A test that wants the 1006 "abnormal closure" path on
+// the client must close the TCP socket abruptly instead.
+func TestFaultInjection_CloseCodeOnAccept_Rejected(t *testing.T) {
+	cfg := Config{
+		Logger:   slog.New(slog.NewTextHandler(io.Discard, nil)),
+		SkipAuth: true,
+	}
+	// Reserved by RFC 6455 §7.4.1 / coder/websocket validator.
+	for _, code := range []int{1004, 1005, 1006, 1015} {
+		_, err := NewServerForTesting(cfg, WithCloseCodeOnAccept(code))
+		if err == nil {
+			t.Errorf("WithCloseCodeOnAccept(%d) returned nil error; want rejection", code)
+			continue
+		}
+		if !strings.Contains(err.Error(), "WithCloseCodeOnAccept") {
+			t.Errorf("code %d: error %q does not mention the option name", code, err.Error())
+		}
+	}
+
+	// Protocol-reserved range (1016-2999) and codes outside the WS
+	// close-code space are also rejected — these would otherwise
+	// silently fail at Close-frame send time inside coder/websocket.
+	for _, code := range []int{0, 1, 999, 1016, 1500, 2999, 5000, 10000} {
+		_, err := NewServerForTesting(cfg, WithCloseCodeOnAccept(code))
+		if err == nil {
+			t.Errorf("WithCloseCodeOnAccept(%d) returned nil error; want rejection", code)
+		}
+	}
+
+	// Sanity: representative valid codes accept.
+	for _, code := range []int{1000, 1011, 1014, 3000, 4400, 4999} {
+		_, err := NewServerForTesting(cfg, WithCloseCodeOnAccept(code))
+		if err != nil {
+			t.Errorf("WithCloseCodeOnAccept(%d) returned error: %v", code, err)
+		}
+	}
+}
+
+// TestFaultInjection_RejectControlDial verifies that the next inbound
+// listener control dial after the knob is armed gets HTTP 503,
+// pre-upgrade.
+func TestFaultInjection_RejectControlDial(t *testing.T) {
+	s := silentServer(t, WithRejectControlDial())
+	srv := httptest.NewServer(s.Handler())
+	defer srv.Close()
+
+	// Use http.Get rather than websocket.Dial so we observe the raw
+	// 503 instead of the WS library's "expected status 101" wrapping.
+	resp, err := http.Get(srv.URL + "/$hc/reject-entity?sb-hc-action=listen")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close() //nolint:errcheck // best-effort cleanup
+	if resp.StatusCode != http.StatusServiceUnavailable {
+		t.Errorf("status = %d, want %d (ServiceUnavailable)", resp.StatusCode, http.StatusServiceUnavailable)
+	}
+
+	// Single-shot: the next dial must succeed (i.e. attempt the WS
+	// upgrade) instead of returning 503 again. Without the
+	// Upgrade/Connection headers, the WS library returns 426 / 400 /
+	// 200 with an error body — anything other than 503 confirms the
+	// fault disarmed.
+	resp2, err := http.Get(srv.URL + "/$hc/reject-entity?sb-hc-action=listen")
+	if err != nil {
+		t.Fatalf("second GET: %v", err)
+	}
+	defer resp2.Body.Close() //nolint:errcheck // best-effort cleanup
+	if resp2.StatusCode == http.StatusServiceUnavailable {
+		t.Errorf("second dial also got 503; fault should have disarmed after first hit")
+	}
+}
+
+// TestFaultInjection_AcceptDelay verifies that the accept-side
+// upgrade is delayed by at least the configured duration. The delay
+// is intentionally measured against a lower bound only — scheduling
+// noise can only make the elapsed time larger, never smaller.
+func TestFaultInjection_AcceptDelay(t *testing.T) {
+	const delay = 150 * time.Millisecond
+	s := silentServer(t, WithAcceptDelay(delay))
+	srv := httptest.NewServer(s.Handler())
+	defer srv.Close()
+
+	const (
+		entity = "delay-entity"
+		id     = "abcdefabcdefabcdefabcdefabcdefab"
+	)
+	pending := newTestPending()
+	s.hub.addPending(entity, id, pending)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	start := time.Now()
+	ws := dialAccept(t, ctx, srv.URL, entity, id)
+	elapsed := time.Since(start)
+	t.Cleanup(func() {
+		// Unblock the handler's pending.bridgeDone wait so the server
+		// goroutine exits before httptest.Server.Close.
+		close(pending.bridgeDone)
+		_ = ws.CloseNow()
+	})
+
+	if elapsed < delay {
+		t.Errorf("upgrade took %v, want >= %v", elapsed, delay)
+	}
+
+	// Negative durations must clamp to zero (no fault).
+	s2 := silentServer(t)
+	if err := WithAcceptDelay(-1)(s2); err != nil {
+		t.Fatalf("WithAcceptDelay(-1) returned err: %v", err)
+	}
+	if got := s2.faults.acceptDelay.Load(); got != 0 {
+		t.Errorf("negative duration not clamped: acceptDelay = %d ns", got)
+	}
+}
+
+// TestFaultInjection_OptionsDontLeakToProduction verifies that the
+// production constructor (mockrelay/server.NewServer) leaves the
+// fault knobs at their zero values — nothing armed.
+func TestFaultInjection_OptionsDontLeakToProduction(t *testing.T) {
+	s, err := NewServer(Config{
+		Logger:   slog.New(slog.NewTextHandler(io.Discard, nil)),
+		SkipAuth: true,
+	})
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+	if got := s.faults.closeCodeOnAccept.Load(); got != 0 {
+		t.Errorf("closeCodeOnAccept = %d, want 0", got)
+	}
+	if s.faults.closeControlOnRenew.Load() {
+		t.Errorf("closeControlOnRenew = true, want false")
+	}
+	if s.faults.rejectControlDial.Load() {
+		t.Errorf("rejectControlDial = true, want false")
+	}
+	if got := s.faults.acceptDelay.Load(); got != 0 {
+		t.Errorf("acceptDelay = %d ns, want 0", got)
+	}
+
+	// Behavioural sanity: a normal control dial succeeds.
+	srv := httptest.NewServer(s.Handler())
+	defer srv.Close()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	ws, _ := dialListener(t, ctx, srv.URL, "no-fault-entity")
+	defer ws.CloseNow() //nolint:errcheck // best-effort cleanup
+	// If WithRejectControlDial had leaked, the dial above would have
+	// failed with HTTP 503 instead of upgrading to a WebSocket.
+}
+
+// TestFaultInjection_NewServerForTesting_NoOpts verifies that calling
+// the testing constructor without options is equivalent to the
+// production constructor: no faults armed, identical behaviour.
+func TestFaultInjection_NewServerForTesting_NoOpts(t *testing.T) {
+	s, err := NewServerForTesting(Config{
+		Logger:   slog.New(slog.NewTextHandler(io.Discard, nil)),
+		SkipAuth: true,
+	})
+	if err != nil {
+		t.Fatalf("NewServerForTesting (no opts): %v", err)
+	}
+	if got := s.faults.closeCodeOnAccept.Load(); got != 0 {
+		t.Errorf("closeCodeOnAccept = %d, want 0", got)
+	}
+	if s.faults.closeControlOnRenew.Load() {
+		t.Errorf("closeControlOnRenew = true, want false")
+	}
+	if s.faults.rejectControlDial.Load() {
+		t.Errorf("rejectControlDial = true, want false")
+	}
+	if got := s.faults.acceptDelay.Load(); got != 0 {
+		t.Errorf("acceptDelay = %d ns, want 0", got)
+	}
+}
+
+// TestFaultInjection_NewServerForTesting_NilOption verifies that a
+// nil Option returns a clear error rather than panicking.
+func TestFaultInjection_NewServerForTesting_NilOption(t *testing.T) {
+	_, err := NewServerForTesting(Config{SkipAuth: true}, nil)
+	if err == nil {
+		t.Fatal("NewServerForTesting(nil Option) returned nil error; want rejection")
+	}
+}

--- a/mockrelay/server/options.go
+++ b/mockrelay/server/options.go
@@ -1,0 +1,166 @@
+package server
+
+import (
+	"errors"
+	"fmt"
+	"sync/atomic"
+	"time"
+)
+
+// Option configures a Server constructed via NewServerForTesting. Each
+// Option arms a deterministic fault — a close code, a delay, or a
+// rejection — that exercises a relay failure mode the in-process
+// mock can reproduce reliably but Azure Relay cannot. Production code
+// MUST NOT use NewServerForTesting or Option; both live in this
+// package so they cannot be wired into the aztunnel-relay CLI without
+// importing it explicitly.
+type Option func(*Server) error
+
+// faults holds the configured fault-injection state for a Server. It
+// must be reachable from request handlers, so the field lives on
+// Server. All access is via atomic operations so the read-side cost
+// is a single load and no extra synchronization with the rest of the
+// server.
+//
+// Single-shot knobs (closeCodeOnAccept, closeControlOnRenew,
+// rejectControlDial) use Swap / CompareAndSwap so the first event
+// that observes the armed value also disarms it. Persistent knobs
+// (acceptDelay) use Load so they apply to every matching event.
+type faults struct {
+	closeCodeOnAccept   atomic.Int32 // 0 = disarmed, otherwise the WebSocket close code to emit
+	closeControlOnRenew atomic.Bool
+	rejectControlDial   atomic.Bool
+	acceptDelay         atomic.Int64 // nanoseconds; 0 = no delay
+}
+
+// WithCloseControlOnRenew makes the server close the listener's
+// control WebSocket as soon as it observes the next inbound
+// renewToken message. The listener's renewLoop will then observe its
+// next write or read fail and trigger a reconnect, exercising the
+// renew-failure client log path.
+//
+// This knob replaces the previously-proposed "silent renew failure":
+// the on-wire renew protocol is fire-and-forget — the listener does
+// NOT expect an echo back from the relay, so a server that silently
+// swallows renewToken messages is indistinguishable from a healthy
+// one. An observable close is the closest analogue tests can drive
+// against the current client.
+//
+// Single-shot: fires once on the first renewToken observed by any
+// listener, then disarms.
+func WithCloseControlOnRenew() Option {
+	return func(s *Server) error {
+		s.faults.closeControlOnRenew.Store(true)
+		return nil
+	}
+}
+
+// WithCloseCodeOnAccept makes the next accept-side (listener-
+// rendezvous) WebSocket emit the given close code (for example 1011
+// "server error", or an application code in the 3000-4999 range like
+// 4400). The peer observes the configured code in its close frame.
+//
+// Sendable close codes are constrained by RFC 6455 §7.4.1 and the
+// coder/websocket library's wire-code validator: only 1000-1003,
+// 1007-1014, and 3000-4999 may appear on the wire. Codes outside
+// that set — including the reserved 1004 / 1005 / 1006 / 1015 and
+// the protocol-reserved range 1016-2999 — are rejected at
+// construction with a clear error.
+//
+// A test that wants the 1006 "abnormal closure" code path on the
+// client side must close the underlying TCP socket without a close
+// frame instead — there is no Option for that today; add a dedicated
+// helper when a test needs it.
+//
+// Single-shot: fires on the first accept after construction, then
+// disarms.
+func WithCloseCodeOnAccept(code int) Option {
+	return func(s *Server) error {
+		if !isSendableCloseCode(code) {
+			return fmt.Errorf("WithCloseCodeOnAccept: WS code %d is not sendable in a close frame (sendable: 1000-1003, 1007-1014, 3000-4999)", code)
+		}
+		s.faults.closeCodeOnAccept.Store(int32(code))
+		return nil
+	}
+}
+
+// isSendableCloseCode mirrors coder/websocket's validWireCloseCode:
+// accept 1000-1014 and 3000-4999, except the four codes RFC 6455
+// reserves as forbidden on the wire (1004, 1005, 1006, 1015).
+func isSendableCloseCode(code int) bool {
+	switch code {
+	case 1004, 1005, 1006, 1015:
+		return false
+	}
+	if code >= 1000 && code <= 1014 {
+		return true
+	}
+	if code >= 3000 && code <= 4999 {
+		return true
+	}
+	return false
+}
+
+// WithRejectControlDial rejects the next inbound listener control-
+// channel dial outright at HTTP-upgrade time, returning HTTP 503.
+// "Control dial" is the listener-side path: aztunnel listeners open
+// the long-lived control WebSocket with the relay via
+// /$hc/<entity>?sb-hc-action=listen. The sender side uses the
+// rendezvous (accept) endpoints and is unaffected by this knob.
+//
+// The check fires after SAS validation, so an unauthenticated probe
+// cannot accidentally consume the fault. Tests that don't want to
+// mint tokens should set Config.SkipAuth.
+//
+// Single-shot: fires on the first authenticated listen request,
+// then disarms.
+func WithRejectControlDial() Option {
+	return func(s *Server) error {
+		s.faults.rejectControlDial.Store(true)
+		return nil
+	}
+}
+
+// WithAcceptDelay sleeps for d before completing the WebSocket
+// upgrade on any accept-side (listener-rendezvous) dial. Unlike the
+// single-shot knobs, WithAcceptDelay applies to every accept for the
+// lifetime of the Server; tests should pair it with t.Cleanup or a
+// short-lived Server to avoid bleed-through.
+//
+// Negative durations are clamped to zero; zero disables the delay.
+// The sleep honors the inbound request context so server shutdown is
+// not blocked on a pending delay.
+func WithAcceptDelay(d time.Duration) Option {
+	return func(s *Server) error {
+		if d < 0 {
+			d = 0
+		}
+		s.faults.acceptDelay.Store(int64(d))
+		return nil
+	}
+}
+
+// NewServerForTesting returns a Server configured with testing-only
+// fault-injection hooks. It takes the same Config the production
+// constructor takes; faults compose on top of normal behaviour.
+// Production code MUST use NewServer instead — the two constructors
+// share the same Server type so existing public methods (Handler,
+// Serve, ...) continue to work.
+//
+// Options are applied left-to-right; any option that returns an
+// error causes construction to fail.
+func NewServerForTesting(cfg Config, opts ...Option) (*Server, error) {
+	s, err := NewServer(cfg)
+	if err != nil {
+		return nil, err
+	}
+	for _, opt := range opts {
+		if opt == nil {
+			return nil, errors.New("NewServerForTesting: nil Option")
+		}
+		if err := opt(s); err != nil {
+			return nil, err
+		}
+	}
+	return s, nil
+}

--- a/mockrelay/server/options.go
+++ b/mockrelay/server/options.go
@@ -10,10 +10,15 @@ import (
 // Option configures a Server constructed via NewServerForTesting. Each
 // Option arms a deterministic fault — a close code, a delay, or a
 // rejection — that exercises a relay failure mode the in-process
-// mock can reproduce reliably but Azure Relay cannot. Production code
-// MUST NOT use NewServerForTesting or Option; both live in this
-// package so they cannot be wired into the aztunnel-relay CLI without
-// importing it explicitly.
+// mock can reproduce reliably but Azure Relay cannot.
+//
+// Options are testing-only: the production constructor NewServer
+// never invokes any Option, so a Server returned from NewServer is
+// guaranteed to have every fault knob disarmed regardless of which
+// callers (including the aztunnel-relay CLI) import this package.
+// The "do not use in production" rule is therefore enforced by code
+// path, not by import boundary; callers building production
+// binaries MUST construct their Server with NewServer.
 type Option func(*Server) error
 
 // faults holds the configured fault-injection state for a Server. It

--- a/mockrelay/server/rendezvous.go
+++ b/mockrelay/server/rendezvous.go
@@ -8,6 +8,7 @@ import (
 	"net/url"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/coder/websocket"
 )
@@ -214,6 +215,19 @@ func (s *Server) handleConnect(w http.ResponseWriter, r *http.Request, entity st
 // goroutine never took ownership (which can happen if the
 // RendezvousTimeout fires concurrently with the claim).
 func (s *Server) handleAccept(w http.ResponseWriter, r *http.Request, entity, id string) {
+	// Fault injection: optionally sleep before completing the upgrade.
+	// Applied to every accept for the lifetime of the Server. Honors
+	// the request context so server shutdown is not blocked on a
+	// pending delay.
+	if d := time.Duration(s.faults.acceptDelay.Load()); d > 0 {
+		t := time.NewTimer(d)
+		select {
+		case <-t.C:
+		case <-r.Context().Done():
+			t.Stop()
+			return
+		}
+	}
 	pending := s.hub.takePending(entity, id)
 	if pending == nil {
 		http.Error(w, "unknown rendezvous id", http.StatusNotFound)
@@ -226,6 +240,17 @@ func (s *Server) handleAccept(w http.ResponseWriter, r *http.Request, entity, id
 	if err != nil {
 		s.log.Warn("listener-rendezvous upgrade failed", "entity", entity, "id", id, "error", err)
 		pending.abort()
+		return
+	}
+	// Fault injection: emit a configurable close code on the next
+	// accept. Single-shot; consumed via Swap(0). We abort the pending
+	// entry BEFORE the close handshake so any concurrent sender
+	// goroutine waking on pending.ready exits immediately rather than
+	// waiting for our Close to drain.
+	if code := s.faults.closeCodeOnAccept.Swap(0); code != 0 {
+		s.log.Debug("fault: closing accept-side WS with code", "entity", entity, "id", id, "code", code)
+		pending.abort()
+		_ = listenerWS.Close(websocket.StatusCode(code), "fault: close on accept")
 		return
 	}
 	listenerWS.SetReadLimit(bridgeReadLimit)

--- a/mockrelay/server/server.go
+++ b/mockrelay/server/server.go
@@ -92,10 +92,18 @@ const (
 
 // Server is a relay server. Use NewServer to construct one and pass
 // Handler() to an http.Server (or http.ListenAndServe) to serve.
+//
+// Server is intended to be allocated once and accessed through a
+// *Server; do not copy the value (the embedded faults struct holds
+// atomics that go vet would flag on copy).
 type Server struct {
 	cfg Config
 	hub *hub
 	log *slog.Logger
+	// faults holds fault-injection state set via NewServerForTesting.
+	// Zero value means no faults active; the production NewServer
+	// constructor never touches it.
+	faults faults
 }
 
 // NewServer constructs a Server with the given config. It validates the


### PR DESCRIPTION
The in-process `mockrelay` server now supports deterministic fault injection so tests can reproduce relay failure modes that Azure Relay does not yield reliably. Production callers of `mockrelay.NewServer(cfg)` see no change; a new testing-only constructor accepts functional options that arm individual faults.

## Knobs

- **`WithCloseControlOnRenew()`** — closes the listener control WebSocket on the next inbound `renewToken` message (single-shot). Surfaces on the listener as a forced reconnect on its next read or write.
- **`WithCloseCodeOnAccept(code)`** — emits the given close code on the next accept-side (listener-rendezvous) WebSocket (single-shot). Validates `code` against the wire-sendable close-code set (1000-1003, 1007-1014, 3000-4999); rejects reserved codes (1004, 1005, 1006, 1015) and the protocol-reserved 1016-2999 range at construction.
- **`WithRejectControlDial()`** — returns HTTP 503 on the next authenticated listener control dial (single-shot). The check runs after SAS validation so unauthenticated probes cannot consume the fault.
- **`WithAcceptDelay(d)`** — sleeps for `d` before completing every accept-side upgrade (persistent for the lifetime of the Server; honors request cancellation).

## Constructor

```go
server.NewServerForTesting(cfg server.Config, opts ...server.Option) (*server.Server, error)
```

Both `Option` and `NewServerForTesting` live in `mockrelay/server` and are documented as testing-only. The production `NewServer(cfg)` constructor remains unchanged and never arms any fault.

## Tests

`mockrelay/server/fault_test.go` adds dedicated coverage for each knob: control-channel close on renew, accept-side close codes 1011 and 4400, rejection of every code coder/websocket would refuse to put on the wire, the 503 on next control dial, accept-side delay observation, and a regression guard that the production constructor leaves every knob disarmed. All pass under `go test -race ./mockrelay/...`.
