### PR TITLE
feat(obs): observe token-fetch latency and outcome via metrics

### DIFF
--- a/cmd/aztunnel/connect.go
+++ b/cmd/aztunnel/connect.go
@@ -21,7 +21,7 @@ func (c *ConnectCmd) Run(globals *Globals) error {
 		return err
 	}
 
-	endpoint, opts, tp, err := resolveAuth(c.AuthFlags)
+	endpoint, opts, tp, providerName, err := resolveAuth(c.AuthFlags)
 	if err != nil {
 		return err
 	}
@@ -45,6 +45,7 @@ func (c *ConnectCmd) Run(globals *Globals) error {
 	if cfg.Metrics, err = resolveMetrics(ctx, globals.MetricsAddr, globals.MetricsMaxTargets, logger); err != nil {
 		return err
 	}
+	cfg.TokenProvider = observeTokenFetch(tp, cfg.Metrics, providerName)
 
 	return sender.Connect(ctx, cfg)
 }

--- a/cmd/aztunnel/main.go
+++ b/cmd/aztunnel/main.go
@@ -96,10 +96,14 @@ func resolveHyco(hycoFlag string) (string, error) {
 // Auth resolution: SAS env vars (AZTUNNEL_KEY_NAME + AZTUNNEL_KEY) →
 // SAS; otherwise → Entra ID via DefaultAzureCredential.
 //
+// providerName is the short label ("sas" or "entra") matching
+// relay.Provider* — callers use it as the `provider` label when
+// wrapping tp with relay.WithMetrics.
+//
 // --relay-insecure-tls (or AZTUNNEL_RELAY_INSECURE_TLS=1) populates
 // opts.TLSConfig with InsecureSkipVerify. Callers are expected to log
 // a warning when this is set.
-func resolveAuth(af AuthFlags) (endpoint string, opts relay.ClientOptions, tp relay.TokenProvider, err error) {
+func resolveAuth(af AuthFlags) (endpoint string, opts relay.ClientOptions, tp relay.TokenProvider, providerName string, err error) {
 	ns := af.Relay
 	if ns == "" {
 		ns = af.Namespace
@@ -108,7 +112,7 @@ func resolveAuth(af AuthFlags) (endpoint string, opts relay.ClientOptions, tp re
 		ns = os.Getenv("AZTUNNEL_RELAY_NAME")
 	}
 	if ns == "" {
-		return "", relay.ClientOptions{}, nil, fmt.Errorf("relay namespace is required: use --relay or set AZTUNNEL_RELAY_NAME")
+		return "", relay.ClientOptions{}, nil, "", fmt.Errorf("relay namespace is required: use --relay or set AZTUNNEL_RELAY_NAME")
 	}
 	suffix := af.RelaySuffix
 	if suffix == "" {
@@ -120,7 +124,7 @@ func resolveAuth(af AuthFlags) (endpoint string, opts relay.ClientOptions, tp re
 
 	endpoint = relay.ParseRelay(ns, suffix)
 	if endpoint == "" {
-		return "", relay.ClientOptions{}, nil, fmt.Errorf("invalid relay endpoint: %q", ns)
+		return "", relay.ClientOptions{}, nil, "", fmt.Errorf("invalid relay endpoint: %q", ns)
 	}
 
 	if af.RelayInsecureTLS || os.Getenv("AZTUNNEL_RELAY_INSECURE_TLS") == "1" {
@@ -130,14 +134,28 @@ func resolveAuth(af AuthFlags) (endpoint string, opts relay.ClientOptions, tp re
 	keyName := os.Getenv("AZTUNNEL_KEY_NAME")
 	key := os.Getenv("AZTUNNEL_KEY")
 	if keyName != "" && key != "" {
-		return endpoint, opts, &relay.SASTokenProvider{KeyName: keyName, Key: key}, nil
+		return endpoint, opts, &relay.SASTokenProvider{KeyName: keyName, Key: key}, relay.ProviderSAS, nil
 	}
 
 	entra, err := relay.NewEntraTokenProvider()
 	if err != nil {
-		return "", relay.ClientOptions{}, nil, fmt.Errorf("no SAS credentials found (AZTUNNEL_KEY_NAME/AZTUNNEL_KEY) and Entra auth failed: %w", err)
+		return "", relay.ClientOptions{}, nil, "", fmt.Errorf("no SAS credentials found (AZTUNNEL_KEY_NAME/AZTUNNEL_KEY) and Entra auth failed: %w", err)
 	}
-	return endpoint, opts, entra, nil
+	return endpoint, opts, entra, relay.ProviderEntra, nil
+}
+
+// observeTokenFetch wraps tp with relay.WithMetrics when m is a live
+// (non-nil) *metrics.Metrics. m can be nil (when --metrics-addr is not
+// set), in which case tp is returned unchanged. The explicit nil check
+// is needed at the call site: a typed-nil *metrics.Metrics wrapped in
+// a TokenFetchObserver interface compares != nil, and relay.WithMetrics
+// cannot tell from the interface value alone whether the underlying
+// pointer is nil without reflection.
+func observeTokenFetch(tp relay.TokenProvider, m *metrics.Metrics, providerName string) relay.TokenProvider {
+	if m == nil {
+		return tp
+	}
+	return relay.WithMetrics(tp, m, providerName)
 }
 
 // warnInsecureTLS emits a one-line warning when opts.TLSConfig disables

--- a/cmd/aztunnel/main_test.go
+++ b/cmd/aztunnel/main_test.go
@@ -71,7 +71,7 @@ func TestResolveAuth_NamespaceFromEnv(t *testing.T) {
 	t.Setenv("AZTUNNEL_KEY_NAME", "mykey")
 	t.Setenv("AZTUNNEL_KEY", "dGVzdGtleQ==")
 
-	endpoint, _, tp, err := resolveAuth(AuthFlags{})
+	endpoint, _, tp, providerName, err := resolveAuth(AuthFlags{})
 	if err != nil {
 		t.Fatalf("resolveAuth: %v", err)
 	}
@@ -81,6 +81,9 @@ func TestResolveAuth_NamespaceFromEnv(t *testing.T) {
 	if tp == nil {
 		t.Fatal("token provider is nil")
 	}
+	if providerName != relay.ProviderSAS {
+		t.Errorf("providerName = %q, want %q", providerName, relay.ProviderSAS)
+	}
 }
 
 func TestResolveAuth_SASCredentials(t *testing.T) {
@@ -88,7 +91,7 @@ func TestResolveAuth_SASCredentials(t *testing.T) {
 	t.Setenv("AZTUNNEL_KEY_NAME", "RootManageSharedAccessKey")
 	t.Setenv("AZTUNNEL_KEY", "dGVzdGtleQ==")
 
-	endpoint, _, tp, err := resolveAuth(AuthFlags{})
+	endpoint, _, tp, providerName, err := resolveAuth(AuthFlags{})
 	if err != nil {
 		t.Fatalf("resolveAuth: %v", err)
 	}
@@ -106,6 +109,9 @@ func TestResolveAuth_SASCredentials(t *testing.T) {
 	if sas.Key != "dGVzdGtleQ==" {
 		t.Errorf("Key = %q, want %q", sas.Key, "dGVzdGtleQ==")
 	}
+	if providerName != relay.ProviderSAS {
+		t.Errorf("providerName = %q, want %q", providerName, relay.ProviderSAS)
+	}
 }
 
 func TestResolveAuth_MissingNamespace(t *testing.T) {
@@ -113,7 +119,7 @@ func TestResolveAuth_MissingNamespace(t *testing.T) {
 	t.Setenv("AZTUNNEL_KEY_NAME", "")
 	t.Setenv("AZTUNNEL_KEY", "")
 
-	_, _, _, err := resolveAuth(AuthFlags{})
+	_, _, _, _, err := resolveAuth(AuthFlags{})
 	if err == nil {
 		t.Fatal("expected error when namespace is missing, got nil")
 	}
@@ -127,7 +133,7 @@ func TestResolveAuth_NamespaceFlagPriority(t *testing.T) {
 	t.Setenv("AZTUNNEL_KEY_NAME", "mykey")
 	t.Setenv("AZTUNNEL_KEY", "dGVzdGtleQ==")
 
-	endpoint, _, _, err := resolveAuth(AuthFlags{Relay: "from-flag"})
+	endpoint, _, _, _, err := resolveAuth(AuthFlags{Relay: "from-flag"})
 	if err != nil {
 		t.Fatalf("resolveAuth: %v", err)
 	}
@@ -141,7 +147,7 @@ func TestResolveAuth_FQDNInput(t *testing.T) {
 	t.Setenv("AZTUNNEL_KEY_NAME", "mykey")
 	t.Setenv("AZTUNNEL_KEY", "dGVzdGtleQ==")
 
-	endpoint, _, _, err := resolveAuth(AuthFlags{})
+	endpoint, _, _, _, err := resolveAuth(AuthFlags{})
 	if err != nil {
 		t.Fatalf("resolveAuth: %v", err)
 	}
@@ -154,7 +160,7 @@ func TestResolveAuth_URIInput(t *testing.T) {
 	t.Setenv("AZTUNNEL_KEY_NAME", "mykey")
 	t.Setenv("AZTUNNEL_KEY", "dGVzdGtleQ==")
 
-	endpoint, _, _, err := resolveAuth(AuthFlags{Relay: "sb://my-relay.servicebus.windows.net"})
+	endpoint, _, _, _, err := resolveAuth(AuthFlags{Relay: "sb://my-relay.servicebus.windows.net"})
 	if err != nil {
 		t.Fatalf("resolveAuth: %v", err)
 	}
@@ -168,7 +174,7 @@ func TestResolveAuth_CustomSuffixFlag(t *testing.T) {
 	t.Setenv("AZTUNNEL_KEY_NAME", "mykey")
 	t.Setenv("AZTUNNEL_KEY", "dGVzdGtleQ==")
 
-	endpoint, _, _, err := resolveAuth(AuthFlags{RelaySuffix: ".servicebus.chinacloudapi.cn"})
+	endpoint, _, _, _, err := resolveAuth(AuthFlags{RelaySuffix: ".servicebus.chinacloudapi.cn"})
 	if err != nil {
 		t.Fatalf("resolveAuth: %v", err)
 	}
@@ -183,7 +189,7 @@ func TestResolveAuth_SuffixEnvVar(t *testing.T) {
 	t.Setenv("AZTUNNEL_KEY_NAME", "mykey")
 	t.Setenv("AZTUNNEL_KEY", "dGVzdGtleQ==")
 
-	endpoint, _, _, err := resolveAuth(AuthFlags{})
+	endpoint, _, _, _, err := resolveAuth(AuthFlags{})
 	if err != nil {
 		t.Fatalf("resolveAuth: %v", err)
 	}
@@ -196,7 +202,7 @@ func TestResolveAuth_SuffixIgnoredForFQDN(t *testing.T) {
 	t.Setenv("AZTUNNEL_KEY_NAME", "mykey")
 	t.Setenv("AZTUNNEL_KEY", "dGVzdGtleQ==")
 
-	endpoint, _, _, err := resolveAuth(AuthFlags{Relay: "my-relay.servicebus.chinacloudapi.cn", RelaySuffix: ".should-be-ignored"})
+	endpoint, _, _, _, err := resolveAuth(AuthFlags{Relay: "my-relay.servicebus.chinacloudapi.cn", RelaySuffix: ".should-be-ignored"})
 	if err != nil {
 		t.Fatalf("resolveAuth: %v", err)
 	}
@@ -211,7 +217,7 @@ func TestResolveAuth_SuffixFlagPrecedenceOverEnv(t *testing.T) {
 	t.Setenv("AZTUNNEL_KEY_NAME", "mykey")
 	t.Setenv("AZTUNNEL_KEY", "dGVzdGtleQ==")
 
-	endpoint, _, _, err := resolveAuth(AuthFlags{RelaySuffix: ".servicebus.usgovcloudapi.net"})
+	endpoint, _, _, _, err := resolveAuth(AuthFlags{RelaySuffix: ".servicebus.usgovcloudapi.net"})
 	if err != nil {
 		t.Fatalf("resolveAuth: %v", err)
 	}
@@ -224,7 +230,7 @@ func TestResolveAuth_InvalidURIInput(t *testing.T) {
 	t.Setenv("AZTUNNEL_KEY_NAME", "mykey")
 	t.Setenv("AZTUNNEL_KEY", "dGVzdGtleQ==")
 
-	_, _, _, err := resolveAuth(AuthFlags{Relay: "sb://"})
+	_, _, _, _, err := resolveAuth(AuthFlags{Relay: "sb://"})
 	if err == nil {
 		t.Fatal("expected error for invalid URI input, got nil")
 	}
@@ -238,12 +244,15 @@ func TestResolveAuth_OnlyKeyNameNoKey(t *testing.T) {
 	t.Setenv("AZTUNNEL_KEY_NAME", "mykey")
 	t.Setenv("AZTUNNEL_KEY", "")
 
-	_, _, tp, err := resolveAuth(AuthFlags{})
+	_, _, tp, providerName, err := resolveAuth(AuthFlags{})
 	// Either it succeeds with Entra or fails because no Azure creds available.
 	// Either way, tp should NOT be a SASTokenProvider.
 	if err == nil {
 		if _, ok := tp.(*relay.SASTokenProvider); ok {
 			t.Error("expected non-SAS provider when only KEY_NAME is set (no KEY)")
+		}
+		if providerName != relay.ProviderEntra {
+			t.Errorf("providerName = %q, want %q", providerName, relay.ProviderEntra)
 		}
 	}
 	// If err != nil, that's expected in CI where no Azure creds are available.
@@ -254,7 +263,7 @@ func TestResolveAuth_InsecureTLSFlag(t *testing.T) {
 	t.Setenv("AZTUNNEL_KEY_NAME", "k")
 	t.Setenv("AZTUNNEL_KEY", "v")
 
-	_, opts, _, err := resolveAuth(AuthFlags{
+	_, opts, _, _, err := resolveAuth(AuthFlags{
 		Relay:            "wss://localhost:8443",
 		RelayInsecureTLS: true,
 	})
@@ -283,7 +292,7 @@ func TestResolveAuth_RejectsPlainSchemes(t *testing.T) {
 		{"ftp scheme", "ftp://relay.example.com:8443"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			_, _, _, err := resolveAuth(AuthFlags{Relay: tc.relay})
+			_, _, _, _, err := resolveAuth(AuthFlags{Relay: tc.relay})
 			if err == nil {
 				t.Fatalf("expected error for relay %q, got nil", tc.relay)
 			}

--- a/cmd/aztunnel/port_forward.go
+++ b/cmd/aztunnel/port_forward.go
@@ -24,7 +24,7 @@ func (p *PortForwardCmd) Run(globals *Globals) error {
 		return err
 	}
 
-	endpoint, opts, tp, err := resolveAuth(p.AuthFlags)
+	endpoint, opts, tp, providerName, err := resolveAuth(p.AuthFlags)
 	if err != nil {
 		return err
 	}
@@ -59,6 +59,7 @@ func (p *PortForwardCmd) Run(globals *Globals) error {
 	if cfg.Metrics, err = resolveMetrics(ctx, globals.MetricsAddr, globals.MetricsMaxTargets, logger); err != nil {
 		return err
 	}
+	cfg.TokenProvider = observeTokenFetch(tp, cfg.Metrics, providerName)
 
 	return sender.PortForward(ctx, cfg)
 }

--- a/cmd/aztunnel/relay_listener.go
+++ b/cmd/aztunnel/relay_listener.go
@@ -25,7 +25,7 @@ func (r *RelayListenerCmd) Run(globals *Globals) error {
 		return err
 	}
 
-	endpoint, opts, tp, err := resolveAuth(r.AuthFlags)
+	endpoint, opts, tp, providerName, err := resolveAuth(r.AuthFlags)
 	if err != nil {
 		return err
 	}
@@ -44,7 +44,7 @@ func (r *RelayListenerCmd) Run(globals *Globals) error {
 	cfg := listener.Config{
 		Endpoint:       endpoint,
 		EntityPath:     hyco,
-		TokenProvider:  tp,
+		TokenProvider:  observeTokenFetch(tp, m, providerName),
 		ClientOptions:  opts,
 		AllowList:      r.Allow,
 		MaxConnections: r.MaxConnections,

--- a/cmd/aztunnel/socks5_proxy.go
+++ b/cmd/aztunnel/socks5_proxy.go
@@ -23,7 +23,7 @@ func (s *Socks5ProxyCmd) Run(globals *Globals) error {
 		return err
 	}
 
-	endpoint, opts, tp, err := resolveAuth(s.AuthFlags)
+	endpoint, opts, tp, providerName, err := resolveAuth(s.AuthFlags)
 	if err != nil {
 		return err
 	}
@@ -57,6 +57,7 @@ func (s *Socks5ProxyCmd) Run(globals *Globals) error {
 	if cfg.Metrics, err = resolveMetrics(ctx, globals.MetricsAddr, globals.MetricsMaxTargets, logger); err != nil {
 		return err
 	}
+	cfg.TokenProvider = observeTokenFetch(tp, cfg.Metrics, providerName)
 
 	return sender.SOCKS5Proxy(ctx, cfg)
 }

--- a/e2e/token_fetch_metric_test.go
+++ b/e2e/token_fetch_metric_test.go
@@ -1,0 +1,160 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"fmt"
+	"io"
+	"net"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestTokenFetchMetric_Azure verifies that aztunnel_token_fetch_seconds
+// (histogram) and aztunnel_token_fetch_total (counter) appear on a real
+// Azure-bound subprocess's metrics surface after a successful dial,
+// with the `provider` label matching the auth method in use.
+//
+// Both auth methods are exercised — Entra and SAS — so the same
+// invariants are checked for both production code paths
+// (resolveAuth → relay.WithMetrics wrapping). The sender path is
+// asserted, not the listener, because the sender's dial is the
+// observable trigger for the wrapper from a single round-trip: the
+// listener's control-channel attach also fetches a token but completes
+// before the test holds an addressable metrics endpoint to scrape.
+// Asserting the sender side is sufficient for confirming the
+// production wiring is intact end-to-end.
+func TestTokenFetchMetric_Azure(t *testing.T) {
+	t.Parallel()
+	env := requireDedicatedHyco(t)
+
+	for _, auth := range availableAuths(t, env) {
+		auth := auth
+		t.Run(auth.name, func(t *testing.T) {
+			echo := startEchoServer(t)
+			listener := startListener(t, env, auth,
+				"--allow", echo.Addr(),
+			)
+			sender := startPortForwardSender(t, env, auth, echo.Addr(),
+				"--metrics-addr", "127.0.0.1:0",
+			)
+
+			waitForLog(t, listener, "control channel connected", 30*time.Second)
+			senderAddr := waitForLogAddr(t, sender, "port-forward listening", 15*time.Second)
+			senderMetrics := sender.MetricsAddr(t, 15*time.Second)
+
+			// One successful round-trip ensures the sender's dial
+			// actually ran (and therefore exercised the wrapped
+			// TokenProvider) before we scrape metrics.
+			conn, err := net.DialTimeout("tcp", senderAddr, 10*time.Second)
+			if err != nil {
+				t.Fatalf("dial sender: %v", err)
+			}
+			defer conn.Close() //nolint:errcheck // best-effort cleanup
+			payload := []byte("token-fetch-metric\n")
+			if _, err := conn.Write(payload); err != nil {
+				t.Fatalf("write: %v", err)
+			}
+			buf := make([]byte, len(payload))
+			if _, err := io.ReadFull(conn, buf); err != nil {
+				t.Fatalf("read: %v", err)
+			}
+
+			// Expected provider label: auth.name is "entra" or "sas",
+			// which matches relay.ProviderEntra / relay.ProviderSAS by
+			// construction.
+			counterLine := fmt.Sprintf(`aztunnel_token_fetch_total{provider="%s",result="ok"}`, auth.name)
+			waitForMetricsContains(t, senderMetrics, counterLine, 15*time.Second)
+
+			// Both the counter and the histogram must have at least
+			// one sample under the (provider=auth.name, result=ok)
+			// label pair. The histogram's _count line confirms
+			// observations landed, not just the counter.
+			histCountLine := fmt.Sprintf(`aztunnel_token_fetch_seconds_count{provider="%s",result="ok"}`, auth.name)
+			body := waitForMetricsContains(t, senderMetrics, histCountLine, 5*time.Second)
+
+			// Sanity-check the counter actually has a positive value
+			// (the substring match would also pass for a 0 value).
+			counterValue := metricLineValue(t, body, counterLine)
+			if counterValue < 1 {
+				t.Errorf("%s = %v, want >= 1", counterLine, counterValue)
+			}
+			histCountValue := metricLineValue(t, body, histCountLine)
+			if histCountValue < 1 {
+				t.Errorf("%s = %v, want >= 1", histCountLine, histCountValue)
+			}
+
+			// The histogram count must equal the counter value:
+			// ObserveTokenFetch increments both per call. They are
+			// distinct Prometheus collectors so the two writes are
+			// not atomic, but the test holds the wrapper still — no
+			// new GetToken calls happen between the dial completing
+			// and the scrape, so a single Gather observes consistent
+			// values.
+			if histCountValue != counterValue {
+				t.Errorf("histogram count %v != counter %v (wrapper must observe both per call)",
+					histCountValue, counterValue)
+			}
+
+			// No other provider label may appear on these metric
+			// families — the wiring should only register one
+			// provider per process.
+			assertNoOtherProvider(t, body, "aztunnel_token_fetch_total", auth.name)
+		})
+	}
+}
+
+// metricLineValue parses the value off the end of the first Prometheus
+// text line in body that starts with linePrefix. Returns 0 on miss.
+// Used by TestTokenFetchMetric_Azure to read a single labelled sample
+// without bringing in a full prom-text parser.
+func metricLineValue(t *testing.T, body, linePrefix string) float64 {
+	t.Helper()
+	for _, line := range strings.Split(body, "\n") {
+		if !strings.HasPrefix(line, linePrefix) {
+			continue
+		}
+		// Line format: name{labels} value [timestamp]
+		idx := strings.LastIndex(line, " ")
+		if idx == -1 || idx == len(line)-1 {
+			continue
+		}
+		var v float64
+		if _, err := fmt.Sscanf(line[idx+1:], "%f", &v); err != nil {
+			t.Logf("could not parse value from line %q: %v", line, err)
+			continue
+		}
+		return v
+	}
+	return 0
+}
+
+// assertNoOtherProvider fails the test if family appears in body with
+// a `provider="..."` label that is not wantProvider. Catches
+// accidental wiring of multiple TokenProvider implementations under
+// distinct provider labels in one process, which is not a supported
+// production configuration.
+func assertNoOtherProvider(t *testing.T, body, family, wantProvider string) {
+	t.Helper()
+	for _, line := range strings.Split(body, "\n") {
+		if !strings.HasPrefix(line, family+"{") {
+			continue
+		}
+		const marker = `provider="`
+		i := strings.Index(line, marker)
+		if i == -1 {
+			continue
+		}
+		rest := line[i+len(marker):]
+		end := strings.IndexByte(rest, '"')
+		if end == -1 {
+			continue
+		}
+		got := rest[:end]
+		if got != wantProvider {
+			t.Errorf("%s has unexpected provider label %q (want only %q): %s",
+				family, got, wantProvider, line)
+		}
+	}
+}

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -57,6 +57,8 @@ type Metrics struct {
 	controlChannelUp   prometheus.Gauge
 	connectionDuration *prometheus.HistogramVec
 	dialDuration       *prometheus.HistogramVec
+	tokenFetchSeconds  *prometheus.HistogramVec
+	tokenFetchTotal    *prometheus.CounterVec
 
 	targetCount atomic.Int64
 	targets     sync.Map // map[string]struct{}
@@ -114,6 +116,27 @@ func New() *Metrics {
 			Help:      "Time to establish outbound connections in seconds.",
 			Buckets:   []float64{0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30},
 		}, []string{"role"}),
+
+		tokenFetchSeconds: prometheus.NewHistogramVec(prometheus.HistogramOpts{
+			Namespace: namespace,
+			Name:      "token_fetch_seconds",
+			Help: "Latency of TokenProvider.GetToken calls. " +
+				"Records end-to-end GetToken latency, including any " +
+				"in-process caching the wrapped provider performs " +
+				"(e.g. EntraTokenProvider's cache hits land as " +
+				"sub-millisecond observations alongside underlying-" +
+				"credential refreshes; SAS providers re-sign per call " +
+				"and have no cache, so observations reflect the signing " +
+				"cost). The tail extends to 60s to keep slow-path " +
+				"signal (e.g. `az` shell-out cold start) bucketed.",
+			Buckets: []float64{0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 15, 30, 60},
+		}, []string{"provider", "result"}),
+
+		tokenFetchTotal: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace: namespace,
+			Name:      "token_fetch_total",
+			Help:      "Count of TokenProvider.GetToken calls by outcome.",
+		}, []string{"provider", "result"}),
 	}
 
 	reg.MustRegister(
@@ -124,6 +147,8 @@ func New() *Metrics {
 		m.controlChannelUp,
 		m.connectionDuration,
 		m.dialDuration,
+		m.tokenFetchSeconds,
+		m.tokenFetchTotal,
 	)
 
 	return m
@@ -234,6 +259,18 @@ func (m *Metrics) ObserveDialDuration(role string, seconds float64) {
 		return
 	}
 	m.dialDuration.WithLabelValues(role).Observe(seconds)
+}
+
+// ObserveTokenFetch records the latency and outcome of a single
+// TokenProvider.GetToken call. Safe to call on a nil receiver — observation
+// is dropped silently in that case so callers can wire the observer
+// unconditionally and let the call site decide whether metrics are enabled.
+func (m *Metrics) ObserveTokenFetch(provider, result string, durationSec float64) {
+	if m == nil {
+		return
+	}
+	m.tokenFetchSeconds.WithLabelValues(provider, result).Observe(durationSec)
+	m.tokenFetchTotal.WithLabelValues(provider, result).Inc()
 }
 
 // SetControlChannelConnected sets the control channel gauge.

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -31,6 +31,7 @@ func TestNew(t *testing.T) {
 	// Trigger all metrics so they appear in Gather output.
 	m.ConnectionError("test", "test")
 	m.ObserveDialDuration("test", 0.1)
+	m.ObserveTokenFetch("stub", "ok", 0.01)
 	m.SetControlChannelConnected(true)
 	tracker := m.ConnectionOpened("test", "test:22")
 	tracker.Done(1.0, 100, 200, nil)
@@ -48,6 +49,8 @@ func TestNew(t *testing.T) {
 		"aztunnel_control_channel_connected",
 		"aztunnel_connection_duration_seconds",
 		"aztunnel_dial_duration_seconds",
+		"aztunnel_token_fetch_seconds",
+		"aztunnel_token_fetch_total",
 	}
 	got := make(map[string]bool)
 	for _, f := range fams {
@@ -489,9 +492,79 @@ func TestNilMetrics(t *testing.T) {
 
 	m.ConnectionError("sender", ReasonDialFailed)
 	m.ObserveDialDuration("sender", 0.1)
+	m.ObserveTokenFetch("entra", "ok", 0.1)
 	m.SetControlChannelConnected(true)
 
 	// Calling Done on a nil *ConnectionTracker must not panic.
 	var nilTracker *ConnectionTracker
 	nilTracker.Done(1.0, 100, 200, nil)
+}
+
+// TestObserveTokenFetch_RecordsHistogramAndCounter verifies that a
+// single ObserveTokenFetch call increments both the counter (by 1) and
+// the histogram (one sample) under the exact (provider, result) label
+// pair passed in.
+func TestObserveTokenFetch_RecordsHistogramAndCounter(t *testing.T) {
+	m := New()
+	m.ObserveTokenFetch("entra", "ok", 0.123)
+	m.ObserveTokenFetch("entra", "ok", 0.456)
+	m.ObserveTokenFetch("entra", "error", 1.5)
+
+	fams, err := m.Registry.Gather()
+	if err != nil {
+		t.Fatalf("gather: %v", err)
+	}
+
+	var sawCounter, sawHistogram bool
+	for _, f := range fams {
+		switch f.GetName() {
+		case "aztunnel_token_fetch_total":
+			sawCounter = true
+			counts := map[string]float64{}
+			for _, sample := range f.GetMetric() {
+				key := labelKey(sample, "provider", "result")
+				counts[key] = sample.GetCounter().GetValue()
+			}
+			if counts["entra/ok"] != 2 {
+				t.Errorf("token_fetch_total{entra,ok} = %v, want 2", counts["entra/ok"])
+			}
+			if counts["entra/error"] != 1 {
+				t.Errorf("token_fetch_total{entra,error} = %v, want 1", counts["entra/error"])
+			}
+		case "aztunnel_token_fetch_seconds":
+			sawHistogram = true
+			samples := map[string]uint64{}
+			for _, sample := range f.GetMetric() {
+				key := labelKey(sample, "provider", "result")
+				samples[key] = sample.GetHistogram().GetSampleCount()
+			}
+			if samples["entra/ok"] != 2 {
+				t.Errorf("token_fetch_seconds{entra,ok} count = %v, want 2", samples["entra/ok"])
+			}
+			if samples["entra/error"] != 1 {
+				t.Errorf("token_fetch_seconds{entra,error} count = %v, want 1", samples["entra/error"])
+			}
+		}
+	}
+	if !sawCounter {
+		t.Error("aztunnel_token_fetch_total not registered")
+	}
+	if !sawHistogram {
+		t.Error("aztunnel_token_fetch_seconds not registered")
+	}
+}
+
+// labelKey concatenates the named label values from a Prometheus
+// metric sample in the order given, separated by "/". Used to index
+// histogram/counter samples by their label tuple in tests.
+func labelKey(sample *dto.Metric, names ...string) string {
+	values := make(map[string]string)
+	for _, lp := range sample.GetLabel() {
+		values[lp.GetName()] = lp.GetValue()
+	}
+	parts := make([]string, len(names))
+	for i, n := range names {
+		parts[i] = values[n]
+	}
+	return strings.Join(parts, "/")
 }

--- a/internal/relay/auth.go
+++ b/internal/relay/auth.go
@@ -48,6 +48,84 @@ type TokenProvider interface {
 	GetToken(ctx context.Context, resourceURI string) (string, error)
 }
 
+// Provider label values for TokenFetchObserver. These are the values
+// passed as the `provider` label on aztunnel_token_fetch_seconds /
+// _total when WithMetrics wraps a TokenProvider. Defined here so the
+// label vocabulary is shared between the wiring side (cmd/aztunnel)
+// and the wrapper itself, and not duplicated as string literals.
+const (
+	ProviderSAS   = "sas"
+	ProviderEntra = "entra"
+)
+
+// TokenFetchObserver receives one observation per TokenProvider.GetToken
+// call when WithMetrics is applied. The metrics package's *Metrics type
+// satisfies this interface via its ObserveTokenFetch method; declaring
+// the interface here lets internal/relay wrap a provider without
+// importing internal/metrics, which would create an import cycle
+// (metrics already imports relay).
+type TokenFetchObserver interface {
+	// ObserveTokenFetch records one GetToken call. result is "ok" for
+	// successful fetches and "error" for failures; durationSec is the
+	// wall-clock time spent inside the wrapped provider's GetToken.
+	ObserveTokenFetch(provider, result string, durationSec float64)
+}
+
+// metricsTokenProvider wraps another TokenProvider and reports each
+// GetToken call to a TokenFetchObserver. It is intentionally
+// transparent to callers: the inner provider's token and error are
+// returned unchanged.
+//
+// Placement matters. Wrapping an EntraTokenProvider (the cached
+// provider) means cache-hit returns are observed too, with near-zero
+// latency — what an operator dashboard sees is effective end-to-end
+// GetToken latency, not pure upstream-credential refresh latency. The
+// metric Help text reflects that contract.
+type metricsTokenProvider struct {
+	inner    TokenProvider
+	provider string
+	obs      TokenFetchObserver
+}
+
+// GetToken delegates to the wrapped provider and reports latency +
+// outcome to the observer. The observer is never nil here — WithMetrics
+// short-circuits a nil observer at construction time, so this hot path
+// pays no per-call branch.
+func (p *metricsTokenProvider) GetToken(ctx context.Context, resourceURI string) (string, error) {
+	start := time.Now()
+	tok, err := p.inner.GetToken(ctx, resourceURI)
+	result := "ok"
+	if err != nil {
+		result = "error"
+	}
+	p.obs.ObserveTokenFetch(p.provider, result, time.Since(start).Seconds())
+	return tok, err
+}
+
+// WithMetrics returns a TokenProvider that reports each GetToken call
+// to obs as (provider, result, durationSec). provider is a short label
+// string such as ProviderSAS or ProviderEntra; result is "ok" or
+// "error" depending on the inner call's outcome.
+//
+// If obs is the plain (untyped) nil, p is returned unchanged — no
+// wrapping, no overhead. Callers passing an interface value whose
+// underlying concrete pointer is nil (the classic "typed-nil-in-an-
+// interface" pitfall) MUST handle that themselves at the call site,
+// e.g.:
+//
+//	if m != nil {
+//	    tp = relay.WithMetrics(tp, m, relay.ProviderEntra)
+//	}
+//
+// because WithMetrics cannot tell from the interface value alone
+// whether the underlying observer is nil without reflection.
+func WithMetrics(p TokenProvider, obs TokenFetchObserver, provider string) TokenProvider {
+	if obs == nil {
+		return p
+	}
+	return &metricsTokenProvider{inner: p, provider: provider, obs: obs}
+}
+
 // SASTokenProvider generates Shared Access Signature tokens.
 type SASTokenProvider struct {
 	KeyName string

--- a/internal/relay/auth_test.go
+++ b/internal/relay/auth_test.go
@@ -394,3 +394,189 @@ func TestEntraTokenProvider_RespectsRefreshOn(t *testing.T) {
 		}
 	})
 }
+
+// stubTokenProvider is a TokenProvider whose GetToken behaviour is
+// configured per-test. delay simulates underlying credential latency;
+// err, when set, replaces the token return. Used to drive
+// metricsTokenProvider through both result paths without touching the
+// real EntraTokenProvider or SASTokenProvider machinery.
+type stubTokenProvider struct {
+	delay time.Duration
+	token string
+	err   error
+}
+
+func (s *stubTokenProvider) GetToken(ctx context.Context, _ string) (string, error) {
+	if s.delay > 0 {
+		select {
+		case <-time.After(s.delay):
+		case <-ctx.Done():
+			return "", ctx.Err()
+		}
+	}
+	if s.err != nil {
+		return "", s.err
+	}
+	return s.token, nil
+}
+
+// recordingObserver captures every ObserveTokenFetch call. Tests inspect
+// observations directly rather than going through the full metrics
+// package — relay's contract with TokenFetchObserver is what's under
+// test here, not the metrics implementation.
+type recordingObserver struct {
+	mu           sync.Mutex
+	observations []tokenFetchObservation
+}
+
+type tokenFetchObservation struct {
+	provider    string
+	result      string
+	durationSec float64
+}
+
+func (r *recordingObserver) ObserveTokenFetch(provider, result string, durationSec float64) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.observations = append(r.observations, tokenFetchObservation{
+		provider:    provider,
+		result:      result,
+		durationSec: durationSec,
+	})
+}
+
+func (r *recordingObserver) snapshot() []tokenFetchObservation {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([]tokenFetchObservation, len(r.observations))
+	copy(out, r.observations)
+	return out
+}
+
+// TestMetricsTokenProvider_RecordsLatency_OK verifies that a successful
+// GetToken call yields one observation with result="ok" and a duration
+// that brackets the underlying provider's actual latency. The bracket is
+// loose (40-300ms for a 50ms inner delay) to absorb scheduler jitter on
+// slow CI runners without losing the property under test: the wrapper
+// records the wall-clock time spent inside the inner GetToken, not zero
+// and not the test deadline.
+func TestMetricsTokenProvider_RecordsLatency_OK(t *testing.T) {
+	const innerDelay = 50 * time.Millisecond
+	inner := &stubTokenProvider{token: "tok-ok", delay: innerDelay}
+	obs := &recordingObserver{}
+	tp := WithMetrics(inner, obs, "stub")
+
+	tok, err := tp.GetToken(context.Background(), "ignored")
+	if err != nil {
+		t.Fatalf("GetToken: %v", err)
+	}
+	if tok != "tok-ok" {
+		t.Errorf("token = %q, want %q", tok, "tok-ok")
+	}
+
+	got := obs.snapshot()
+	if len(got) != 1 {
+		t.Fatalf("observations = %d, want 1", len(got))
+	}
+	if got[0].provider != "stub" {
+		t.Errorf("provider = %q, want %q", got[0].provider, "stub")
+	}
+	if got[0].result != "ok" {
+		t.Errorf("result = %q, want %q", got[0].result, "ok")
+	}
+	if got[0].durationSec < 0.04 || got[0].durationSec > 0.30 {
+		t.Errorf("durationSec = %v, want in [0.04, 0.30] for %v inner delay",
+			got[0].durationSec, innerDelay)
+	}
+}
+
+// TestMetricsTokenProvider_RecordsLatency_Error verifies that a failing
+// GetToken call yields one observation with result="error", the error is
+// surfaced to the caller unchanged (errors.Is matches the sentinel), and
+// the duration still reflects the time spent inside the inner provider.
+func TestMetricsTokenProvider_RecordsLatency_Error(t *testing.T) {
+	sentinel := errors.New("boom")
+	inner := &stubTokenProvider{err: sentinel, delay: 20 * time.Millisecond}
+	obs := &recordingObserver{}
+	tp := WithMetrics(inner, obs, "stub")
+
+	_, err := tp.GetToken(context.Background(), "ignored")
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("GetToken error = %v, want wraps %v", err, sentinel)
+	}
+
+	got := obs.snapshot()
+	if len(got) != 1 {
+		t.Fatalf("observations = %d, want 1", len(got))
+	}
+	if got[0].result != "error" {
+		t.Errorf("result = %q, want %q", got[0].result, "error")
+	}
+	if got[0].durationSec <= 0 {
+		t.Errorf("durationSec = %v, want > 0", got[0].durationSec)
+	}
+}
+
+// TestMetricsTokenProvider_LabelsCorrect verifies the provider label
+// passed to WithMetrics is what shows up on the observation. Covers both
+// the documented ProviderSAS / ProviderEntra constants and an arbitrary
+// custom string, ensuring there is no hidden allow-list of labels.
+func TestMetricsTokenProvider_LabelsCorrect(t *testing.T) {
+	for _, want := range []string{ProviderSAS, ProviderEntra, "custom"} {
+		t.Run(want, func(t *testing.T) {
+			inner := &stubTokenProvider{token: "tok"}
+			obs := &recordingObserver{}
+			tp := WithMetrics(inner, obs, want)
+			if _, err := tp.GetToken(context.Background(), "ignored"); err != nil {
+				t.Fatalf("GetToken: %v", err)
+			}
+			got := obs.snapshot()
+			if len(got) != 1 || got[0].provider != want {
+				t.Errorf("provider label = %q, want %q (observations=%#v)",
+					func() string {
+						if len(got) == 0 {
+							return ""
+						}
+						return got[0].provider
+					}(), want, got)
+			}
+		})
+	}
+}
+
+// TestWithMetrics_NilObserverPassThrough verifies that an untyped-nil
+// observer makes WithMetrics a no-op: the caller gets back the original
+// TokenProvider unchanged, so calls bypass the wrapper entirely. This
+// keeps WithMetrics safe to call from any construction pipeline that
+// may not yet have observability wired in, without forcing callers to
+// branch on a nil observer themselves.
+func TestWithMetrics_NilObserverPassThrough(t *testing.T) {
+	inner := &stubTokenProvider{token: "tok"}
+	tp := WithMetrics(inner, nil, "stub")
+	if tp != TokenProvider(inner) {
+		t.Errorf("WithMetrics(_, nil, _) should return the inner provider unchanged, got %T", tp)
+	}
+	tok, err := tp.GetToken(context.Background(), "ignored")
+	if err != nil {
+		t.Fatalf("GetToken: %v", err)
+	}
+	if tok != "tok" {
+		t.Errorf("token = %q, want %q", tok, "tok")
+	}
+}
+
+// TestMetricsTokenProvider_PreservesError verifies that the wrapper
+// returns the inner error reference unmodified (not a wrapped or copied
+// error) so errors.Is/As callers see exactly what the underlying
+// provider produced.
+func TestMetricsTokenProvider_PreservesError(t *testing.T) {
+	sentinel := errors.New("inner")
+	inner := &stubTokenProvider{err: sentinel}
+	obs := &recordingObserver{}
+	tp := WithMetrics(inner, obs, "stub")
+
+	_, err := tp.GetToken(context.Background(), "ignored")
+	if err != sentinel {
+		t.Errorf("error = %v, want exactly %v (wrapper must not wrap)", err, sentinel)
+	}
+}

--- a/mockrelay/testharness/parity/token_fetch_metric_test.go
+++ b/mockrelay/testharness/parity/token_fetch_metric_test.go
@@ -1,0 +1,291 @@
+package parity
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/philsphicas/aztunnel/internal/listener"
+	"github.com/philsphicas/aztunnel/internal/metrics"
+	"github.com/philsphicas/aztunnel/internal/relay"
+	"github.com/philsphicas/aztunnel/internal/sender"
+	"github.com/philsphicas/aztunnel/mockrelay/server"
+	dto "github.com/prometheus/client_model/go"
+)
+
+// erroringTokenProvider is a TokenProvider that always returns the
+// configured error. Used to drive the result=error path through the
+// wrapper end-to-end against the shared Metrics surface — the dial
+// machinery itself does not retry on token-fetch errors, so we
+// exercise the error path by calling GetToken on the wrapped provider
+// directly rather than through DialWithRetry.
+type erroringTokenProvider struct{ err error }
+
+func (e *erroringTokenProvider) GetToken(context.Context, string) (string, error) {
+	return "", e.err
+}
+
+// TestTokenFetchMetric_MockRelay verifies that relay.WithMetrics,
+// when applied at the production wiring point (around a real
+// TokenProvider passed into listener.Config.TokenProvider /
+// sender.PortForwardConfig.TokenProvider), produces observations on
+// the wrapped Metrics surface:
+//
+//   - result=ok: a real listener + sender topology drives a successful
+//     round-trip through the mock relay; the wrapper records every
+//     GetToken call the listener (control-channel attach + renews) and
+//     the sender (each dial) make against the underlying SAS provider.
+//
+//   - result=error: a separately wrapped TokenProvider, primed to
+//     always error, is exercised directly. The wrapper's contract is
+//     identical regardless of who calls GetToken — DialWithRetry does
+//     not retry on token errors, so driving the error path through the
+//     full sender machinery would short-circuit the wrapper's
+//     observation budget after a single bridge-killing attempt. Direct
+//     invocation keeps the assertion focused on the wrapper's
+//     integration with the metrics surface, while the unit tests in
+//     internal/relay cover the wrapper's own behaviour.
+//
+// This is a mockrelay-only integration test. The e2e Azure test
+// (e2e/token_fetch_metric_test.go) covers the result=ok path against
+// real Entra/SAS providers.
+func TestTokenFetchMetric_MockRelay(t *testing.T) {
+	host, clientOpts := startMockRelay(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	var wg sync.WaitGroup
+	t.Cleanup(func() {
+		cancel()
+		wg.Wait()
+	})
+
+	entity := mustEntityName(t)
+	silentLogger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	// Share one metrics surface between the listener and the sender so
+	// the final assertion can read the merged token_fetch_total /
+	// _seconds samples from a single registry. In production each
+	// process has its own surface, but the wrapper is the same code
+	// path regardless of how many providers point at the same
+	// Metrics, so the merge here doesn't lose any property under test.
+	m := metrics.New()
+	sasInner := relay.TokenProvider(&relay.SASTokenProvider{
+		KeyName: server.DefaultSASKeyName,
+		Key:     server.DefaultSASKey,
+	})
+	listenerTP := relay.WithMetrics(sasInner, m, relay.ProviderSAS)
+	senderTP := relay.WithMetrics(sasInner, m, relay.ProviderSAS)
+
+	echoLn, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen echo: %v", err)
+	}
+	t.Cleanup(func() { _ = echoLn.Close() })
+	go runEchoServer(echoLn)
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		err := listener.ListenAndServe(ctx, listener.Config{
+			Endpoint:      host,
+			EntityPath:    entity,
+			TokenProvider: listenerTP,
+			ClientOptions: clientOpts,
+			AllowList:     []string{echoLn.Addr().String()},
+			Logger:        silentLogger,
+			Metrics:       m,
+		})
+		if err != nil && ctx.Err() == nil {
+			t.Logf("listener exited: %v", err)
+		}
+	}()
+
+	if !waitForGauge(m, "aztunnel_control_channel_connected", 1, 15*time.Second) {
+		t.Fatalf("listener never reported control_channel_connected")
+	}
+
+	addrCh := make(chan net.Addr, 1)
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		err := sender.PortForward(ctx, sender.PortForwardConfig{
+			Endpoint:      host,
+			EntityPath:    entity,
+			TokenProvider: senderTP,
+			ClientOptions: clientOpts,
+			Target:        echoLn.Addr().String(),
+			BindAddress:   "127.0.0.1:0",
+			Logger:        silentLogger,
+			Metrics:       m,
+			Ready: func(a net.Addr) {
+				select {
+				case addrCh <- a:
+				default:
+				}
+			},
+		})
+		if err != nil && ctx.Err() == nil {
+			t.Logf("sender exited: %v", err)
+		}
+	}()
+
+	var senderAddr net.Addr
+	select {
+	case senderAddr = <-addrCh:
+	case <-time.After(15 * time.Second):
+		t.Fatalf("sender never became ready")
+	}
+
+	// Drive one successful round-trip. The listener's control-channel
+	// attach has already produced its first ok observation; the
+	// sender's dial here produces the next one.
+	conn, err := net.DialTimeout("tcp", senderAddr.String(), 5*time.Second)
+	if err != nil {
+		t.Fatalf("dial sender: %v", err)
+	}
+	defer conn.Close() //nolint:errcheck // best-effort cleanup
+	_ = conn.SetDeadline(time.Now().Add(10 * time.Second))
+	payload := []byte("token-fetch-metric\n")
+	if _, err := conn.Write(payload); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	buf := make([]byte, len(payload))
+	if _, err := io.ReadFull(conn, buf); err != nil {
+		t.Fatalf("read: %v", err)
+	}
+
+	// Now drive the error path through a separately wrapped provider
+	// against the same shared metrics surface, exercising the wrapper
+	// end-to-end (caller → wrapper → observer → registry) without
+	// going through DialWithRetry, which would not retry on token
+	// errors and would short-circuit the wrapper after a single
+	// bridge-killing attempt.
+	errSentinel := errors.New("simulated upstream failure")
+	failingTP := relay.WithMetrics(&erroringTokenProvider{err: errSentinel}, m, relay.ProviderSAS)
+	for i := 0; i < 2; i++ {
+		if _, err := failingTP.GetToken(ctx, "ignored"); !errors.Is(err, errSentinel) {
+			t.Fatalf("failingTP.GetToken: got %v, want wraps %v", err, errSentinel)
+		}
+	}
+
+	// Wait until the success counter reaches at least 2 (one from the
+	// listener control-channel attach, one from the sender dial). The
+	// listener's renew loop may produce more between observations; we
+	// only assert the floor.
+	if !waitForCounter(m, "aztunnel_token_fetch_total", relay.ProviderSAS, "ok", 2, 5*time.Second) {
+		t.Fatalf("token_fetch_total{provider=sas,result=ok} never reached 2 (got %v)",
+			counterValue(m, "aztunnel_token_fetch_total", relay.ProviderSAS, "ok"))
+	}
+	if got := counterValue(m, "aztunnel_token_fetch_total", relay.ProviderSAS, "error"); got != 2 {
+		t.Errorf("token_fetch_total{provider=sas,result=error} = %v, want 2", got)
+	}
+
+	// Both histograms must have observations matching their counter
+	// sample counts (counter and histogram are paired in
+	// ObserveTokenFetch).
+	if got := histogramCount(m, "aztunnel_token_fetch_seconds", relay.ProviderSAS, "ok"); got < 2 {
+		t.Errorf("token_fetch_seconds{provider=sas,result=ok} count = %v, want >= 2", got)
+	}
+	if got := histogramCount(m, "aztunnel_token_fetch_seconds", relay.ProviderSAS, "error"); got != 2 {
+		t.Errorf("token_fetch_seconds{provider=sas,result=error} count = %v, want 2", got)
+	}
+}
+
+// runEchoServer accepts connections and echoes bytes until the
+// listener is closed. The error from Accept after Close is expected
+// and not surfaced.
+func runEchoServer(ln net.Listener) {
+	for {
+		c, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		go func(conn net.Conn) {
+			defer conn.Close() //nolint:errcheck // best-effort cleanup
+			_, _ = io.Copy(conn, conn)
+		}(c)
+	}
+}
+
+// waitForCounter polls m's registry for the given counter to reach at
+// least want under the (provider, result) label pair before timeout.
+// Returns true on success, false on deadline.
+func waitForCounter(m *metrics.Metrics, name, provider, result string, want float64, timeout time.Duration) bool {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if counterValue(m, name, provider, result) >= want {
+			return true
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	return false
+}
+
+// counterValue returns the single-sample value of a counter under the
+// (provider, result) label pair from m's registry. Returns 0 if the
+// counter is missing or has no matching label combination.
+func counterValue(m *metrics.Metrics, name, provider, result string) float64 {
+	families, err := m.Registry.Gather()
+	if err != nil {
+		return 0
+	}
+	for _, f := range families {
+		if f.GetName() != name {
+			continue
+		}
+		for _, sample := range f.GetMetric() {
+			if matchesProviderResult(sample.GetLabel(), provider, result) {
+				return sample.GetCounter().GetValue()
+			}
+		}
+	}
+	return 0
+}
+
+// histogramCount returns the SampleCount of a histogram under the
+// (provider, result) label pair from m's registry.
+func histogramCount(m *metrics.Metrics, name, provider, result string) uint64 {
+	families, err := m.Registry.Gather()
+	if err != nil {
+		return 0
+	}
+	for _, f := range families {
+		if f.GetName() != name {
+			continue
+		}
+		for _, sample := range f.GetMetric() {
+			if matchesProviderResult(sample.GetLabel(), provider, result) {
+				return sample.GetHistogram().GetSampleCount()
+			}
+		}
+	}
+	return 0
+}
+
+// matchesProviderResult reports whether a metric sample's labels match
+// the given (provider, result) pair exactly. Used to look up specific
+// label combinations in counter/histogram samples without depending on
+// label ordering.
+func matchesProviderResult(labels []*dto.LabelPair, provider, result string) bool {
+	var sawProvider, sawResult bool
+	for _, lp := range labels {
+		switch lp.GetName() {
+		case "provider":
+			if lp.GetValue() != provider {
+				return false
+			}
+			sawProvider = true
+		case "result":
+			if lp.GetValue() != result {
+				return false
+			}
+			sawResult = true
+		}
+	}
+	return sawProvider && sawResult
+}


### PR DESCRIPTION
Operators currently have no signal when `TokenProvider.GetToken` calls are slow or failing — the underlying credential latency only becomes visible at the moment a relay renew fails downstream. After PR #67's Entra token caching, the cache hides the upstream provider's latency entirely.

This change adds two metrics so that token-fetch problems are directly dashboardable:

- `aztunnel_token_fetch_seconds{provider,result}` — histogram of every `TokenProvider.GetToken` call's latency.
- `aztunnel_token_fetch_total{provider,result}` — counter of every call's outcome.

`provider` is one of `sas`, `entra`, or `custom`. `result` is `ok` or `error`.

The wrapper sits *outside* `EntraTokenProvider`'s in-process cache, so the histogram reflects the effective end-to-end token latency an operator cares about: cache hits show as sub-millisecond observations, real refreshes land in higher buckets, and slow `az` shell-out cold-starts fall into the 1–60 s tail (the histogram bucket layout is extended past the Prometheus default 10 s tail for exactly this reason).

The listener, port-forward, socks5, and relay-listener entrypoints all wrap `tp` with the decorator automatically when a metrics endpoint is configured; nothing wires up when `--metrics-addr` is unset, so the decorator is invisible to users who haven't asked for observability.

### Operator workflow this enables

- Alert on `rate(aztunnel_token_fetch_total{result="error"}[5m]) > 0` to catch credential expiry / outages before the next renew failure.
- Dashboard `histogram_quantile(0.99, sum by (le,provider) (rate(aztunnel_token_fetch_seconds_bucket[5m])))` to spot a creeping cold-start regression.
- Compare `provider="entra"` and `provider="sas"` latencies side-by-side when deciding whether to migrate a workload.

### Test coverage

- Unit tests for the decorator (ok / error / labels / nil-observer pass-through / error preservation).
- Unit tests for the new metrics' registration and observation paths.
- Mockrelay integration test driving the ok path through a real listener+sender topology and the error path directly (because `DialWithRetry` does not retry on token-fetch failures).
- e2e test (`//go:build e2e`) covering both Entra and SAS against a real Azure Relay namespace, asserting that the counter and histogram both record under the expected `(provider, result=ok)` label pair.

`go test -race ./...` is green on both modules.