### PR TITLE
feat(obs): correlate accept lifecycle log lines via accept_id

### DIFF
--- a/e2e/accept_id_test.go
+++ b/e2e/accept_id_test.go
@@ -1,0 +1,200 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"net"
+	"regexp"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// TestAcceptID_Saturation drives a listener with --max-connections=5
+// past its semaphore cap with concurrent idle clients, then asserts
+// that the listener's debug log lines for the accept lifecycle
+// correlate via a stable accept_id and that every dropped accept
+// also carries one (with reason=semaphore_full).
+//
+// This gives operators a stable correlation key: a specific
+// dropped accept can be filtered out of a noisy log by its
+// accept_id, separately from the accepts that succeeded.
+//
+// Why hold idle clients instead of round-tripping data: idle clients
+// keep the listener-side semaphore slots occupied, so every accept
+// that arrives while N clients are connected gets a deterministic
+// path — either acquired (slots free) or dropped (slots full).
+// Round-trip echo would race with drop because connections complete
+// fast enough to free slots before the next accept arrives.
+func TestAcceptID_Saturation(t *testing.T) {
+	t.Parallel()
+	env := requireDedicatedHyco(t)
+
+	const (
+		maxConns  = 5
+		numClient = 20
+	)
+
+	for _, auth := range availableAuths(t, env) {
+		t.Run(auth.name, func(t *testing.T) {
+			echo := startEchoServer(t)
+			listener := startListener(t, env, auth,
+				"--allow", echo.Addr(),
+				"--max-connections", strconv.Itoa(maxConns),
+				"--metrics-addr", "127.0.0.1:0",
+				"--log-level", "debug",
+			)
+			sender := startPortForwardSender(t, env, auth, echo.Addr(),
+				"--log-level", "debug",
+			)
+
+			waitForLog(t, listener, "control channel connected", 30*time.Second)
+			listenerMetrics := listener.MetricsAddr(t, 15*time.Second)
+			senderAddr := waitForLogAddr(t, sender, "port-forward listening", 15*time.Second)
+
+			// Open numClient connections concurrently. Each holds the
+			// socket idle (no read/write) until close, so the
+			// listener-side semaphore stays saturated and excess
+			// accepts deterministically hit the drop path.
+			var (
+				mu        sync.Mutex
+				openConns []net.Conn
+				wg        sync.WaitGroup
+			)
+			for i := 0; i < numClient; i++ {
+				wg.Add(1)
+				go func() {
+					defer wg.Done()
+					conn, err := net.DialTimeout("tcp", senderAddr, 15*time.Second)
+					if err != nil {
+						// Sender accepts local TCP unconditionally; a
+						// dial failure here would indicate the sender
+						// is down, not a back-pressure signal.
+						t.Errorf("client dial: %v", err)
+						return
+					}
+					mu.Lock()
+					openConns = append(openConns, conn)
+					mu.Unlock()
+				}()
+			}
+			wg.Wait()
+			t.Cleanup(func() {
+				mu.Lock()
+				defer mu.Unlock()
+				for _, c := range openConns {
+					_ = c.Close()
+				}
+			})
+
+			// Saturate first (5 listener-side slots full), then wait
+			// for at least one drop to be logged. Both waits use the
+			// authoritative sources: the active gauge for capacity,
+			// the log line for the drop event we will then parse.
+			waitForMetric(t, listenerMetrics, "aztunnel_active_connections",
+				func(v float64) bool { return v >= maxConns }, 30*time.Second)
+			if _, ok := listener.logs.waitFor("accept dropped", 30*time.Second); !ok {
+				t.Fatalf("listener never logged 'accept dropped' (waited 30s; have %d clients open)", len(openConns))
+			}
+
+			// Parse listener stderr: group log lines by accept_id and
+			// inspect each group's contents. slog renders attrs as
+			// key=value, so a fixed-format regex over the 16-char
+			// base32 ID is precise enough to ignore unrelated lines.
+			groups := groupByAcceptID(listener.logs.String())
+			if len(groups) == 0 {
+				t.Fatalf("no log lines carried accept_id (listener stderr did not include any 16-char accept_id values)\n--- listener log ---\n%s",
+					listener.logs.String())
+			}
+
+			var (
+				droppedIDs    []string
+				acquiredIDs   []string
+				lifecycleSeen int
+			)
+			for id, lines := range groups {
+				kinds := classifyAcceptLines(lines)
+				if kinds["dropped"] {
+					droppedIDs = append(droppedIDs, id)
+					if !kinds["semaphore_full"] {
+						t.Errorf("accept_id %s: 'accept dropped' line missing reason=semaphore_full\n  lines: %v", id, lines)
+					}
+					if kinds["acquired"] || kinds["dial_started"] || kinds["dial_complete"] || kinds["released"] {
+						t.Errorf("accept_id %s: dropped accept also has lifecycle events — must be one or the other, never both\n  lines: %v", id, lines)
+					}
+					continue
+				}
+				if kinds["acquired"] {
+					acquiredIDs = append(acquiredIDs, id)
+					if kinds["dial_started"] && kinds["dial_complete"] {
+						lifecycleSeen++
+					}
+				}
+			}
+
+			if len(acquiredIDs) < maxConns {
+				t.Errorf("only %d distinct acquired accept_ids observed; want >= %d (maxConns)\n  groups=%d",
+					len(acquiredIDs), maxConns, len(groups))
+			}
+			if len(droppedIDs) == 0 {
+				t.Errorf("no dropped accept_ids observed despite %d clients vs maxConns=%d", numClient, maxConns)
+			}
+			if lifecycleSeen == 0 {
+				t.Errorf("no acquired accept_id had a full lifecycle (acquired + dial started + dial complete); want >= 1\n  acquired=%d, dropped=%d",
+					len(acquiredIDs), len(droppedIDs))
+			}
+		})
+	}
+}
+
+// acceptIDLineRe captures the 16-base32-char accept_id slog attribute
+// as rendered by NewTextHandler — `accept_id=<base32-16>`, terminated
+// by a word boundary. The charset is [A-Z2-7] per the idgen contract.
+var acceptIDLineRe = regexp.MustCompile(`accept_id=([A-Z2-7]{16})\b`)
+
+// groupByAcceptID scans every log line in raw, extracts accept_id from
+// any line that has one, and returns a map keyed by accept_id with the
+// matching lines as values. Lines without an accept_id are skipped.
+func groupByAcceptID(raw string) map[string][]string {
+	out := make(map[string][]string)
+	for _, line := range strings.Split(raw, "\n") {
+		m := acceptIDLineRe.FindStringSubmatch(line)
+		if m == nil {
+			continue
+		}
+		out[m[1]] = append(out[m[1]], line)
+	}
+	return out
+}
+
+// classifyAcceptLines flags which lifecycle events (and the structured
+// drop reason) appear across the lines for a single accept_id. The
+// returned map is keyed by short tags the test uses for its
+// assertions (no booleans are negated in the caller; missing keys
+// already read as false). Match the message text directly — slog's
+// TextHandler renders multi-word values quoted but its JSON form (and
+// future renderers) may not, and the message strings here are
+// distinctive enough that a bare substring match is unambiguous.
+func classifyAcceptLines(lines []string) map[string]bool {
+	kinds := make(map[string]bool)
+	for _, ln := range lines {
+		switch {
+		case strings.Contains(ln, "accept acquired"):
+			kinds["acquired"] = true
+		case strings.Contains(ln, "accept dropped"):
+			kinds["dropped"] = true
+		case strings.Contains(ln, "accept released"):
+			kinds["released"] = true
+		case strings.Contains(ln, "accept dial started"):
+			kinds["dial_started"] = true
+		case strings.Contains(ln, "accept dial complete"):
+			kinds["dial_complete"] = true
+		}
+		if strings.Contains(ln, "reason=semaphore_full") {
+			kinds["semaphore_full"] = true
+		}
+	}
+	return kinds
+}

--- a/internal/idgen/idgen.go
+++ b/internal/idgen/idgen.go
@@ -1,7 +1,7 @@
 // Package idgen mints short opaque identifiers used as log
 // correlation keys across the aztunnel observability surface
-// (bridge_id, listener_id, control_session_id; future accept_id and
-// related ids will join here).
+// (bridge_id, listener_id, control_session_id, accept_id; future
+// ids will join here).
 //
 // IDs are not security-sensitive — they exist to correlate
 // observations across components. All ids share one shape: 16
@@ -51,6 +51,19 @@ func NewListenerID() string {
 // mints a new id, letting operators mechanically split before-and-
 // after log streams. Panics on OS RNG failure (see NewBridgeID).
 func NewControlSessionID() string {
+	return newID()
+}
+
+// NewAcceptID returns a fresh, opaque correlation ID for a single
+// listener-side accept attempt. Callers bind the result onto their
+// slog logger with `logger.With("accept_id", id)` so every lifecycle
+// log line for that attempt (drop, acquire, rendezvous dial start,
+// rendezvous dial end, release) shares the same key — letting
+// operators group one accept's events with a single grep. An accept
+// that succeeds owns a distinct id from the bridge_id assigned later
+// by the sender; the two are not expected to be related. Panics on
+// OS RNG failure (see NewBridgeID).
+func NewAcceptID() string {
 	return newID()
 }
 

--- a/internal/idgen/idgen_test.go
+++ b/internal/idgen/idgen_test.go
@@ -136,7 +136,54 @@ func TestNewControlSessionID_NoCollisions(t *testing.T) {
 	}
 }
 
-// TestIDs_DistinctConstructors asserts the three constructors mint
+// TestNewAcceptID_Format mirrors TestNewBridgeID_Format for the
+// per-accept id. The format is a public contract because log
+// scrapers grep for accept_id=<value> across listener stderr; any
+// drift here breaks operator queries.
+func TestNewAcceptID_Format(t *testing.T) {
+	const want = 16
+	for i := 0; i < 32; i++ {
+		id := NewAcceptID()
+		if len(id) != want {
+			t.Fatalf("NewAcceptID() len = %d, want %d (id=%q)", len(id), want, id)
+		}
+		for j, c := range id {
+			ok := (c >= 'A' && c <= 'Z') || (c >= '2' && c <= '7')
+			if !ok {
+				t.Fatalf("NewAcceptID() id=%q: invalid char %q at %d", id, c, j)
+			}
+		}
+	}
+}
+
+// TestNewAcceptID_NoCollisions defends the 80-bit entropy claim for
+// accept ids. Each accept attempt mints a fresh id; collisions here
+// would silently merge the lifecycle log lines of unrelated accepts.
+func TestNewAcceptID_NoCollisions(t *testing.T) {
+	const n = 10_000
+	seen := make(map[string]struct{}, n)
+	for i := 0; i < n; i++ {
+		id := NewAcceptID()
+		if _, dup := seen[id]; dup {
+			t.Fatalf("collision after %d IDs: %q", i+1, id)
+		}
+		seen[id] = struct{}{}
+	}
+}
+
+// TestNewAcceptID_NotEmpty is a defence against the zero-value
+// regression — a caller that fails to call NewAcceptID and binds the
+// zero value onto a logger would emit accept_id="" on every log
+// line, silently breaking the correlation guarantee. A non-empty
+// contract here means "this function never produces that signal by
+// accident".
+func TestNewAcceptID_NotEmpty(t *testing.T) {
+	if NewAcceptID() == "" {
+		t.Fatalf("NewAcceptID() returned empty string")
+	}
+}
+
+// TestIDs_DistinctConstructors asserts the four constructors mint
 // independent values even though they share an internal helper. A
 // regression that collapsed them onto one source (e.g. a memoised
 // global) would defeat correlation by introducing matching ids
@@ -150,5 +197,14 @@ func TestIDs_DistinctConstructors(t *testing.T) {
 	}
 	if NewListenerID() == NewControlSessionID() {
 		t.Fatalf("expected distinct ids from independent constructors (listener vs control-session)")
+	}
+	if NewBridgeID() == NewAcceptID() {
+		t.Fatalf("expected distinct ids from independent constructors (bridge vs accept)")
+	}
+	if NewListenerID() == NewAcceptID() {
+		t.Fatalf("expected distinct ids from independent constructors (listener vs accept)")
+	}
+	if NewControlSessionID() == NewAcceptID() {
+		t.Fatalf("expected distinct ids from independent constructors (control-session vs accept)")
 	}
 }

--- a/internal/relay/control.go
+++ b/internal/relay/control.go
@@ -172,29 +172,47 @@ func runControlLoop(ctx context.Context, cfg ControlConfig) (connected bool, err
 			continue
 		}
 
+		// Mint a short-lived accept_id before the semaphore check so
+		// the drop path carries the same correlation key as the
+		// accepted path. Subsequent lifecycle log lines (acquire,
+		// release, rendezvous dial start/end) all go through
+		// acceptLogger so an operator can group them with one filter;
+		// the control_session_id binding on logger flows through so
+		// every accept line carries both attributes.
+		acceptID := idgen.NewAcceptID()
+		acceptLogger := logger.With("accept_id", acceptID)
+
 		if !sem.tryAcquire(loopCtx) {
-			logger.Warn("max connections reached, dropping accept")
+			acceptLogger.Warn("accept dropped", "reason", "semaphore_full")
 			continue
 		}
+		acceptLogger.Debug("accept acquired")
 
 		wg.Add(1)
-		go func(addr string) {
+		go func(addr string, logger *slog.Logger) {
 			defer wg.Done()
-			defer sem.release()
-			if err := handleAccept(loopCtx, addr, cfg); err != nil {
+			defer func() {
+				sem.release()
+				logger.Debug("accept released")
+			}()
+			if err := handleAccept(loopCtx, addr, cfg, logger); err != nil {
 				logger.Warn("accept failed", "error", err)
 			}
-		}(msg.Accept.Address)
+		}(msg.Accept.Address, acceptLogger)
 	}
 }
 
-func handleAccept(ctx context.Context, addr string, cfg ControlConfig) error {
+func handleAccept(ctx context.Context, addr string, cfg ControlConfig, logger *slog.Logger) error {
+	logger.Debug("accept dial started")
 	dialCtx, dialCancel := context.WithTimeout(ctx, cfg.DialTimeout)
 	defer dialCancel()
 	ws, _, err := websocket.Dial(dialCtx, addr, cfg.Options.dialOptions())
 	if err != nil {
-		return fmt.Errorf("dial rendezvous: %w", sanitizeErr(err))
+		sanitized := sanitizeErr(err)
+		logger.Debug("accept dial complete", "ok", false, "error", sanitized)
+		return fmt.Errorf("dial rendezvous: %w", sanitized)
 	}
+	logger.Debug("accept dial complete", "ok", true)
 	defer func() { _ = ws.CloseNow() }()
 
 	cfg.Handler(ctx, ws)

--- a/internal/relay/control_test.go
+++ b/internal/relay/control_test.go
@@ -105,7 +105,7 @@ func TestHandleAccept(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
 
-		err := handleAccept(ctx, "wss://"+testEndpoint(rendezvousSrv), cfg)
+		err := handleAccept(ctx, "wss://"+testEndpoint(rendezvousSrv), cfg, discardLogger())
 		if err != nil {
 			t.Fatalf("handleAccept returned error: %v", err)
 		}
@@ -130,7 +130,7 @@ func TestHandleAccept(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
 
-		err := handleAccept(ctx, "ws://127.0.0.1:1", cfg)
+		err := handleAccept(ctx, "ws://127.0.0.1:1", cfg, discardLogger())
 		if err == nil {
 			t.Fatal("expected error for bad address")
 		}
@@ -1118,4 +1118,389 @@ func extractSessionID(t *testing.T, rec *logRecorder) string {
 	}
 	t.Fatalf("no control_session_id in captured records: %s", string(rec.buf))
 	return ""
+}
+
+// ---------- TestAcceptID ----------
+
+// capStore is the shared backing store for captureHandler clones
+// produced by With/WithAttrs/WithGroup. Records always end up in the
+// same slice no matter which derived handler emits them.
+type capStore struct {
+	mu      sync.Mutex
+	records []capRecord
+}
+
+// capRecord is a single captured log emission with its attribute map
+// flattened across With(...) and Record-level attrs. Tests query
+// attrs by key (e.g. attrs["accept_id"]) instead of scraping the
+// rendered text.
+type capRecord struct {
+	level slog.Level
+	msg   string
+	attrs map[string]any
+}
+
+// captureHandler is a slog.Handler that snapshots every record into a
+// shared capStore. Used to assert structured attributes (accept_id,
+// reason, ok) on lifecycle log lines.
+type captureHandler struct {
+	store *capStore
+	attrs []slog.Attr
+}
+
+func newCaptureHandler() (*slog.Logger, *capStore) {
+	s := &capStore{}
+	return slog.New(&captureHandler{store: s}), s
+}
+
+func (h *captureHandler) Enabled(_ context.Context, _ slog.Level) bool { return true }
+
+func (h *captureHandler) Handle(_ context.Context, r slog.Record) error {
+	rec := capRecord{
+		level: r.Level,
+		msg:   r.Message,
+		attrs: make(map[string]any, len(h.attrs)+r.NumAttrs()),
+	}
+	for _, a := range h.attrs {
+		rec.attrs[a.Key] = a.Value.Any()
+	}
+	r.Attrs(func(a slog.Attr) bool {
+		rec.attrs[a.Key] = a.Value.Any()
+		return true
+	})
+	h.store.mu.Lock()
+	h.store.records = append(h.store.records, rec)
+	h.store.mu.Unlock()
+	return nil
+}
+
+func (h *captureHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	combined := make([]slog.Attr, 0, len(h.attrs)+len(attrs))
+	combined = append(combined, h.attrs...)
+	combined = append(combined, attrs...)
+	return &captureHandler{store: h.store, attrs: combined}
+}
+
+func (h *captureHandler) WithGroup(_ string) slog.Handler {
+	// Groups are unused in the relay package; preserve attrs unchanged
+	// so tests still see accept_id without group prefixing.
+	return &captureHandler{store: h.store, attrs: h.attrs}
+}
+
+// snapshot returns a copy of the captured records under the store
+// lock, so callers can iterate without racing the producer goroutines.
+func (s *capStore) snapshot() []capRecord {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]capRecord, len(s.records))
+	copy(out, s.records)
+	return out
+}
+
+// filterByMsg returns every captured record whose message equals msg.
+func (s *capStore) filterByMsg(msg string) []capRecord {
+	var out []capRecord
+	for _, r := range s.snapshot() {
+		if r.msg == msg {
+			out = append(out, r)
+		}
+	}
+	return out
+}
+
+// waitForRecord polls until at least one record matches msg, or the
+// deadline expires. Returns the first match, or zero-value + false on
+// timeout. Used to synchronise the test on lifecycle events (e.g.
+// wait until "accept acquired" is logged before sending the next
+// accept message) so the suite doesn't rely on time.Sleep heuristics.
+func (s *capStore) waitForRecord(msg string, timeout time.Duration) (capRecord, bool) {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if recs := s.filterByMsg(msg); len(recs) > 0 {
+			return recs[0], true
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	return capRecord{}, false
+}
+
+// TestAcceptID_StableAcrossLifecycle drives one accept through the
+// happy path (acquire → dial start → dial complete → release) and
+// asserts every lifecycle log line carries the same accept_id, so
+// operators can group them with a single filter.
+func TestAcceptID_StableAcrossLifecycle(t *testing.T) {
+	useInsecureTransport(t)
+
+	rendezvousSrv := tlsServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ws, err := websocket.Accept(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer ws.CloseNow()
+		// Block until the handler is done and the client closes.
+		for {
+			if _, _, err := ws.Read(r.Context()); err != nil {
+				return
+			}
+		}
+	}))
+	rendezvousAddr := "wss://" + testEndpoint(rendezvousSrv)
+
+	handlerDone := make(chan struct{})
+	controlSrv := tlsServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ws, err := websocket.Accept(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer ws.CloseNow()
+
+		msg := map[string]interface{}{
+			"accept": map[string]interface{}{
+				"address": rendezvousAddr,
+				"id":      "test-id-0",
+			},
+		}
+		data, _ := json.Marshal(msg)
+		if err := ws.Write(r.Context(), websocket.MessageText, data); err != nil {
+			return
+		}
+		// Wait for the in-process accept handler to finish, then close
+		// the control channel so runControlLoop returns and any
+		// deferred "accept released" line gets flushed before the
+		// test inspects the capture store.
+		select {
+		case <-handlerDone:
+		case <-time.After(3 * time.Second):
+		}
+		ws.Close(websocket.StatusNormalClosure, "done")
+	}))
+
+	// Cap test runtime well above the expected lifecycle round-trip
+	// but cancel proactively as soon as the expected records are
+	// observed (runControlLoop's deferred wg.Wait would otherwise sit
+	// on the renew/ping goroutines, which only exit on ctx.Done()).
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	logger, store := newCaptureHandler()
+	tp := &mockTokenProvider{token: "test-token"}
+	cfg := ControlConfig{
+		Endpoint:      testEndpoint(controlSrv),
+		EntityPath:    "test-entity",
+		TokenProvider: tp,
+		Handler: func(ctx context.Context, ws *websocket.Conn) {
+			close(handlerDone)
+		},
+		DialTimeout: 2 * time.Second,
+		Logger:      logger,
+	}
+
+	loopErrCh := make(chan error, 1)
+	go func() {
+		_, err := runControlLoop(ctx, cfg)
+		loopErrCh <- err
+	}()
+
+	// Wait for the deferred release line: that's the last lifecycle
+	// event for the accepted attempt and arrives after the goroutine
+	// returns. Once seen, cancel ctx so the renew/ping goroutines
+	// exit and runControlLoop unwinds promptly.
+	if _, ok := store.waitForRecord("accept released", 10*time.Second); !ok {
+		cancel()
+		<-loopErrCh
+		t.Fatalf("never observed 'accept released' (records=%v)", store.snapshot())
+	}
+	cancel()
+	if err := <-loopErrCh; err == nil {
+		t.Fatal("expected error from runControlLoop")
+	}
+
+	lifecycle := []string{"accept acquired", "accept dial started", "accept dial complete", "accept released"}
+	var acceptID string
+	for _, msg := range lifecycle {
+		recs := store.filterByMsg(msg)
+		if len(recs) == 0 {
+			t.Fatalf("no captured record with msg=%q (have %d total records)", msg, len(store.snapshot()))
+		}
+		id, ok := recs[0].attrs["accept_id"].(string)
+		if !ok || id == "" {
+			t.Fatalf("record msg=%q missing accept_id attribute (attrs=%v)", msg, recs[0].attrs)
+		}
+		if acceptID == "" {
+			acceptID = id
+		} else if id != acceptID {
+			t.Fatalf("record msg=%q accept_id=%q differs from first accept_id=%q — lifecycle lines must share one ID",
+				msg, id, acceptID)
+		}
+	}
+
+	// Dial-complete on the happy path reports ok=true.
+	dialComplete := store.filterByMsg("accept dial complete")
+	if got, want := dialComplete[0].attrs["ok"], true; got != want {
+		t.Errorf("accept dial complete: ok=%v, want %v", got, want)
+	}
+
+	// accept_id is a 16-char base32 [A-Z2-7] string (idgen contract).
+	if len(acceptID) != 16 {
+		t.Errorf("accept_id %q: want 16 base32 chars", acceptID)
+	}
+	for _, c := range acceptID {
+		ok := (c >= 'A' && c <= 'Z') || (c >= '2' && c <= '7')
+		if !ok {
+			t.Errorf("accept_id %q has non-base32 char %q", acceptID, c)
+			break
+		}
+	}
+}
+
+// TestAcceptID_PresentOnDrop saturates the listener-side semaphore
+// (MaxConnections=1, first accept blocks in-handler), then sends a
+// second accept that must drop. The dropped log line must carry an
+// accept_id distinct from the accepted one, plus a structured drop
+// reason — operators can filter on the dropped accept_id and find
+// no further lifecycle lines for it.
+func TestAcceptID_PresentOnDrop(t *testing.T) {
+	useInsecureTransport(t)
+
+	rendezvousSrv := tlsServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ws, err := websocket.Accept(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer ws.CloseNow()
+		for {
+			if _, _, err := ws.Read(r.Context()); err != nil {
+				return
+			}
+		}
+	}))
+	rendezvousAddr := "wss://" + testEndpoint(rendezvousSrv)
+
+	logger, store := newCaptureHandler()
+
+	// Buffered so the in-process handler's send always completes —
+	// the unbuffered+default form silently lost the only sync signal
+	// when the receiver hadn't yet reached its select case.
+	handlerEntered := make(chan struct{}, 1)
+	controlSrv := tlsServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ws, err := websocket.Accept(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer ws.CloseNow()
+
+		send := func(id string) error {
+			msg := map[string]interface{}{
+				"accept": map[string]interface{}{
+					"address": rendezvousAddr,
+					"id":      id,
+				},
+			}
+			data, _ := json.Marshal(msg)
+			return ws.Write(r.Context(), websocket.MessageText, data)
+		}
+
+		// First accept: must be acquired and held by the in-process
+		// handler (which blocks on context).
+		if err := send("first"); err != nil {
+			return
+		}
+		// Wait until the first handler actually entered (i.e. the
+		// semaphore slot is held) before sending the second accept.
+		// This removes the time.Sleep race that a slow CI runner
+		// could lose, where the second accept arrives before the
+		// first handler grabs the semaphore.
+		select {
+		case <-handlerEntered:
+		case <-time.After(5 * time.Second):
+			ws.Close(websocket.StatusNormalClosure, "first handler never entered")
+			return
+		}
+		// Second accept: semaphore is now full, must be dropped.
+		if err := send("second"); err != nil {
+			return
+		}
+
+		// Wait for the drop to be logged before closing so the test
+		// can observe it on the capture store deterministically.
+		if _, ok := store.waitForRecord("accept dropped", 5*time.Second); !ok {
+			ws.Close(websocket.StatusNormalClosure, "drop never logged")
+			return
+		}
+		ws.Close(websocket.StatusNormalClosure, "done")
+	}))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	tp := &mockTokenProvider{token: "test-token"}
+	cfg := ControlConfig{
+		Endpoint:       testEndpoint(controlSrv),
+		EntityPath:     "test-entity",
+		TokenProvider:  tp,
+		MaxConnections: 1,
+		Handler: func(ctx context.Context, ws *websocket.Conn) {
+			// Signal that we entered (the semaphore slot is held)
+			// then block until the control loop tears us down. The
+			// buffered+default pattern keeps the send non-blocking
+			// even though the buffer guarantees it always lands.
+			select {
+			case handlerEntered <- struct{}{}:
+			default:
+			}
+			<-ctx.Done()
+		},
+		DialTimeout: 2 * time.Second,
+		Logger:      logger,
+	}
+
+	loopErrCh := make(chan error, 1)
+	go func() {
+		_, err := runControlLoop(ctx, cfg)
+		loopErrCh <- err
+	}()
+
+	// Wait for both the acquired and dropped log lines, then cancel
+	// ctx to unwind runControlLoop promptly.
+	if _, ok := store.waitForRecord("accept acquired", 10*time.Second); !ok {
+		cancel()
+		<-loopErrCh
+		t.Fatalf("never observed 'accept acquired'")
+	}
+	if _, ok := store.waitForRecord("accept dropped", 10*time.Second); !ok {
+		cancel()
+		<-loopErrCh
+		t.Fatalf("never observed 'accept dropped' (records=%v)", store.snapshot())
+	}
+	cancel()
+	if err := <-loopErrCh; err == nil {
+		t.Fatal("expected error from runControlLoop when server closes")
+	}
+
+	acquired := store.filterByMsg("accept acquired")
+	dropped := store.filterByMsg("accept dropped")
+	if len(acquired) == 0 {
+		t.Fatalf("no 'accept acquired' record captured (have %d records total)", len(store.snapshot()))
+	}
+	if len(dropped) == 0 {
+		t.Fatalf("no 'accept dropped' record captured (have %d records total)", len(store.snapshot()))
+	}
+
+	acqID, _ := acquired[0].attrs["accept_id"].(string)
+	dropID, _ := dropped[0].attrs["accept_id"].(string)
+	if acqID == "" {
+		t.Errorf("accept acquired missing accept_id (attrs=%v)", acquired[0].attrs)
+	}
+	if dropID == "" {
+		t.Errorf("accept dropped missing accept_id (attrs=%v)", dropped[0].attrs)
+	}
+	if acqID == dropID {
+		t.Errorf("accept_id %q reused across accept lifecycle — each accept attempt must mint its own", acqID)
+	}
+	if got, want := dropped[0].attrs["reason"], "semaphore_full"; got != want {
+		t.Errorf("accept dropped reason=%v, want %v", got, want)
+	}
+	if got, want := dropped[0].level, slog.LevelWarn; got != want {
+		t.Errorf("accept dropped level=%v, want %v (drops are operator-actionable)", got, want)
+	}
 }


### PR DESCRIPTION
## Operator-visible improvement

Investigating a specific dropped accept used to require reasoning from timestamps — the "max connections reached" log line stood alone with no correlation to anything else. After this change, every log line emitted during one accept attempt — drop, acquire, release, rendezvous dial start, rendezvous dial end — carries the same `accept_id` attribute.

An operator can now filter the listener log by `accept_id=<base32-16>` to see whether a given accept was acquired or dropped, the reason it was dropped, and the lifecycle of accepts that succeeded.

## What changed

- The listener-side accept handler mints a fresh `accept_id` (16-char base32 NoPadding `[A-Z2-7]` / 10 random bytes, 80 bits of entropy, via `internal/idgen`) at the very start of each accept message processing — **before** the semaphore `tryAcquire` check, so the drop path carries the same correlation key as the accepted path.
- A per-accept logger is bound to that `accept_id` and used for every lifecycle event:
  - `accept dropped` — `level=Warn`, `reason=semaphore_full` (operator-actionable capacity signal)
  - `accept acquired`, `accept dial started`, `accept dial complete` (with `ok=true|false`), `accept released` — `level=Debug` (routine, avoids log spam)

## Scope

`accept_id` is logger-only by design. It is:

- **Not** added as a metric label (label cardinality concern, as flagged in the spec).
- **Not** threaded into the listener-side envelope-read / target-dial / bridge log lines in this PR — that is a candidate follow-up. The current scope covers the drop/acquire/release/rendezvous-dial lifecycle that lives in `internal/relay/control.go`.

## Tests

- `TestAcceptID_StableAcrossLifecycle` — drives one accept and asserts every lifecycle log line shares the same `accept_id`, plus validates the 16-char base32 shape.
- `TestAcceptID_PresentOnDrop` — saturates the semaphore (`MaxConnections=1`) and asserts the dropped accept carries its own `accept_id`, distinct from the acquired one, plus `reason=semaphore_full` at `level=Warn`.
- `TestAcceptID_Saturation` (e2e) — opens 20 idle TCP clients against a `--max-connections=5` listener, waits for at least one drop log line, parses listener stderr for `accept_id` groupings, and asserts at least one fully-acquired lifecycle and at least one dropped accept_id are present, with no accept_id appearing on both sides.

All run green under `go test -race`. Both modules' linters and the test suite pass locally.
