### PR TITLE
feat(obs): classify DNS failures in listener dial

### DIFF
--- a/e2e/azure_backend_test.go
+++ b/e2e/azure_backend_test.go
@@ -92,11 +92,12 @@ func (b *azureBackend) Setup(t testing.TB, opts relayparity.SetupOptions) *relay
 		waitForLog(t, lst, "control channel connected", 30*time.Second)
 		metricsAddr := lst.MetricsAddr(t, 15*time.Second)
 		return &relayparity.Listener{
-			Addr:      metricsAddr,
-			Completed: scrapeCounter(metricsAddr, "aztunnel_connections_total"),
-			Active:    scrapeGauge(metricsAddr, "aztunnel_active_connections"),
-			Stop:      func() { lst.Stop(t) },
-			Logs:      func() string { return lst.logs.String() },
+			Addr:             metricsAddr,
+			Completed:        scrapeCounter(metricsAddr, "aztunnel_connections_total"),
+			Active:           scrapeGauge(metricsAddr, "aztunnel_active_connections"),
+			ConnectionErrors: scrapeConnectionErrors(metricsAddr),
+			Stop:             func() { lst.Stop(t) },
+			Logs:             func() string { return lst.logs.String() },
 		}
 	}
 
@@ -168,5 +169,18 @@ func scrapeGauge(addr, name string) func() int64 {
 	return func() int64 {
 		text := scrapeMetricsBest(addr)
 		return int64(sumMetric(text, name))
+	}
+}
+
+// scrapeConnectionErrors returns a closure that scrapes /metrics on
+// addr and returns the sum of aztunnel_connection_errors_total samples
+// whose `reason` label equals the requested reason. Used by negative-
+// path parity scenarios that assert the listener classified a dial
+// failure into a specific reason bucket.
+func scrapeConnectionErrors(addr string) func(reason string) int64 {
+	return func(reason string) int64 {
+		text := scrapeMetricsBest(addr)
+		return int64(sumMetricByLabel(text,
+			"aztunnel_connection_errors_total", "reason", reason))
 	}
 }

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -1627,3 +1627,33 @@ func sumMetric(text, name string) float64 {
 	}
 	return total
 }
+
+// sumMetricByLabel sums sample values for metric `name` whose labels
+// include the requested labelName=labelValue pair. Label order in the
+// scraped /metrics output is not stable across Prometheus versions, so
+// the match is a substring check against the well-formed `name="value"`
+// form rather than a position-sensitive parse.
+func sumMetricByLabel(text, name, labelName, labelValue string) float64 {
+	var total float64
+	needle := labelName + `="` + labelValue + `"`
+	scanner := bufio.NewScanner(strings.NewReader(text))
+	for scanner.Scan() {
+		line := scanner.Text()
+		if strings.HasPrefix(line, "#") {
+			continue
+		}
+		if !strings.HasPrefix(line, name+"{") {
+			continue
+		}
+		if !strings.Contains(line, needle) {
+			continue
+		}
+		parts := strings.Fields(line)
+		if len(parts) >= 2 {
+			var v float64
+			fmt.Sscanf(parts[len(parts)-1], "%f", &v)
+			total += v
+		}
+	}
+	return total
+}

--- a/internal/listener/listener.go
+++ b/internal/listener/listener.go
@@ -171,16 +171,30 @@ func sendResponseWithCode(ctx context.Context, ws *websocket.Conn, ok bool, errM
 // constants. Empty string when no classification applies — the sender
 // treats that the same as "generic failure".
 //
-// The order matters: timeouts (both context.DeadlineExceeded and the
-// net.Error Timeout() form for OS-level connect timeouts) are checked
-// first because the underlying syscall errno can vary by platform on
-// timeouts; classifying by surface error type is more portable.
+// The order matters:
+//
+//   - context.DeadlineExceeded wins so an operator-cancelled dial keeps
+//     CodeTimeout regardless of which layer the error originated in.
+//   - *net.DNSError is checked before the generic netErr.Timeout()
+//     branch because *net.DNSError satisfies net.Error and its
+//     Timeout() returns IsTimeout; without this ordering a DNS timeout
+//     would be misclassified as the generic CodeTimeout.
+//   - Other timeouts (OS-level connect timeouts) are classified by
+//     surface error type rather than by errno, because the underlying
+//     syscall errno can vary by platform on timeouts.
 func classifyDialError(err error) string {
 	if err == nil {
 		return ""
 	}
 	if errors.Is(err, context.DeadlineExceeded) {
 		return protocol.CodeTimeout
+	}
+	var dnsErr *net.DNSError
+	if errors.As(err, &dnsErr) {
+		if dnsErr.IsTimeout {
+			return protocol.CodeDNSTimeout
+		}
+		return protocol.CodeDNSNotFound
 	}
 	var netErr net.Error
 	if errors.As(err, &netErr) && netErr.Timeout() {

--- a/internal/listener/listener_test.go
+++ b/internal/listener/listener_test.go
@@ -1,6 +1,14 @@
 package listener
 
-import "testing"
+import (
+	"context"
+	"errors"
+	"net"
+	"syscall"
+	"testing"
+
+	"github.com/philsphicas/aztunnel/internal/protocol"
+)
 
 func TestIsAllowed(t *testing.T) {
 	tests := []struct {
@@ -54,6 +62,81 @@ func TestSplitAllowEntry(t *testing.T) {
 			}
 			if p != tt.wantPort {
 				t.Errorf("port = %q, want %q", p, tt.wantPort)
+			}
+		})
+	}
+}
+
+func TestClassifyDialError_Nil(t *testing.T) {
+	if got := classifyDialError(nil); got != "" {
+		t.Errorf("classifyDialError(nil) = %q, want %q", got, "")
+	}
+}
+
+func TestClassifyDialError_DNSNotFound(t *testing.T) {
+	err := &net.DNSError{Err: "no such host", Name: "nonexistent.invalid", IsNotFound: true}
+	if got := classifyDialError(err); got != protocol.CodeDNSNotFound {
+		t.Errorf("classifyDialError(DNSError{IsNotFound}) = %q, want %q", got, protocol.CodeDNSNotFound)
+	}
+}
+
+func TestClassifyDialError_DNSTimeout(t *testing.T) {
+	err := &net.DNSError{Err: "i/o timeout", Name: "slow.example", IsTimeout: true}
+	if got := classifyDialError(err); got != protocol.CodeDNSTimeout {
+		t.Errorf("classifyDialError(DNSError{IsTimeout}) = %q, want %q", got, protocol.CodeDNSTimeout)
+	}
+}
+
+func TestClassifyDialError_DNSTemporary(t *testing.T) {
+	// Non-timeout, non-not-found DNS errors (e.g. SERVFAIL) fall through
+	// to CodeDNSNotFound under the current spec. This documents that
+	// behaviour so a future refinement (e.g. a separate dns_failed code)
+	// is a deliberate change rather than an accidental one.
+	err := &net.DNSError{Err: "server misbehaving", Name: "example.invalid"}
+	if got := classifyDialError(err); got != protocol.CodeDNSNotFound {
+		t.Errorf("classifyDialError(DNSError{plain}) = %q, want %q", got, protocol.CodeDNSNotFound)
+	}
+}
+
+func TestClassifyDialError_DNSWrappedInOpError(t *testing.T) {
+	// net.Dialer wraps DNS failures inside *net.OpError; classifyDialError
+	// must unwrap via errors.As to find the underlying *net.DNSError.
+	dnsErr := &net.DNSError{Err: "no such host", Name: "nonexistent.invalid", IsNotFound: true}
+	wrapped := &net.OpError{Op: "dial", Net: "tcp", Err: dnsErr}
+	if got := classifyDialError(wrapped); got != protocol.CodeDNSNotFound {
+		t.Errorf("classifyDialError(OpError wrapping DNSError) = %q, want %q", got, protocol.CodeDNSNotFound)
+	}
+}
+
+func TestClassifyDialError_ContextDeadlineBeatsDNSTimeout(t *testing.T) {
+	// When the dial error is both a DNS timeout AND ctx.DeadlineExceeded,
+	// the context-deadline branch must win: the operator deliberately
+	// cancelled, so CodeTimeout reflects that intent better than the
+	// underlying DNS-layer detail.
+	dnsErr := &net.DNSError{Err: "i/o timeout", Name: "slow.example", IsTimeout: true}
+	combined := errors.Join(context.DeadlineExceeded, dnsErr)
+	if got := classifyDialError(combined); got != protocol.CodeTimeout {
+		t.Errorf("classifyDialError(Join(DeadlineExceeded, DNS timeout)) = %q, want %q",
+			got, protocol.CodeTimeout)
+	}
+}
+
+func TestClassifyDialError_OtherErrors(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want string
+	}{
+		{"refused", &net.OpError{Op: "dial", Err: syscall.ECONNREFUSED}, protocol.CodeConnectionRefused},
+		{"host unreachable", &net.OpError{Op: "dial", Err: syscall.EHOSTUNREACH}, protocol.CodeHostUnreachable},
+		{"net unreachable", &net.OpError{Op: "dial", Err: syscall.ENETUNREACH}, protocol.CodeNetworkUnreachable},
+		{"context deadline", context.DeadlineExceeded, protocol.CodeTimeout},
+		{"unclassified", errors.New("something broke"), ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := classifyDialError(tt.err); got != tt.want {
+				t.Errorf("classifyDialError(%v) = %q, want %q", tt.err, got, tt.want)
 			}
 		})
 	}

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -29,6 +29,16 @@ const (
 	ReasonAuthFailed        = "auth_failed"
 	ReasonEnvelopeError     = "envelope_error"
 	ReasonAllowlistRejected = "allowlist_rejected"
+	// ReasonDNSNotFound is the reason label for dial failures caused by
+	// name resolution returning no result (typically NXDOMAIN or NODATA).
+	// Distinct from ReasonDialFailed so operators can see DNS-misconfig
+	// failures separately from network-layer failures.
+	ReasonDNSNotFound = "dns_not_found"
+	// ReasonDNSTimeout is the reason label for dial failures caused by
+	// DNS resolution exceeding the resolver's deadline. Distinct from
+	// ReasonDialTimeout because the failure happened before any SYN was
+	// sent; the underlying network may be fine.
+	ReasonDNSTimeout = "dns_timeout"
 )
 
 // Metrics holds all Prometheus metrics for aztunnel.
@@ -182,12 +192,34 @@ func (m *Metrics) ConnectionError(role, reason string) {
 	m.connectionErrors.WithLabelValues(role, reason).Inc()
 }
 
-// DialReason returns "dial_timeout" if err is a network timeout, otherwise
-// returns fallback. Use this to distinguish timeout errors from other dial
-// failures in metrics.
+// DialReason maps a dial error to a metric reason label. It returns
+// ReasonDialTimeout for network timeouts, ReasonDNSTimeout for DNS
+// resolver timeouts, ReasonDNSNotFound for non-timeout DNS failures, or
+// fallback for any other error.
+//
+// The DNS-error classification is scoped to listener target dials by
+// gating on `fallback == ReasonDialFailed`. Sender callers pass
+// ReasonRelayFailed and skip the DNS branch entirely; their DNS errors
+// fall through to the timeout / fallback paths below.
+//
+// Ordering mirrors classifyDialError in internal/listener: ctx-deadline
+// is checked first so operator-cancelled dials keep the timeout
+// classification; *net.DNSError is checked before the generic
+// netErr.Timeout() branch because DNS timeouts also satisfy
+// net.Error.Timeout() and would otherwise be misclassified as
+// ReasonDialTimeout.
 func DialReason(err error, fallback string) string {
 	if errors.Is(err, context.DeadlineExceeded) {
 		return ReasonDialTimeout
+	}
+	if fallback == ReasonDialFailed {
+		var dnsErr *net.DNSError
+		if errors.As(err, &dnsErr) {
+			if dnsErr.IsTimeout {
+				return ReasonDNSTimeout
+			}
+			return ReasonDNSNotFound
+		}
 	}
 	var netErr net.Error
 	if errors.As(err, &netErr) && netErr.Timeout() {

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -2,6 +2,7 @@ package metrics
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -149,6 +150,62 @@ func TestDialReason(t *testing.T) {
 	wrappedDeadline := fmt.Errorf("dial: %w", context.DeadlineExceeded)
 	if r := DialReason(wrappedDeadline, "relay_failed"); r != ReasonDialTimeout {
 		t.Errorf("DialReason(wrapped DeadlineExceeded) = %q, want %q", r, ReasonDialTimeout)
+	}
+}
+
+func TestDialReason_DNSNotFound(t *testing.T) {
+	// Bare *net.DNSError without IsTimeout maps to ReasonDNSNotFound,
+	// matching classifyDialError's behaviour so the metric reason and
+	// the protocol code line up for the common NXDOMAIN case.
+	dnsErr := &net.DNSError{Err: "no such host", Name: "nonexistent.invalid", IsNotFound: true}
+	if r := DialReason(dnsErr, ReasonDialFailed); r != ReasonDNSNotFound {
+		t.Errorf("DialReason(DNSError{IsNotFound}) = %q, want %q", r, ReasonDNSNotFound)
+	}
+
+	// Wrapped in *net.OpError (the form net.Dialer actually returns).
+	wrapped := &net.OpError{Op: "dial", Net: "tcp", Err: dnsErr}
+	if r := DialReason(wrapped, ReasonDialFailed); r != ReasonDNSNotFound {
+		t.Errorf("DialReason(OpError wrapping DNSError) = %q, want %q", r, ReasonDNSNotFound)
+	}
+}
+
+func TestDialReason_DNSTimeout(t *testing.T) {
+	// DNS-layer timeout takes precedence over the generic dial_timeout
+	// reason — *net.DNSError satisfies net.Error.Timeout(), so without
+	// the explicit DNS branch in DialReason this would be classified
+	// as ReasonDialTimeout.
+	dnsErr := &net.DNSError{Err: "i/o timeout", Name: "slow.example", IsTimeout: true}
+	if r := DialReason(dnsErr, ReasonDialFailed); r != ReasonDNSTimeout {
+		t.Errorf("DialReason(DNSError{IsTimeout}) = %q, want %q", r, ReasonDNSTimeout)
+	}
+
+	// context.DeadlineExceeded still wins over a DNS-layer timeout when
+	// both are present in the chain — mirrors classifyDialError.
+	combined := errors.Join(context.DeadlineExceeded, dnsErr)
+	if r := DialReason(combined, ReasonDialFailed); r != ReasonDialTimeout {
+		t.Errorf("DialReason(Join(DeadlineExceeded, DNS timeout)) = %q, want %q",
+			r, ReasonDialTimeout)
+	}
+}
+
+func TestDialReason_DNSClassificationGatedByFallback(t *testing.T) {
+	// DNS classification is scoped to listener target dials
+	// (fallback == ReasonDialFailed). With ReasonRelayFailed the DNS
+	// branch is skipped and DialReason returns the fallback.
+	dnsErr := &net.DNSError{Err: "no such host", Name: "nonexistent.invalid", IsNotFound: true}
+	if r := DialReason(dnsErr, ReasonRelayFailed); r != ReasonRelayFailed {
+		t.Errorf("DialReason(DNSError, ReasonRelayFailed) = %q, want %q (DNS classification must not leak to sender callers)",
+			r, ReasonRelayFailed)
+	}
+
+	// DNS timeouts with ReasonRelayFailed bypass the gated DNS branch
+	// and fall through to the generic netErr.Timeout() check:
+	// *net.DNSError satisfies net.Error and Timeout() returns IsTimeout,
+	// so the result is ReasonDialTimeout.
+	dnsTimeout := &net.DNSError{Err: "i/o timeout", Name: "slow.example", IsTimeout: true}
+	if r := DialReason(dnsTimeout, ReasonRelayFailed); r != ReasonDialTimeout {
+		t.Errorf("DialReason(DNSError{IsTimeout}, ReasonRelayFailed) = %q, want %q",
+			r, ReasonDialTimeout)
 	}
 }
 

--- a/internal/protocol/envelope.go
+++ b/internal/protocol/envelope.go
@@ -73,4 +73,14 @@ const (
 	// listener's configured connect timeout (no SYN-ACK from the
 	// target, typical of black-holed addresses).
 	CodeTimeout = "timeout"
+
+	// CodeDNSNotFound indicates the listener could not resolve the target
+	// hostname (typically NXDOMAIN or NODATA). Distinct from CodeHostUnreachable
+	// because the failure is at the name-resolution layer, not the network.
+	CodeDNSNotFound = "dns_not_found"
+
+	// CodeDNSTimeout indicates DNS resolution exceeded the resolver's deadline.
+	// Distinct from CodeTimeout because the failure happened before any SYN was
+	// sent; the underlying network may be fine.
+	CodeDNSTimeout = "dns_timeout"
 )

--- a/internal/testharness/relayparity/backend.go
+++ b/internal/testharness/relayparity/backend.go
@@ -102,8 +102,8 @@ type SetupOptions struct {
 // Listener is a handle to a single listener in a Tunnel. Backends
 // populate Tunnel.Listeners with one entry per running listener.
 //
-// All accessor closures (Completed, Active) are safe to call
-// concurrently and return monotonically-updating values without
+// All accessor closures (Completed, Active, ConnectionErrors) are safe
+// to call concurrently and return monotonically-updating values without
 // blocking on the listener.
 type Listener struct {
 	// Addr is the listener's metrics-scrape address for subprocess
@@ -124,6 +124,17 @@ type Listener struct {
 	// this listener (aztunnel_active_connections summed across all
 	// label combinations).
 	Active func() int64
+
+	// ConnectionErrors returns the value of
+	// aztunnel_connection_errors_total filtered to samples whose
+	// reason label equals the given reason, summed across any other
+	// label combinations (e.g. role) on this listener's metrics
+	// surface. Used by negative-path scenarios to assert the listener
+	// classified a dial failure into the expected reason bucket.
+	//
+	// Returns 0 when the metric has no samples for that reason yet
+	// (counters are not initialized until the first observation).
+	ConnectionErrors func(reason string) int64
 
 	// Stop drops this listener: in-process backends cancel the
 	// listener's context and wait for the goroutine to exit;

--- a/internal/testharness/relayparity/reliability.go
+++ b/internal/testharness/relayparity/reliability.go
@@ -31,6 +31,7 @@ func RunReliabilitySuite(t *testing.T, b Backend) {
 	}{
 		{"ErrorPropagation_TargetRefused", ScenarioErrorPropagation_TargetRefused},
 		{"ErrorPropagation_TargetUnreachable", ScenarioErrorPropagation_TargetUnreachable},
+		{"ErrorPropagation_TargetDNSFailure", ScenarioErrorPropagation_TargetDNSFailure},
 		{"ErrorPropagation_TargetHangs", ScenarioErrorPropagation_TargetHangs},
 		{"SlowConsumer_BackPressure", ScenarioSlowConsumer_BackPressure},
 		{"HalfClose_RequestResponse", ScenarioHalfClose_RequestResponse},
@@ -386,6 +387,69 @@ sampling:
 		t.Errorf("writer pushed %d bytes during %v window; expected >= 1 KiB",
 			writtenMid, slowConsumerTestDuration)
 	}
+}
+
+// dnsFailureTarget is the host:port the DNS-failure scenario asks the
+// listener to dial. The hostname uses the RFC 6761 reserved ".invalid"
+// TLD with a trailing dot so resolver search-domain expansion cannot
+// turn it into a real lookup. Every conformant resolver should answer
+// NXDOMAIN, surfacing as *net.DNSError{IsNotFound:true} inside
+// dialer.DialContext.
+const dnsFailureTarget = "nonexistent.invalid.:80"
+
+// ScenarioErrorPropagation_TargetDNSFailure asserts that when the
+// listener fails to resolve the target hostname, the failure is
+// classified as a DNS error in the listener metrics rather than as a
+// generic dial failure or a network-layer timeout. This is the
+// operator-visible signal that lets dashboards and alerts separate
+// "DNS misconfigured" from "target unreachable on the network".
+//
+// The scenario uses SOCKS5 so the client receives a clean SOCKS5-reply
+// failure (current sender maps unknown protocol codes to
+// RepHostUnreachable, so the REP byte itself is not asserted; the
+// metric reason label is the contract under test). The listener's
+// connection_errors_total{reason="dns_not_found"} counter is polled
+// via the Listener.ConnectionErrors accessor, which both backends
+// implement — in-process Registry.Gather for the mock backend and
+// /metrics scrape for the Azure backend.
+func ScenarioErrorPropagation_TargetDNSFailure(t *testing.T, b Backend) {
+	t.Helper()
+	AssertNoLeaks(t)
+
+	tun := b.Setup(t, SetupOptions{
+		NumListeners:   1,
+		SenderMode:     ModeSOCKS5,
+		AllowedTargets: []string{dnsFailureTarget},
+		ConnectTimeout: 5 * time.Second,
+	})
+
+	_, err := DialSOCKS5(tun.SenderAddr, dnsFailureTarget, 15*time.Second)
+	if err == nil {
+		t.Fatalf("expected SOCKS5 dial to DNS-NXDOMAIN target to fail")
+	}
+	var sErr *SOCKS5Error
+	if !errors.As(err, &sErr) {
+		// A SOCKS5-level reply is the expected outcome; anything else
+		// (e.g. a dial-proxy IO error) would mean the listener never
+		// got far enough to even attempt the dial, which would mask
+		// the metric we're trying to assert.
+		t.Fatalf("expected SOCKS5Error from DNS-failed dial, got %T: %v", err, err)
+	}
+
+	if tun.Listeners[0].ConnectionErrors == nil {
+		t.Skip("backend does not expose ConnectionErrors on Listener")
+	}
+	deadline := time.Now().Add(15 * time.Second)
+	var seen int64
+	for time.Now().Before(deadline) {
+		seen = tun.Listeners[0].ConnectionErrors("dns_not_found")
+		if seen > 0 {
+			return
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	t.Fatalf("listener connection_errors_total{reason=dns_not_found} did not increment within 15s after a SOCKS5 dial to %s (last value %d)",
+		dnsFailureTarget, seen)
 }
 
 // ScenarioHalfClose_RequestResponse is the acceptance-contract test

--- a/mockrelay/testharness/parity/mock_backend.go
+++ b/mockrelay/testharness/parity/mock_backend.go
@@ -31,6 +31,7 @@ import (
 	"github.com/philsphicas/aztunnel/internal/sender"
 	"github.com/philsphicas/aztunnel/internal/testharness/relayparity"
 	"github.com/philsphicas/aztunnel/mockrelay/server"
+	dto "github.com/prometheus/client_model/go"
 )
 
 // MockBackend implements relayparity.Backend by standing up a mock
@@ -138,11 +139,12 @@ func (*MockBackend) Setup(t testing.TB, opts relayparity.SetupOptions) *relaypar
 		}
 
 		return &relayparity.Listener{
-			Addr:      "",
-			Completed: counterReader(m, "aztunnel_connections_total"),
-			Active:    gaugeReader(m, "aztunnel_active_connections"),
-			Stop:      stop,
-			Logs:      logs.String,
+			Addr:             "",
+			Completed:        counterReader(m, "aztunnel_connections_total"),
+			Active:           gaugeReader(m, "aztunnel_active_connections"),
+			ConnectionErrors: connectionErrorReader(m),
+			Stop:             stop,
+			Logs:             logs.String,
 		}
 	}
 
@@ -350,6 +352,48 @@ func gaugeReader(m *metrics.Metrics, name string) func() int64 {
 		}
 		return int64(total)
 	}
+}
+
+// connectionErrorReader returns a closure that sums every sample of
+// aztunnel_connection_errors_total whose reason label equals the
+// requested reason, on m's registry. Each per-listener metrics surface
+// only sees its own connection errors, so summing across the other
+// labels (role) is safe.
+//
+// Returns 0 when the counter has no samples for that reason — Prometheus
+// counters are not initialized until the first observation.
+func connectionErrorReader(m *metrics.Metrics) func(reason string) int64 {
+	return func(reason string) int64 {
+		families, err := m.Registry.Gather()
+		if err != nil {
+			return 0
+		}
+		var total float64
+		for _, f := range families {
+			if f.GetName() != "aztunnel_connection_errors_total" {
+				continue
+			}
+			for _, sample := range f.GetMetric() {
+				if !labelMatches(sample.GetLabel(), "reason", reason) {
+					continue
+				}
+				if c := sample.GetCounter(); c != nil {
+					total += c.GetValue()
+				}
+			}
+		}
+		return int64(total)
+	}
+}
+
+// labelMatches reports whether any of pairs has the given name and value.
+func labelMatches(pairs []*dto.LabelPair, name, value string) bool {
+	for _, lp := range pairs {
+		if lp.GetName() == name && lp.GetValue() == value {
+			return true
+		}
+	}
+	return false
 }
 
 // gaugeValue returns the single-sample value of a gauge by name. Used


### PR DESCRIPTION
## Summary

The relay-listener now emits structured signal when target dials fail at the DNS layer rather than burying it in raw error text. Operators can distinguish "the hostname doesn't resolve" from "the network is unreachable" in metrics and in the protocol-level connect-response.

## Operator-visible behaviour

Two new failure classes flow from the listener:

- `dns_not_found` — the target hostname returned no result (NXDOMAIN/NODATA, or any non-timeout `*net.DNSError`).
- `dns_timeout` — DNS resolution exceeded the resolver's deadline.

These appear in:

- `aztunnel_connection_errors_total{role="listener",reason="dns_not_found"}`
- `aztunnel_connection_errors_total{role="listener",reason="dns_timeout"}`
- `ConnectResponse.Code` in the protocol envelope, as `dns_not_found` / `dns_timeout`.

Sender-side metrics are intentionally unchanged — sender relay-endpoint DNS failures keep their historical `relay_failed` reason so existing operator dashboards do not silently re-bucket.

## Precedence

Classification order in both `classifyDialError` and `DialReason`:

1. `context.DeadlineExceeded` — operator-cancelled, keep the generic timeout classification.
2. `*net.DNSError` — DNS-layer detail wins over the generic timeout branch (DNS timeouts also satisfy `net.Error.Timeout()`).
3. Generic `net.Error.Timeout()` — OS-level connect timeouts.
4. POSIX errno checks for `ECONNREFUSED` / `EHOSTUNREACH` / `ENETUNREACH`.

## Tests

- Unit coverage for `classifyDialError` and `DialReason` across bare DNS errors, `*net.OpError`-wrapped DNS errors, context-deadline precedence, and the listener-vs-sender fallback gate.
- New cross-backend parity scenario `ErrorPropagation_TargetDNSFailure` (mockrelay + Azure) dials `nonexistent.invalid.:80` via SOCKS5 and asserts the listener's `connection_errors_total{reason="dns_not_found"}` increments. Wired via a new additive `Listener.ConnectionErrors(reason)` accessor on the parity backend interface.
