### PR TITLE
feat(obs): correlate sender and listener logs via bridge_id

### DIFF
--- a/e2e/azure_backend_test.go
+++ b/e2e/azure_backend_test.go
@@ -96,6 +96,7 @@ func (b *azureBackend) Setup(t testing.TB, opts relayparity.SetupOptions) *relay
 			Completed: scrapeCounter(metricsAddr, "aztunnel_connections_total"),
 			Active:    scrapeGauge(metricsAddr, "aztunnel_active_connections"),
 			Stop:      func() { lst.Stop(t) },
+			Logs:      func() string { return lst.logs.String() },
 		}
 	}
 
@@ -129,6 +130,7 @@ func (b *azureBackend) Setup(t testing.TB, opts relayparity.SetupOptions) *relay
 			Completed: scrapeCounter(metricsAddr, "aztunnel_connections_total"),
 			Active:    scrapeGauge(metricsAddr, "aztunnel_active_connections"),
 			Stop:      func() { proc.Stop(t) },
+			Logs:      func() string { return proc.logs.String() },
 		})
 	}
 

--- a/e2e/parity_test.go
+++ b/e2e/parity_test.go
@@ -30,6 +30,7 @@ func TestParity_Azure(t *testing.T) {
 			relayparity.RunCoreSuite(t, b)
 			relayparity.RunTopologySuite(t, b)
 			relayparity.RunReliabilitySuite(t, b)
+			relayparity.RunObservabilitySuite(t, b)
 		})
 	}
 }

--- a/internal/idgen/idgen.go
+++ b/internal/idgen/idgen.go
@@ -1,0 +1,36 @@
+// Package idgen mints short opaque identifiers used as log
+// correlation keys across the aztunnel observability surface
+// (bridge_id today; listener_id / control_session_id / accept_id in
+// later observability work).
+//
+// IDs are 16 characters of base32 with no padding, encoding 80 bits
+// of entropy from crypto/rand. The character set is [A-Z2-7], which
+// is safe to embed in slog TextHandler output without quoting and is
+// easy to copy/paste from log lines.
+package idgen
+
+import (
+	"crypto/rand"
+	"encoding/base32"
+	"fmt"
+	"io"
+)
+
+// bridgeIDBytes is the number of random bytes encoded into a
+// BridgeID. 10 bytes encode to exactly 16 base32 characters with no
+// padding (10*8 == 16*5).
+const bridgeIDBytes = 10
+
+// NewBridgeID returns a fresh, opaque correlation ID for a single
+// bridge. It panics if the OS RNG fails, which only happens under
+// resource exhaustion so catastrophic that the process cannot
+// continue anyway — propagating an error from every call site would
+// pollute the public API for a failure mode callers cannot recover
+// from.
+func NewBridgeID() string {
+	var b [bridgeIDBytes]byte
+	if _, err := io.ReadFull(rand.Reader, b[:]); err != nil {
+		panic(fmt.Errorf("idgen: read crypto/rand: %w", err))
+	}
+	return base32.StdEncoding.WithPadding(base32.NoPadding).EncodeToString(b[:])
+}

--- a/internal/idgen/idgen_test.go
+++ b/internal/idgen/idgen_test.go
@@ -1,0 +1,54 @@
+package idgen
+
+import (
+	"testing"
+)
+
+// TestNewBridgeID_Format asserts NewBridgeID returns a stable-length
+// base32 string drawn from the [A-Z2-7] charset. Log scrapers grep
+// for this exact pattern, so the format is a public contract: any
+// change here must come with an explicit version bump and downstream
+// scraper updates.
+func TestNewBridgeID_Format(t *testing.T) {
+	const want = 16
+	for i := 0; i < 32; i++ {
+		id := NewBridgeID()
+		if len(id) != want {
+			t.Fatalf("NewBridgeID() len = %d, want %d (id=%q)", len(id), want, id)
+		}
+		for j, c := range id {
+			ok := (c >= 'A' && c <= 'Z') || (c >= '2' && c <= '7')
+			if !ok {
+				t.Fatalf("NewBridgeID() id=%q: invalid char %q at %d", id, c, j)
+			}
+		}
+	}
+}
+
+// TestNewBridgeID_NoCollisions defends the 80-bit entropy claim.
+// 10_000 IDs gives a vanishingly small birthday-collision probability
+// at 2^80; a collision here is a regression in either the RNG plumbing
+// or the encoding (e.g. accidentally truncating).
+func TestNewBridgeID_NoCollisions(t *testing.T) {
+	const n = 10_000
+	seen := make(map[string]struct{}, n)
+	for i := 0; i < n; i++ {
+		id := NewBridgeID()
+		if _, dup := seen[id]; dup {
+			t.Fatalf("collision after %d IDs: %q", i+1, id)
+		}
+		seen[id] = struct{}{}
+	}
+}
+
+// TestNewBridgeID_NotEmpty is a defence against the zero-value
+// regression — a caller that fails to call NewBridgeID and binds the
+// zero value onto a logger would emit bridge_id="" which is exactly
+// the mixed-version-compatibility signal P5's listener wiring uses.
+// A non-empty contract here means "this function never produces that
+// signal by accident".
+func TestNewBridgeID_NotEmpty(t *testing.T) {
+	if NewBridgeID() == "" {
+		t.Fatalf("NewBridgeID() returned empty string")
+	}
+}

--- a/internal/listener/listener.go
+++ b/internal/listener/listener.go
@@ -99,6 +99,14 @@ func handleConnection(ctx context.Context, ws *websocket.Conn, cfg Config) {
 		return
 	}
 
+	// Bind the sender-minted bridge correlation ID onto the request-
+	// scoped logger so every log line on this listener for this bridge
+	// carries the same value the sender logs against. An empty value
+	// indicates a pre-P5 sender; we bind it anyway (slog emits
+	// bridge_id="") so operators see explicit evidence of mixed-version
+	// traffic rather than a silently absent attribute.
+	logger = logger.With("bridge_id", env.BridgeID)
+
 	logger.Info("connection requested", "target", env.Target)
 
 	// Check allowlist.

--- a/internal/protocol/envelope.go
+++ b/internal/protocol/envelope.go
@@ -17,6 +17,14 @@ type ConnectEnvelope struct {
 	// Metadata carries extensible key-value pairs for future use
 	// (auth tokens, compression negotiation, trace IDs, etc.).
 	Metadata map[string]string `json:"metadata,omitempty"`
+
+	// BridgeID is a sender-minted opaque identifier for this bridge.
+	// Listeners bind it into their request-scoped logger so logs on
+	// both sides correlate via grep for the same value. Listeners
+	// receiving an empty value MUST NOT mint a fallback; absence
+	// means a sender on a pre-P5 version. The format is unspecified
+	// (callers should not parse).
+	BridgeID string `json:"bridge_id,omitempty"`
 }
 
 // ConnectResponse is sent by the relay-listener back to the relay-sender

--- a/internal/protocol/envelope_test.go
+++ b/internal/protocol/envelope_test.go
@@ -11,6 +11,7 @@ func TestEnvelopeRoundTrip(t *testing.T) {
 		Version:  CurrentVersion,
 		Target:   "10.0.0.5:22",
 		Metadata: map[string]string{"trace": "abc123"},
+		BridgeID: "ABCDEFGHIJKLMNOP",
 	}
 	data, err := json.Marshal(env)
 	if err != nil {
@@ -29,6 +30,9 @@ func TestEnvelopeRoundTrip(t *testing.T) {
 	}
 	if got.Metadata["trace"] != "abc123" {
 		t.Errorf("metadata[trace] = %q, want %q", got.Metadata["trace"], "abc123")
+	}
+	if got.BridgeID != env.BridgeID {
+		t.Errorf("bridge_id = %q, want %q", got.BridgeID, env.BridgeID)
 	}
 }
 
@@ -66,6 +70,15 @@ func TestEnvelopeOmitEmptyMetadata(t *testing.T) {
 	s := string(data)
 	if strings.Contains(s, "metadata") {
 		t.Errorf("expected metadata to be omitted, got: %s", s)
+	}
+}
+
+func TestEnvelopeOmitEmptyBridgeID(t *testing.T) {
+	env := ConnectEnvelope{Version: CurrentVersion, Target: "host:22"}
+	data, _ := json.Marshal(env)
+	s := string(data)
+	if strings.Contains(s, "bridge_id") {
+		t.Errorf("expected bridge_id to be omitted, got: %s", s)
 	}
 }
 

--- a/internal/sender/connect.go
+++ b/internal/sender/connect.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"log/slog"
 
+	"github.com/philsphicas/aztunnel/internal/idgen"
 	"github.com/philsphicas/aztunnel/internal/metrics"
 	"github.com/philsphicas/aztunnel/internal/relay"
 )
@@ -30,18 +31,22 @@ func Connect(ctx context.Context, cfg ConnectConfig) error {
 		cfg.Logger = slog.Default()
 	}
 
-	ws, err := cfg.Metrics.InstrumentedDial(ctx, cfg.Endpoint, cfg.EntityPath, cfg.TokenProvider, cfg.ClientOptions, "sender", cfg.Logger)
+	bridgeID := idgen.NewBridgeID()
+	logger := cfg.Logger.With("bridge_id", bridgeID)
+	logger.Info("connection requested", "target", cfg.Target)
+
+	ws, err := cfg.Metrics.InstrumentedDial(ctx, cfg.Endpoint, cfg.EntityPath, cfg.TokenProvider, cfg.ClientOptions, "sender", logger)
 	if err != nil {
 		return err
 	}
 	defer func() { _ = ws.CloseNow() }()
 
-	if err := sendEnvelopeAndCheck(ctx, ws, cfg.Target); err != nil {
+	if err := sendEnvelopeAndCheck(ctx, ws, cfg.Target, bridgeID); err != nil {
 		cfg.Metrics.ConnectionError("sender", metrics.ReasonEnvelopeError)
 		return err
 	}
 
-	cfg.Logger.Debug("connected", "target", cfg.Target)
+	logger.Debug("connected", "target", cfg.Target)
 
 	stdio := &stdioConn{in: cfg.Stdin, out: cfg.Stdout}
 	_, bridgeErr := cfg.Metrics.TrackedBridge(ctx, ws, stdio, "sender", cfg.Target)

--- a/internal/sender/portforward.go
+++ b/internal/sender/portforward.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/coder/websocket"
+	"github.com/philsphicas/aztunnel/internal/idgen"
 	"github.com/philsphicas/aztunnel/internal/metrics"
 	"github.com/philsphicas/aztunnel/internal/protocol"
 	"github.com/philsphicas/aztunnel/internal/relay"
@@ -74,9 +75,11 @@ func PortForward(ctx context.Context, cfg PortForwardConfig) error {
 
 		go func() {
 			defer conn.Close() //nolint:errcheck // best-effort cleanup
-			if err := forwardConnection(ctx, conn, cfg.Target, cfg); err != nil {
-				cfg.Logger.Warn("forward failed", "error", err)
-			}
+			// forwardConnection logs its own per-bridge errors with
+			// the bridge_id-bound logger; the returned error is
+			// surfaced for tests and metrics, not for top-level
+			// logging.
+			_ = forwardConnection(ctx, conn, cfg.Target, cfg)
 		}()
 	}
 }
@@ -85,20 +88,29 @@ func forwardConnection(ctx context.Context, conn net.Conn, target string, cfg Po
 	// Set TCP keepalive on the incoming connection.
 	relay.SetTCPKeepAlive(conn, cfg.TCPKeepAlive)
 
-	ws, err := cfg.Metrics.InstrumentedDial(ctx, cfg.Endpoint, cfg.EntityPath, cfg.TokenProvider, cfg.ClientOptions, "sender", cfg.Logger)
+	bridgeID := idgen.NewBridgeID()
+	logger := cfg.Logger.With("bridge_id", bridgeID)
+	logger.Info("connection requested", "target", target)
+
+	ws, err := cfg.Metrics.InstrumentedDial(ctx, cfg.Endpoint, cfg.EntityPath, cfg.TokenProvider, cfg.ClientOptions, "sender", logger)
 	if err != nil {
+		logger.Warn("forward failed", "error", err)
 		return err
 	}
 	defer func() { _ = ws.CloseNow() }()
 
 	// Send envelope and read response.
-	if err := sendEnvelopeAndCheck(ctx, ws, target); err != nil {
+	if err := sendEnvelopeAndCheck(ctx, ws, target, bridgeID); err != nil {
 		cfg.Metrics.ConnectionError("sender", metrics.ReasonEnvelopeError)
+		logger.Warn("forward failed", "error", err)
 		return err
 	}
 
 	// Bridge data.
 	_, bridgeErr := cfg.Metrics.TrackedBridge(ctx, ws, conn, "sender", target)
+	if bridgeErr != nil {
+		logger.Warn("forward failed", "error", bridgeErr)
+	}
 	return bridgeErr
 }
 
@@ -109,10 +121,15 @@ func forwardConnection(ctx context.Context, conn net.Conn, target string, cfg Po
 // the client (SOCKS5 sender → REP byte) inspect the wrapped value via
 // errors.As; callers that only care about the failure (port-forward) can
 // treat it as an opaque error.
-func sendEnvelopeAndCheck(ctx context.Context, ws *websocket.Conn, target string) error {
+//
+// bridgeID is the sender-minted correlation ID for this bridge; it is
+// propagated to the listener via ConnectEnvelope.BridgeID so logs on
+// both ends carry the same value.
+func sendEnvelopeAndCheck(ctx context.Context, ws *websocket.Conn, target, bridgeID string) error {
 	env := protocol.ConnectEnvelope{
-		Version: protocol.CurrentVersion,
-		Target:  target,
+		Version:  protocol.CurrentVersion,
+		Target:   target,
+		BridgeID: bridgeID,
 	}
 	data, _ := json.Marshal(env) // simple struct, cannot fail
 	if err := ws.Write(ctx, websocket.MessageText, data); err != nil {

--- a/internal/sender/sender_test.go
+++ b/internal/sender/sender_test.go
@@ -228,6 +228,9 @@ func TestSendEnvelopeAndCheck(t *testing.T) {
 				if env.Version != protocol.CurrentVersion {
 					t.Errorf("server: envelope version = %d, want %d", env.Version, protocol.CurrentVersion)
 				}
+				if env.BridgeID != "TESTBRIDGEID0001" {
+					t.Errorf("server: envelope bridge_id = %q, want %q", env.BridgeID, "TESTBRIDGEID0001")
+				}
 
 				// Send response.
 				resp := protocol.ConnectResponse{
@@ -253,7 +256,7 @@ func TestSendEnvelopeAndCheck(t *testing.T) {
 			}
 			defer ws.CloseNow()
 
-			err = sendEnvelopeAndCheck(ctx, ws, tt.target)
+			err = sendEnvelopeAndCheck(ctx, ws, tt.target, "TESTBRIDGEID0001")
 
 			if tt.wantErr != "" {
 				if err == nil {
@@ -294,7 +297,7 @@ func TestSendEnvelopeAndCheck_WriteError(t *testing.T) {
 	// Give the server a moment to send its close frame.
 	time.Sleep(50 * time.Millisecond)
 
-	err = sendEnvelopeAndCheck(ctx, ws, "localhost:80")
+	err = sendEnvelopeAndCheck(ctx, ws, "localhost:80", "TESTBRIDGEID0002")
 	if err == nil {
 		t.Fatal("expected error when writing to closed websocket, got nil")
 	}
@@ -338,7 +341,7 @@ func TestSendEnvelopeAndCheck_InvalidResponse(t *testing.T) {
 	}
 	defer ws.CloseNow()
 
-	err = sendEnvelopeAndCheck(ctx, ws, "localhost:80")
+	err = sendEnvelopeAndCheck(ctx, ws, "localhost:80", "TESTBRIDGEID0003")
 	if err == nil {
 		t.Fatal("expected error for invalid JSON response, got nil")
 	}

--- a/internal/sender/socks5proxy.go
+++ b/internal/sender/socks5proxy.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"time"
 
+	"github.com/philsphicas/aztunnel/internal/idgen"
 	"github.com/philsphicas/aztunnel/internal/metrics"
 	"github.com/philsphicas/aztunnel/internal/protocol"
 	"github.com/philsphicas/aztunnel/internal/relay"
@@ -69,9 +70,12 @@ func SOCKS5Proxy(ctx context.Context, cfg SOCKS5Config) error {
 
 		go func() {
 			defer conn.Close() //nolint:errcheck // best-effort cleanup
-			if err := handleSOCKS5(ctx, conn, cfg); err != nil {
-				cfg.Logger.Warn("socks5 failed", "error", err)
-			}
+			// handleSOCKS5 logs its own per-bridge errors with the
+			// bridge_id-bound logger (or with the unbound logger for
+			// failures that happen before the SOCKS5 handshake reveals
+			// a target). The returned error is surfaced for tests and
+			// metrics, not for top-level logging.
+			_ = handleSOCKS5(ctx, conn, cfg)
 		}()
 	}
 }
@@ -83,28 +87,38 @@ func handleSOCKS5(ctx context.Context, conn net.Conn, cfg SOCKS5Config) error {
 	// Set a deadline for the SOCKS5 handshake.
 	_ = conn.SetReadDeadline(time.Now().Add(30 * time.Second))
 
-	// Perform SOCKS5 handshake to get the target.
+	// Perform SOCKS5 handshake to get the target. No bridge_id is
+	// available yet — the per-bridge ID is minted after the target
+	// is known.
 	target, err := socks5.Handshake(conn)
 	if err != nil {
 		_ = socks5.SendReply(conn, socks5.RepGeneralFailure, nil)
-		return fmt.Errorf("socks5 handshake: %w", err)
+		err = fmt.Errorf("socks5 handshake: %w", err)
+		cfg.Logger.Warn("socks5 failed", "error", err)
+		return err
 	}
 	_ = conn.SetReadDeadline(time.Time{}) // clear deadline
 
-	cfg.Logger.Info("socks5 connect", "target", target)
+	// Mint the bridge_id once the target is known so the per-bridge
+	// logger carries both attributes from this point on.
+	bridgeID := idgen.NewBridgeID()
+	logger := cfg.Logger.With("bridge_id", bridgeID)
+	logger.Info("connection requested", "target", target)
 
 	// Dial the relay.
-	ws, err := cfg.Metrics.InstrumentedDial(ctx, cfg.Endpoint, cfg.EntityPath, cfg.TokenProvider, cfg.ClientOptions, "sender", cfg.Logger)
+	ws, err := cfg.Metrics.InstrumentedDial(ctx, cfg.Endpoint, cfg.EntityPath, cfg.TokenProvider, cfg.ClientOptions, "sender", logger)
 	if err != nil {
 		_ = socks5.SendReply(conn, socks5.RepGeneralFailure, nil)
+		logger.Warn("socks5 failed", "error", err)
 		return err
 	}
 	defer func() { _ = ws.CloseNow() }()
 
 	// Send envelope and check response.
-	if err := sendEnvelopeAndCheck(ctx, ws, target); err != nil {
+	if err := sendEnvelopeAndCheck(ctx, ws, target, bridgeID); err != nil {
 		_ = socks5.SendReply(conn, socks5RepForError(err), nil)
 		cfg.Metrics.ConnectionError("sender", metrics.ReasonEnvelopeError)
+		logger.Warn("socks5 failed", "error", err)
 		return err
 	}
 
@@ -114,6 +128,9 @@ func handleSOCKS5(ctx context.Context, conn net.Conn, cfg SOCKS5Config) error {
 
 	// Bridge data.
 	_, bridgeErr := cfg.Metrics.TrackedBridge(ctx, ws, conn, "sender", target)
+	if bridgeErr != nil {
+		logger.Warn("socks5 failed", "error", bridgeErr)
+	}
 	return bridgeErr
 }
 

--- a/internal/testharness/relayparity/backend.go
+++ b/internal/testharness/relayparity/backend.go
@@ -130,6 +130,13 @@ type Listener struct {
 	// subprocess backends kill and reap the listener process.
 	// Idempotent; safe to call from a scenario goroutine.
 	Stop func()
+
+	// Logs returns every log line this listener has emitted so far,
+	// joined by newlines. Observability parity scenarios grep this
+	// string for cross-process correlation IDs (e.g. bridge_id).
+	// Optional: backends that do not capture logs may leave this nil
+	// and scenarios that need it call t.Skip.
+	Logs func() string
 }
 
 // Sender is a handle to a single sender in a Tunnel. Backends populate
@@ -152,6 +159,11 @@ type Sender struct {
 
 	// Stop drops this sender. Idempotent.
 	Stop func()
+
+	// Logs returns every log line this sender has emitted so far,
+	// joined by newlines. See Listener.Logs for usage and the
+	// optional-nil contract.
+	Logs func() string
 }
 
 // Tunnel is a running listener/sender/relay topology returned by

--- a/internal/testharness/relayparity/observability.go
+++ b/internal/testharness/relayparity/observability.go
@@ -1,0 +1,217 @@
+package relayparity
+
+import (
+	"bytes"
+	"errors"
+	"regexp"
+	"strings"
+	"testing"
+	"time"
+)
+
+// RunObservabilitySuite runs the cross-backend observability parity
+// scenarios against b. Each scenario asserts a log-shape contract
+// that operators rely on for cross-process correlation (e.g. a
+// bridge_id present on both ends).
+//
+// Backends that do not capture per-handle logs (Listener.Logs /
+// Sender.Logs are nil) will trip the t.Fatal in the scenario itself;
+// adding a new backend therefore forces the implementer to wire
+// log capture so the parity claim stays honest.
+func RunObservabilitySuite(t *testing.T, b Backend) {
+	t.Helper()
+	scenarios := []struct {
+		name string
+		run  func(*testing.T, Backend)
+	}{
+		{"BridgeID_Correlation", ScenarioBridgeID_Correlation},
+	}
+	for _, sc := range scenarios {
+		t.Run(sc.name, func(t *testing.T) {
+			sc.run(t, b)
+		})
+	}
+}
+
+// bridgeIDRe matches a bridge_id=VALUE token in slog TextHandler
+// output. The base32 NoPadding charset ([A-Z2-7]) is safe to leave
+// unquoted in slog output so an unquoted match is sufficient — and
+// is exactly what the operator's grep one-liner will look like.
+var bridgeIDRe = regexp.MustCompile(`bridge_id=([A-Z2-7]+)`)
+
+// ScenarioBridgeID_Correlation drives one successful bridge and one
+// failed bridge through a SOCKS5 sender (so a single sender can pick
+// per-connection targets), then asserts that the bridge_id slog
+// attribute the sender minted appears on the matching listener-side
+// log line for each bridge.
+//
+// Success case: sender emits "connection requested" with
+// bridge_id=X; listener emits "connection requested" with the same
+// bridge_id=X. Failure case: sender emits the same outbound log,
+// listener emits "dial target failed" with the same bridge_id=Y. The
+// scenario does not assert on the failure log on the sender side
+// because the sender's failure surface depends on backend timing
+// (port-forward vs SOCKS5, refused vs timeout); the success-side
+// outbound log is enough to anchor each ID.
+//
+// Cross-backend: identical on mock and Azure because BridgeID is an
+// application-level envelope field that Azure Relay just forwards
+// verbatim.
+func ScenarioBridgeID_Correlation(t *testing.T, b Backend) {
+	t.Helper()
+	AssertNoLeaks(t)
+
+	echo := StartPlainEcho(t)
+	refused := refusedAddr(t)
+
+	tun := b.Setup(t, SetupOptions{
+		NumListeners:   1,
+		SenderMode:     ModeSOCKS5,
+		AllowedTargets: []string{echo.Addr(), refused},
+		ConnectTimeout: 5 * time.Second,
+	})
+	requireLogs(t, tun)
+
+	// 1. Successful bridge through the echo target. Drive a round-trip
+	//    so the listener has unambiguously processed the envelope
+	//    before we scrape its logs.
+	{
+		conn, err := dialSOCKS5WithRetry(tun.SenderAddr, echo.Addr(), 15*time.Second)
+		if err != nil {
+			t.Fatalf("socks5 dial echo: %v", err)
+		}
+		want := []byte("p5 bridge id\n")
+		writeAll(t, conn, want)
+		got := readN(t, conn, len(want), 10*time.Second)
+		if !bytes.Equal(got, want) {
+			t.Fatalf("echo mismatch: got=%q want=%q", got, want)
+		}
+		_ = conn.Close()
+	}
+
+	// 2. Failed bridge to a refused target — allowlisted so the
+	//    listener actually attempts the dial (and logs "dial target
+	//    failed"), rather than rejecting the target outright.
+	{
+		_, err := DialSOCKS5(tun.SenderAddr, refused, 15*time.Second)
+		var sErr *SOCKS5Error
+		if !errors.As(err, &sErr) {
+			t.Fatalf("socks5 dial refused: expected SOCKS5Error, got %T: %v", err, err)
+		}
+		if sErr.Rep != 0x05 {
+			t.Fatalf("socks5 REP for refused = %#x, want 0x05", sErr.Rep)
+		}
+	}
+
+	senderLogs := tun.Senders[0].Logs()
+	listenerLogs := waitForListenerCorrelations(t, tun.Listeners[0].Logs, 2, 10*time.Second)
+
+	dumpOnFail := func() {
+		t.Logf("--- sender logs ---\n%s", senderLogs)
+		t.Logf("--- listener logs ---\n%s", listenerLogs)
+	}
+
+	successID := bridgeIDForTarget(senderLogs, echo.Addr())
+	if successID == "" {
+		dumpOnFail()
+		t.Fatalf("no bridge_id in sender log for echo target %s", echo.Addr())
+	}
+	failureID := bridgeIDForTarget(senderLogs, refused)
+	if failureID == "" {
+		dumpOnFail()
+		t.Fatalf("no bridge_id in sender log for refused target %s", refused)
+	}
+	if successID == failureID {
+		dumpOnFail()
+		t.Fatalf("expected distinct bridge_ids per bridge, both = %q", successID)
+	}
+
+	if !listenerHasBridge(listenerLogs, "connection requested", successID, echo.Addr()) {
+		dumpOnFail()
+		t.Fatalf("listener missing 'connection requested' for bridge_id=%s target=%s",
+			successID, echo.Addr())
+	}
+	if !listenerHasBridge(listenerLogs, "dial target failed", failureID, refused) {
+		dumpOnFail()
+		t.Fatalf("listener missing 'dial target failed' for bridge_id=%s target=%s",
+			failureID, refused)
+	}
+}
+
+// requireLogs fails the scenario if either side of the tunnel has no
+// log capture wired up. This is the parity gate: an observability
+// scenario silently passing because the backend dropped the logs
+// would defeat the point of the test.
+func requireLogs(t *testing.T, tun *Tunnel) {
+	t.Helper()
+	for i, l := range tun.Listeners {
+		if l.Logs == nil {
+			t.Fatalf("backend Listener[%d].Logs is nil; observability scenarios require log capture", i)
+		}
+	}
+	for i, s := range tun.Senders {
+		if s.Logs == nil {
+			t.Fatalf("backend Sender[%d].Logs is nil; observability scenarios require log capture", i)
+		}
+	}
+}
+
+// bridgeIDForTarget scans logs for the first "connection requested"
+// line whose target field matches target and returns its bridge_id.
+// Empty string when no match. Anchoring on the deterministic
+// "connection requested" line avoids double-counting bridges that
+// emit multiple bridge_id-tagged lines (debug logs, bridge-end
+// logs, etc.).
+func bridgeIDForTarget(logs, target string) string {
+	for _, line := range strings.Split(logs, "\n") {
+		if !strings.Contains(line, `msg="connection requested"`) {
+			continue
+		}
+		if !strings.Contains(line, "target="+target) {
+			continue
+		}
+		m := bridgeIDRe.FindStringSubmatch(line)
+		if m != nil {
+			return m[1]
+		}
+	}
+	return ""
+}
+
+// listenerHasBridge reports whether the listener log stream contains
+// a line with the given message, bridge_id, and target — the exact
+// shape an operator's correlation grep would look for.
+func listenerHasBridge(logs, msg, bridgeID, target string) bool {
+	needleMsg := `msg="` + msg + `"`
+	needleID := "bridge_id=" + bridgeID
+	needleTarget := "target=" + target
+	for _, line := range strings.Split(logs, "\n") {
+		if strings.Contains(line, needleMsg) &&
+			strings.Contains(line, needleID) &&
+			strings.Contains(line, needleTarget) {
+			return true
+		}
+	}
+	return false
+}
+
+// waitForListenerCorrelations polls the listener log capture until at
+// least min lines carrying a bridge_id appear, bounded by timeout.
+// Returns the snapshot captured on success or at deadline. The poll
+// defends against the goroutine-scheduling window between sender
+// completion and the listener-side handler returning — slog itself
+// is synchronous, but the listener's handler runs in a goroutine
+// distinct from the sender's request path.
+func waitForListenerCorrelations(t *testing.T, snapshot func() string, min int, timeout time.Duration) string {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	var logs string
+	for time.Now().Before(deadline) {
+		logs = snapshot()
+		if len(bridgeIDRe.FindAllStringIndex(logs, -1)) >= min {
+			return logs
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	return logs
+}

--- a/mockrelay/testharness/parity/mock_backend.go
+++ b/mockrelay/testharness/parity/mock_backend.go
@@ -10,6 +10,7 @@
 package parity
 
 import (
+	"bytes"
 	"context"
 	"crypto/rand"
 	"crypto/tls"
@@ -79,17 +80,19 @@ func (*MockBackend) Setup(t testing.TB, opts relayparity.SetupOptions) *relaypar
 		KeyName: server.DefaultSASKeyName,
 		Key:     server.DefaultSASKey,
 	}
-	silentLogger := slog.New(slog.NewTextHandler(io.Discard, nil))
 
 	tun := &relayparity.Tunnel{}
 
 	// startListener brings up a single listener goroutine and returns
 	// its relayparity handle. Each listener owns a private metrics
 	// surface so Completed() / Active() report only that listener's
-	// bridges.
+	// bridges, and a private log buffer so Logs() returns only this
+	// listener's lines (cross-process correlation tests rely on the
+	// per-handle isolation).
 	startListener := func(t testing.TB) *relayparity.Listener {
 		t.Helper()
 		m := metrics.New()
+		logs := newCaptureBuffer()
 		lctx, lcancel := context.WithCancel(ctx)
 		done := make(chan struct{})
 
@@ -101,7 +104,7 @@ func (*MockBackend) Setup(t testing.TB, opts relayparity.SetupOptions) *relaypar
 			AllowList:      opts.AllowedTargets,
 			MaxConnections: opts.MaxConnections,
 			ConnectTimeout: opts.ConnectTimeout,
-			Logger:         silentLogger,
+			Logger:         slog.New(slog.NewTextHandler(logs, nil)),
 			Metrics:        m,
 		}
 
@@ -139,6 +142,7 @@ func (*MockBackend) Setup(t testing.TB, opts relayparity.SetupOptions) *relaypar
 			Completed: counterReader(m, "aztunnel_connections_total"),
 			Active:    gaugeReader(m, "aztunnel_active_connections"),
 			Stop:      stop,
+			Logs:      logs.String,
 		}
 	}
 
@@ -154,6 +158,8 @@ func (*MockBackend) Setup(t testing.TB, opts relayparity.SetupOptions) *relaypar
 	// MaxConnections.
 	startOneSender := func() *relayparity.Sender {
 		m := metrics.New()
+		logs := newCaptureBuffer()
+		senderLogger := slog.New(slog.NewTextHandler(logs, nil))
 		sctx, scancel := context.WithCancel(ctx)
 		done := make(chan struct{})
 		addrCh := make(chan net.Addr, 1)
@@ -178,7 +184,7 @@ func (*MockBackend) Setup(t testing.TB, opts relayparity.SetupOptions) *relaypar
 					ClientOptions: clientOpts,
 					Target:        opts.Target,
 					BindAddress:   "127.0.0.1:0",
-					Logger:        silentLogger,
+					Logger:        senderLogger,
 					Metrics:       m,
 					Ready:         ready,
 				})
@@ -189,7 +195,7 @@ func (*MockBackend) Setup(t testing.TB, opts relayparity.SetupOptions) *relaypar
 					TokenProvider: tokenProvider,
 					ClientOptions: clientOpts,
 					BindAddress:   "127.0.0.1:0",
-					Logger:        silentLogger,
+					Logger:        senderLogger,
 					Metrics:       m,
 					Ready:         ready,
 				})
@@ -221,6 +227,7 @@ func (*MockBackend) Setup(t testing.TB, opts relayparity.SetupOptions) *relaypar
 			Completed: counterReader(m, "aztunnel_connections_total"),
 			Active:    gaugeReader(m, "aztunnel_active_connections"),
 			Stop:      stop,
+			Logs:      logs.String,
 		}
 	}
 
@@ -364,4 +371,33 @@ func gaugeValue(m *metrics.Metrics, name string) float64 {
 		}
 	}
 	return 0
+}
+
+// captureBuffer is a goroutine-safe io.Writer used as the destination
+// for a slog TextHandler. slog.Handler implementations are themselves
+// goroutine-safe only when their underlying writer is — bytes.Buffer
+// is not — so observability parity scenarios that scrape the captured
+// output across multiple bridges need this mutex-guarded wrapper.
+type captureBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func newCaptureBuffer() *captureBuffer { return &captureBuffer{} }
+
+// Write appends p to the buffer under a mutex. The mutex is what
+// makes the wrapped slog handler safe for concurrent use across the
+// listener / sender goroutines that share this buffer.
+func (c *captureBuffer) Write(p []byte) (int, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.buf.Write(p)
+}
+
+// String returns the captured output as a single string. Safe to
+// call from any goroutine; a snapshot of the buffer at call time.
+func (c *captureBuffer) String() string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.buf.String()
 }

--- a/mockrelay/testharness/parity/parity_test.go
+++ b/mockrelay/testharness/parity/parity_test.go
@@ -17,5 +17,6 @@ func TestParity_Mock(t *testing.T) {
 		relayparity.RunCoreSuite(t, &b)
 		relayparity.RunTopologySuite(t, &b)
 		relayparity.RunReliabilitySuite(t, &b)
+		relayparity.RunObservabilitySuite(t, &b)
 	})
 }


### PR DESCRIPTION
## What

A sender-minted opaque `bridge_id` now flows through the connect envelope and is bound onto the listener's request-scoped logger, so a single grep — `bridge_id=ABCDEF…` — surfaces every log line for one connection across both the sender and listener processes.

## Why

Until now, matching a listener-side `dial target failed` log to its corresponding sender-side `forward failed` (or `socks5 failed`) was a manual exercise of cross-referencing timestamps and targets across two processes. With per-test isolation now landed, dozens of bridges can be in flight at once and timestamp correlation breaks down. One copy-paste-friendly correlation ID solves that.

## Operator-visible improvement

Every per-bridge log line on both processes now carries the same `bridge_id` attribute:

```
sender:   level=INFO msg="connection requested" bridge_id=GZK7Q3FV5AYHWX2P target=10.0.0.5:22
sender:   level=WARN msg="socks5 failed" bridge_id=GZK7Q3FV5AYHWX2P error="connection rejected (connection_refused): connection failed"
listener: level=INFO msg="connection requested" bridge_id=GZK7Q3FV5AYHWX2P target=10.0.0.5:22
listener: level=WARN msg="dial target failed" bridge_id=GZK7Q3FV5AYHWX2P target=10.0.0.5:22 error="dial tcp 10.0.0.5:22: connect: connection refused"
```

`grep bridge_id=GZK7Q3FV5AYHWX2P` across the two log streams yields the full timeline for that one bridge.

## Compatibility

The envelope field is `omitempty`. Older listeners ignore the unknown field silently. Newer listeners receiving an envelope from a pre-P5 sender see `bridge_id=""` — explicit evidence of a mixed-version flow rather than a silently absent attribute. No fallback is minted listener-side, by design.

## Test coverage

A new cross-backend parity scenario, `BridgeID_Correlation`, drives both a successful bridge and a refused-target bridge through a SOCKS5 sender and asserts that the sender-side and listener-side log lines carry the matching `bridge_id` values. The scenario runs on both the mockrelay backend and the Azure backend, so any divergence between the two surfaces as a failing scenario.

Unit coverage:
- JSON round-trip with and without `bridge_id` (verifies `omitempty`).
- `idgen.NewBridgeID` format (16-char base32 `[A-Z2-7]`) and a 10k no-collision check.
- The sender's envelope-sending path verifies the field is populated on the wire.