### PR TITLE
feat(obs): tag control-channel log lines with control_session_id

### DIFF
--- a/internal/idgen/idgen.go
+++ b/internal/idgen/idgen.go
@@ -28,6 +28,26 @@ const bridgeIDBytes = 10
 // pollute the public API for a failure mode callers cannot recover
 // from.
 func NewBridgeID() string {
+	return newID()
+}
+
+// NewControlSessionID returns a fresh, opaque correlation ID for a
+// single run of the relay control loop. Callers bind the result onto
+// their slog logger with `logger.With("control_session_id", id)` so
+// every log line emitted during the session carries the tag — when
+// the control channel dies and a fresh loop starts, the next call
+// mints a new id, letting operators mechanically split before-and-
+// after log streams. Panics on OS RNG failure (see NewBridgeID).
+func NewControlSessionID() string {
+	return newID()
+}
+
+// newID mints one 16-character base32-NoPadding identifier from
+// bridgeIDBytes bytes of crypto/rand. All public id constructors
+// share this impl because every observability id in aztunnel uses
+// the same shape — different exported names exist only so call
+// sites read at the right level of intent.
+func newID() string {
 	var b [bridgeIDBytes]byte
 	if _, err := io.ReadFull(rand.Reader, b[:]); err != nil {
 		panic(fmt.Errorf("idgen: read crypto/rand: %w", err))

--- a/internal/idgen/idgen_test.go
+++ b/internal/idgen/idgen_test.go
@@ -52,3 +52,50 @@ func TestNewBridgeID_NotEmpty(t *testing.T) {
 		t.Fatalf("NewBridgeID() returned empty string")
 	}
 }
+
+// TestNewControlSessionID_Format mirrors TestNewBridgeID_Format for
+// the per-control-loop id. The format is a public contract because
+// log scrapers grep for control_session_id=<value> across listener
+// stderr; any drift here breaks operator queries.
+func TestNewControlSessionID_Format(t *testing.T) {
+	const want = 16
+	for i := 0; i < 32; i++ {
+		id := NewControlSessionID()
+		if len(id) != want {
+			t.Fatalf("NewControlSessionID() len = %d, want %d (id=%q)", len(id), want, id)
+		}
+		for j, c := range id {
+			ok := (c >= 'A' && c <= 'Z') || (c >= '2' && c <= '7')
+			if !ok {
+				t.Fatalf("NewControlSessionID() id=%q: invalid char %q at %d", id, c, j)
+			}
+		}
+	}
+}
+
+// TestNewControlSessionID_NoCollisions defends the 80-bit entropy
+// claim for control-session ids. Each control-channel reconnect
+// mints a fresh id, so collisions here would silently merge log
+// streams that operators rely on being distinct.
+func TestNewControlSessionID_NoCollisions(t *testing.T) {
+	const n = 10_000
+	seen := make(map[string]struct{}, n)
+	for i := 0; i < n; i++ {
+		id := NewControlSessionID()
+		if _, dup := seen[id]; dup {
+			t.Fatalf("collision after %d IDs: %q", i+1, id)
+		}
+		seen[id] = struct{}{}
+	}
+}
+
+// TestControlSessionID_DistinctFromBridgeID asserts the two
+// constructors mint independent values even though they share an
+// internal helper. A regression that collapsed them onto one source
+// (e.g. a memoised global) would defeat correlation by introducing
+// matching ids across unrelated log scopes.
+func TestControlSessionID_DistinctFromBridgeID(t *testing.T) {
+	if NewBridgeID() == NewControlSessionID() {
+		t.Fatalf("expected distinct ids from independent constructors")
+	}
+}

--- a/internal/relay/control.go
+++ b/internal/relay/control.go
@@ -10,6 +10,8 @@ import (
 	"time"
 
 	"github.com/coder/websocket"
+
+	"github.com/philsphicas/aztunnel/internal/idgen"
 )
 
 const (
@@ -87,6 +89,21 @@ func ListenAndServe(ctx context.Context, cfg ControlConfig) error {
 }
 
 func runControlLoop(ctx context.Context, cfg ControlConfig) (connected bool, err error) {
+	// Bind a fresh control_session_id onto the per-session logger
+	// before any work that could log: token fetch, dial, and the
+	// per-loop helpers (renewLoop, pingLoop) all log against this
+	// logger so operators can mechanically separate the lines from
+	// one control-loop run from the lines of the next.
+	//
+	// The outer reconnect loop in ListenAndServe keeps using
+	// cfg.Logger directly, so its "control channel disconnected,
+	// reconnecting" line stays out of any session — that line marks
+	// the boundary between sessions and is intentionally untagged.
+	sessionID := idgen.NewControlSessionID()
+	logger := cfg.Logger.With("control_session_id", sessionID)
+	logger.Info("control loop started")
+	defer logger.Info("control loop ended")
+
 	resURI := ResourceURI(cfg.Endpoint, cfg.EntityPath)
 	token, err := cfg.TokenProvider.GetToken(ctx, resURI)
 	if err != nil {
@@ -105,7 +122,7 @@ func runControlLoop(ctx context.Context, cfg ControlConfig) (connected bool, err
 	}
 	defer func() { _ = ws.CloseNow() }()
 
-	cfg.Logger.Info("control channel connected", "entityPath", cfg.EntityPath)
+	logger.Info("control channel connected", "entityPath", cfg.EntityPath)
 	if cfg.OnConnect != nil {
 		cfg.OnConnect()
 	}
@@ -123,14 +140,14 @@ func runControlLoop(ctx context.Context, cfg ControlConfig) (connected bool, err
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		renewLoop(loopCtx, ws, resURI, cfg.TokenProvider, cfg.Logger, loopCancel)
+		renewLoop(loopCtx, ws, resURI, cfg.TokenProvider, logger, loopCancel)
 	}()
 
 	// Ping heartbeat goroutine.
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		pingLoop(loopCtx, ws, cfg.Logger, loopCancel)
+		pingLoop(loopCtx, ws, logger, loopCancel)
 	}()
 
 	// Read accept messages from the control channel.
@@ -148,7 +165,7 @@ func runControlLoop(ctx context.Context, cfg ControlConfig) (connected bool, err
 			} `json:"accept"`
 		}
 		if err := json.Unmarshal(data, &msg); err != nil {
-			cfg.Logger.Warn("invalid control message", "error", err)
+			logger.Warn("invalid control message", "error", err)
 			continue
 		}
 		if msg.Accept == nil {
@@ -156,7 +173,7 @@ func runControlLoop(ctx context.Context, cfg ControlConfig) (connected bool, err
 		}
 
 		if !sem.tryAcquire(loopCtx) {
-			cfg.Logger.Warn("max connections reached, dropping accept")
+			logger.Warn("max connections reached, dropping accept")
 			continue
 		}
 
@@ -165,7 +182,7 @@ func runControlLoop(ctx context.Context, cfg ControlConfig) (connected bool, err
 			defer wg.Done()
 			defer sem.release()
 			if err := handleAccept(loopCtx, addr, cfg); err != nil {
-				cfg.Logger.Warn("accept failed", "error", err)
+				logger.Warn("accept failed", "error", err)
 			}
 		}(msg.Accept.Address)
 	}

--- a/internal/relay/control_test.go
+++ b/internal/relay/control_test.go
@@ -918,3 +918,204 @@ func TestListenAndServe(t *testing.T) {
 		}
 	})
 }
+
+// ---------- TestControlSessionID ----------
+
+// captureLogger returns a slog logger that writes JSON records to the
+// returned recorder. Records are returned in the order they were
+// emitted; the recorder is safe for concurrent writers.
+type logRecorder struct {
+	mu  sync.Mutex
+	buf []byte
+}
+
+func (r *logRecorder) Write(p []byte) (int, error) {
+	r.mu.Lock()
+	r.buf = append(r.buf, p...)
+	r.mu.Unlock()
+	return len(p), nil
+}
+
+func (r *logRecorder) records(t *testing.T) []map[string]any {
+	t.Helper()
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	lines := strings.Split(strings.TrimRight(string(r.buf), "\n"), "\n")
+	out := make([]map[string]any, 0, len(lines))
+	for _, line := range lines {
+		if line == "" {
+			continue
+		}
+		var rec map[string]any
+		if err := json.Unmarshal([]byte(line), &rec); err != nil {
+			t.Fatalf("non-JSON log line: %q: %v", line, err)
+		}
+		out = append(out, rec)
+	}
+	return out
+}
+
+func captureLogger() (*slog.Logger, *logRecorder) {
+	rec := &logRecorder{}
+	return slog.New(slog.NewJSONHandler(rec, &slog.HandlerOptions{Level: slog.LevelDebug})), rec
+}
+
+// drivenControlLoop spins up a TLS test relay that accepts one
+// rendezvous request then closes the control WebSocket, and runs
+// runControlLoop with the supplied logger. The caller wires a
+// logRecorder behind the logger to capture every log line emitted
+// from the per-session function.
+func drivenControlLoop(t *testing.T, logger *slog.Logger) {
+	t.Helper()
+
+	rendezvousSrv := tlsServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ws, err := websocket.Accept(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer ws.CloseNow()
+		for {
+			if _, _, err := ws.Read(r.Context()); err != nil {
+				return
+			}
+		}
+	}))
+	rendezvousAddr := "wss://" + testEndpoint(rendezvousSrv)
+
+	handlerDone := make(chan struct{}, 1)
+	controlSrv := tlsServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ws, err := websocket.Accept(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer ws.CloseNow()
+		msg := map[string]interface{}{
+			"accept": map[string]interface{}{
+				"address": rendezvousAddr,
+				"id":      "session-id-test",
+			},
+		}
+		data, _ := json.Marshal(msg)
+		if err := ws.Write(r.Context(), websocket.MessageText, data); err != nil {
+			return
+		}
+		// Wait until the listener's handler has been invoked, then
+		// close so runControlLoop returns. Bounded so a stuck
+		// handler can't hang the test indefinitely.
+		select {
+		case <-handlerDone:
+		case <-time.After(3 * time.Second):
+		}
+		ws.Close(websocket.StatusNormalClosure, "done")
+	}))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	cfg := ControlConfig{
+		Endpoint:      testEndpoint(controlSrv),
+		EntityPath:    "test-entity",
+		TokenProvider: &mockTokenProvider{token: "test-token"},
+		Handler: func(ctx context.Context, ws *websocket.Conn) {
+			select {
+			case handlerDone <- struct{}{}:
+			default:
+			}
+		},
+		DialTimeout: 2 * time.Second,
+		Logger:      logger,
+	}
+
+	_, err := runControlLoop(ctx, cfg)
+	if err == nil {
+		t.Fatal("expected error from runControlLoop when server closes")
+	}
+}
+
+// TestControlSessionID_StableWithinLoop drives one runControlLoop
+// invocation end-to-end (connect → one accept → server-initiated
+// close), captures every log line, and asserts that:
+//
+//   - every record carries a non-empty control_session_id;
+//   - every record carries the SAME control_session_id;
+//   - the canonical lifecycle lines ("control loop started",
+//     "control channel connected", "control loop ended") are all
+//     present and tagged.
+//
+// This is the per-session invariant operators rely on to mechanically
+// separate one control-loop run from the next.
+func TestControlSessionID_StableWithinLoop(t *testing.T) {
+	useInsecureTransport(t)
+
+	logger, rec := captureLogger()
+	drivenControlLoop(t, logger)
+
+	records := rec.records(t)
+	if len(records) < 3 {
+		t.Fatalf("expected at least 3 log records (started + connected + ended), got %d: %s", len(records), string(rec.buf))
+	}
+
+	var sessionID string
+	for i, r := range records {
+		id, _ := r["control_session_id"].(string)
+		if id == "" {
+			t.Errorf("record %d missing control_session_id: %v", i, r)
+			continue
+		}
+		if sessionID == "" {
+			sessionID = id
+		} else if id != sessionID {
+			t.Errorf("record %d has control_session_id=%q, want %q", i, id, sessionID)
+		}
+	}
+
+	wantMsgs := []string{"control loop started", "control channel connected", "control loop ended"}
+	for _, want := range wantMsgs {
+		found := false
+		for _, r := range records {
+			if msg, _ := r["msg"].(string); msg == want {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("missing lifecycle log line %q in captured output:\n%s", want, string(rec.buf))
+		}
+	}
+}
+
+// TestControlSessionID_ChangesAcrossRestarts drives runControlLoop
+// twice in sequence — each invocation captures into its own buffer —
+// and asserts the two minted control_session_id values differ. This
+// is the cross-restart invariant: every reconnect gets a fresh id so
+// operators can tell "before the disconnect" from "after the
+// disconnect" log streams.
+func TestControlSessionID_ChangesAcrossRestarts(t *testing.T) {
+	useInsecureTransport(t)
+
+	logger1, rec1 := captureLogger()
+	drivenControlLoop(t, logger1)
+	id1 := extractSessionID(t, rec1)
+
+	logger2, rec2 := captureLogger()
+	drivenControlLoop(t, logger2)
+	id2 := extractSessionID(t, rec2)
+
+	if id1 == "" || id2 == "" {
+		t.Fatalf("missing ids: id1=%q id2=%q", id1, id2)
+	}
+	if id1 == id2 {
+		t.Fatalf("expected distinct control_session_id across runs, got %q twice", id1)
+	}
+}
+
+func extractSessionID(t *testing.T, rec *logRecorder) string {
+	t.Helper()
+	for _, r := range rec.records(t) {
+		if id, _ := r["control_session_id"].(string); id != "" {
+			return id
+		}
+	}
+	t.Fatalf("no control_session_id in captured records: %s", string(rec.buf))
+	return ""
+}

--- a/internal/testharness/relayparity/observability.go
+++ b/internal/testharness/relayparity/observability.go
@@ -25,6 +25,7 @@ func RunObservabilitySuite(t *testing.T, b Backend) {
 		run  func(*testing.T, Backend)
 	}{
 		{"BridgeID_Correlation", ScenarioBridgeID_Correlation},
+		{"ControlSessionID_OnConnectedLine", ScenarioControlSessionID_OnConnectedLine},
 	}
 	for _, sc := range scenarios {
 		t.Run(sc.name, func(t *testing.T) {
@@ -214,4 +215,102 @@ func waitForListenerCorrelations(t *testing.T, snapshot func() string, min int, 
 		time.Sleep(50 * time.Millisecond)
 	}
 	return logs
+}
+
+// controlSessionIDRe matches a control_session_id=VALUE token in
+// slog TextHandler output. Uses the same [A-Z2-7] charset as
+// bridgeIDRe — both ids are minted through idgen, which encodes
+// base32 NoPadding so neither needs slog-quoting.
+var controlSessionIDRe = regexp.MustCompile(`control_session_id=([A-Z2-7]+)`)
+
+// ScenarioControlSessionID_OnConnectedLine asserts that the
+// listener's "control channel connected" log line carries a
+// non-empty control_session_id field, and that the field is stable
+// across the per-session lifecycle (the "control loop started" line
+// minted at runControlLoop entry must share the same id). Both lines
+// are produced inside relay.runControlLoop, so this scenario is the
+// cross-backend gate proving that the per-session logger binding
+// propagates to the canonical lifecycle lines — the same lines
+// every other parity scenario waits for during topology setup.
+//
+// Cross-backend: identical on mock and Azure because the binding
+// happens listener-side before any data crosses the relay.
+func ScenarioControlSessionID_OnConnectedLine(t *testing.T, b Backend) {
+	t.Helper()
+	AssertNoLeaks(t)
+
+	echo := StartPlainEcho(t)
+	tun := b.Setup(t, SetupOptions{
+		NumListeners:   1,
+		SenderMode:     ModePortForward,
+		Target:         echo.Addr(),
+		AllowedTargets: []string{echo.Addr()},
+	})
+	requireLogs(t, tun)
+
+	lst := tun.Listeners[0]
+
+	// Backend.Setup blocks until "control channel connected" has
+	// been logged, so a short poll on lst.Logs is sufficient — keep
+	// a small grace window for pipe-flushing on subprocess backends.
+	connectedLine := waitForLogLineContaining(t, lst.Logs, 5*time.Second, "control channel connected")
+	m := controlSessionIDRe.FindStringSubmatch(connectedLine)
+	if m == nil {
+		t.Fatalf("`control channel connected` line missing control_session_id field:\n%s", connectedLine)
+	}
+	sessionID := m[1]
+
+	// Anchor the "control loop started" lookup on the same
+	// session id we just observed on the connected line. A
+	// listener that retried after an earlier failure (e.g.
+	// transient dial error) will have multiple started/ended
+	// pairs in the buffer; matching on the id pins this assertion
+	// to the lifecycle of the connected session rather than to
+	// whatever attempt happened to be logged first.
+	startedNeedle := "control_session_id=" + sessionID
+	startedLine := waitForLogLineContaining(t, lst.Logs, 2*time.Second, "control loop started", startedNeedle)
+	if !controlSessionIDRe.MatchString(startedLine) {
+		t.Fatalf("`control loop started` line missing control_session_id field:\n%s", startedLine)
+	}
+}
+
+// waitForLogLineContaining returns the first newline-delimited line
+// from logs() that contains every needle in needles, polling at 50ms
+// until timeout. Variadic needles let callers anchor a search to
+// both a message and a correlation id, which is how the scenarios
+// here distinguish the lifecycle line of one session from another.
+// Failing the test rather than returning a sentinel keeps the
+// scenario's stack trace pointing at the missing line.
+func waitForLogLineContaining(t *testing.T, logs func() string, timeout time.Duration, needles ...string) string {
+	t.Helper()
+	if len(needles) == 0 {
+		t.Fatal("waitForLogLineContaining requires at least one needle")
+		return ""
+	}
+	deadline := time.Now().Add(timeout)
+	for {
+		for _, line := range strings.Split(logs(), "\n") {
+			if containsAll(line, needles) {
+				return line
+			}
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("timed out after %v waiting for log line containing %v\n--- logs ---\n%s",
+				timeout, needles, logs())
+			return ""
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+}
+
+// containsAll reports whether s contains every needle. Defined
+// inline (instead of using slices.ContainsFunc + strings.Contains)
+// to keep the helper readable in its single call site.
+func containsAll(s string, needles []string) bool {
+	for _, n := range needles {
+		if !strings.Contains(s, n) {
+			return false
+		}
+	}
+	return true
 }


### PR DESCRIPTION
Every log line emitted from one run of the relay control loop now carries a freshly minted `control_session_id` field. When the control channel dies and a new one connects, a new id is bound — so an operator looking at a 'died and recovered' incident can split the listener's log stream by session instead of guessing from timestamps.

## What's tagged

- `control loop started` — first line of every per-session run.
- `control channel connected`.
- `token renewal failed`, `token renewal attempt failed`, `token renewed` — from `renewLoop`.
- `ping failed, forcing reconnect` — from `pingLoop`.
- `invalid control message`, `max connections reached, dropping accept`, `accept failed`.
- `control loop ended` — last line of every per-session run (deferred, so it fires after goroutine teardown).

## What stays untagged

- The outer reconnect driver's `control channel disconnected, reconnecting` line. That line marks the boundary between sessions; keeping it on the parent logger keeps the boundary visible in log queries.
- Data-bridge log lines on the listener's own logger. Those are correlated by `bridge_id` (separate work item) — mixing the two ids on a single line would be noise.

## New parity scenario

`Scenario_ControlSessionID_OnConnectedLine` joins `RunObservabilitySuite` alongside the existing `BridgeID_Correlation` scenario; both run against the in-process mock backend (always-on CI) and the real Azure backend (e2e CI). It asserts that the listener's `control channel connected` line carries the field, then anchors the lookup of `control loop started` on the same `control_session_id` so a prior failed control-loop attempt in the buffer cannot mismatch the assertion. The scenario consumes the existing `Listener.Logs` accessor from the observability harness — no new backend wiring.

## Tests

- `internal/idgen` — `NewControlSessionID` format, uniqueness, and distinctness from `NewBridgeID`.
- `TestControlSessionID_StableWithinLoop` — drives one full control loop end-to-end with a JSON capture logger, asserts every record (lifecycle, accept, internal helpers) carries the same id and that the canonical lifecycle lines are all present.
- `TestControlSessionID_ChangesAcrossRestarts` — drives the loop twice in sequence and asserts the two minted ids differ.
- New parity scenario above; `RunObservabilitySuite` calls `requireLogs(t, tun)` so a backend that has not wired `Listener.Logs` fails the suite rather than silently passing — matches the contract `BridgeID_Correlation` already enforces.

Verified locally: `go test -race ./...` clean on both modules, `golangci-lint` clean, prettier clean.
