### PR TITLE
feat(e2e): permanent namespace SAS authorization rules

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -50,13 +50,15 @@ reaps anything left behind by killed runners.
 
 Authentication is via `DefaultAzureCredential`: `az login` for local
 development, OIDC federated workload identity for GitHub Actions. No SAS
-listener/sender keys need to be configured by hand — `TestMain` acquires
-two namespace-scoped authorization rules once per `go test` invocation
-(`e2e-run-<hex>-listener` for `Listen` and `e2e-run-<hex>-sender` for
-`Send`) via `azrelay.AcquireRunRules`, reads their keys via
-`Microsoft.Relay/...ListKeys`, and reuses them across every per-test SAS
-hyco. The rules are torn down on `TestMain` exit; the orphan janitor
-reaps anything left behind.
+listener/sender keys need to be configured by hand — the namespace
+holds two **permanent** namespace-scoped authorization rules,
+`e2e-listener` (Listen-only) and `e2e-sender` (Send-only), provisioned
+once by `e2e-infra setup` (or `e2e-infra ci`). `TestMain` reads their
+keys via `azrelay.AcquireRunRules` (a `Microsoft.Relay/...ListKeys`
+call against each permanent rule — no create / no delete) and reuses
+them across every per-test SAS hyco. The rules outlive every test
+invocation; the orphan janitor sweeps only hybrid connections, not
+authorization rules.
 
 ## Test Scenarios
 
@@ -136,14 +138,14 @@ out to no external tooling (no `az`, no `gh`, no `jq`).
 
 ### CLI Subcommands
 
-| Make target         | CLI subcommand                                 | Purpose                                                                                                     |
-| ------------------- | ---------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
-| `e2e-infra-setup`   | `e2e-infra setup`                              | Create RG + namespace + grant yourself `Azure Relay Owner`.                                                 |
-| `e2e-infra-ci`      | `e2e-infra ci`                                 | Above + Entra app + federated credential + GitHub secrets.                                                  |
-| `e2e-infra-clean`   | `e2e-infra clean --yes`                        | Delete the resource group (and everything in it).                                                           |
-| `e2e-infra-env`     | `e2e-infra env`                                | Print `export` statements for `E2E_*` and `AZURE_*` vars.                                                   |
-| `e2e-infra-janitor` | `e2e-infra janitor [--max-age 4h] [--dry-run]` | Delete orphan `e2e-{entra,sas}-<hex>` hycos AND `e2e-run-<hex>-{listener,sender}` rules older than max-age. |
-| (none)              | `e2e-infra grant --self\|--user\|--sp …`       | Grant `Azure Relay Owner` to a principal.                                                                   |
+| Make target         | CLI subcommand                                 | Purpose                                                                           |
+| ------------------- | ---------------------------------------------- | --------------------------------------------------------------------------------- |
+| `e2e-infra-setup`   | `e2e-infra setup`                              | Create RG + namespace + permanent SAS rules + grant yourself `Azure Relay Owner`. |
+| `e2e-infra-ci`      | `e2e-infra ci`                                 | Above + Entra app + federated credential + GitHub secrets.                        |
+| `e2e-infra-clean`   | `e2e-infra clean --yes`                        | Delete the resource group (and everything in it).                                 |
+| `e2e-infra-env`     | `e2e-infra env`                                | Print `export` statements for `E2E_*` and `AZURE_*` vars.                         |
+| `e2e-infra-janitor` | `e2e-infra janitor [--max-age 4h] [--dry-run]` | Delete orphan `e2e-{entra,sas}-<hex>` hycos older than max-age.                   |
+| (none)              | `e2e-infra grant --self\|--user\|--sp …`       | Grant `Azure Relay Owner` to a principal.                                         |
 
 ### Environment Variable Overrides
 
@@ -251,21 +253,19 @@ collisions between concurrent invocations are eliminated at the hyco level:
   longer required and are intentionally not provisioned by the new setup.
 - Hyco names are matched against `^e2e-(entra|sas)-[0-9a-f]{12}$` for the
   janitor, so any unrelated hycos in the namespace are not touched.
-- SAS authorization rules live at **namespace scope**, not per hyco: each
-  `go test` invocation provisions two rules
-  (`e2e-run-<hex>-listener` with Listen-only, `e2e-run-<hex>-sender` with
-  Send-only) once in `TestMain` via `azrelay.AcquireRunRules` and tears
-  them down on exit. Every per-test hyco signs SAS tokens with these
-  run-scoped keys. The two-rule split preserves the contract that a
-  listener key cannot send and vice versa
+- SAS authorization rules live at **namespace scope**, not per hyco,
+  and are permanent fixtures of the namespace: two rules
+  (`e2e-listener` with Listen-only, `e2e-sender` with Send-only) are
+  provisioned once by `e2e-infra setup` and reused across every
+  `go test` invocation. `TestMain` calls `azrelay.AcquireRunRules` to
+  read their primary keys via `ListKeys` — no create, no delete, no
+  per-test rule churn. Every per-test hyco signs SAS tokens with these
+  shared permanent keys. The two-rule split preserves the contract
+  that a listener key cannot send and vice versa
   (asserted by `TestWrongSASClaim`).
-- Run rules are matched against `^e2e-run-[0-9a-f]{12}-(listener|sender)$`
-  for the janitor, which sweeps orphaned rules with the same `--max-age`
-  rule as orphaned hycos.
-- Azure Relay caps authorization rules at 12 per namespace, and the
-  default `RootManageSharedAccessKey` rule consumes one of those
-  slots, so the two-rule-per-run design supports up to five
-  concurrent `go test` invocations in the same namespace before the
-  cap bites.
+- Permanent SAS rules keep the e2e-owned authorization-rule count
+  fixed at two (`e2e-listener` + `e2e-sender`), well below the
+  Azure Relay 12-rules-per-namespace cap, regardless of how many
+  `go test` invocations are running concurrently.
 - The relay namespace itself is shared across pipelines; only hybrid
-  connections are per-test and authorization rules are per-`go test`-run.
+  connections are per-test (authorization rules are permanent).

--- a/e2e/azrelay/provider.go
+++ b/e2e/azrelay/provider.go
@@ -123,8 +123,9 @@ func DefaultClientOptions() *arm.ClientOptions {
 // Provisioner: create entra hyco, create sas hyco. The returned
 // PairToken's Result is stamped with the namespace-scoped SAS rule
 // key info from p.cfg.RunRules. Teardown deletes both hycos; the
-// shared run-scoped rules live on past every PairToken and are
-// torn down by RunRules.Teardown from TestMain.
+// permanent run-scoped rules live on past every PairToken and are
+// not torn down by tests at all (they are provisioned once by
+// `e2e-infra setup` and outlive every test invocation).
 //
 // Provision blocks if the concurrency semaphore is full. The block
 // honours ctx.Done so callers (typically t.Cleanup-registered)

--- a/e2e/azrelay/provisioner.go
+++ b/e2e/azrelay/provisioner.go
@@ -45,12 +45,6 @@ var HycoNamePattern = regexp.MustCompile(`^e2e-(entra|sas)-[0-9a-f]{12}$`)
 // for any realistic CI volume.
 const suffixLen = 12
 
-// readinessMaxWait bounds how long readKey will retry ListKeys after a
-// rule create. ARM propagation is normally well under a second; we allow
-// more to absorb the occasional regional blip without forcing tests to
-// handle the transient 404 themselves.
-const readinessMaxWait = 30 * time.Second
-
 // Bounds on the createRule / bestEffortDelete retry loop that absorbs
 // the transient 40901 MessagingGatewayTooManyRequests conflict produced
 // when Azure Relay's control plane serialises authorizationRule
@@ -96,7 +90,7 @@ type Config struct {
 	// the single-use Provisioner type (it serialises by construction).
 	Concurrency int
 
-	// RunRules supplies the run-scoped namespace SAS rules whose keys
+	// RunRules supplies the namespace-permanent SAS rules whose keys
 	// every PairToken Result stamps onto its ListenerKey/SenderKey
 	// fields. Required for NewProvider and Provisioner; AcquireRunRules
 	// populates it.
@@ -175,7 +169,7 @@ func New(cfg Config) (*Provisioner, error) {
 }
 
 // Provision creates the Entra and SAS hybrid connections and stamps the
-// run-scoped SAS rule key info from cfg.RunRules onto the returned
+// namespace SAS rule key info from cfg.RunRules onto the returned
 // Result. If any step fails after a hyco has been created, Provision
 // attempts a best-effort teardown before returning the error so the
 // caller does not need to handle partial state.
@@ -311,9 +305,9 @@ func defaultAuthRuleRetry() authRuleRetry {
 // The function honours ctx cancellation between retries.
 //
 // Exposed for use by callers outside this package that mutate the same
-// Microsoft.Relay authorizationRules scope (e.g. the janitor's
-// sweep-and-delete loop), so they share the same retry envelope as
-// AcquireRunRules / RunRules.Teardown.
+// Microsoft.Relay authorizationRules scope — currently `e2e-infra`'s
+// namespace SAS-rule provisioning (Provisioner.EnsureRunRules) — so
+// they share the same 40901 retry envelope.
 func RetryOnAuthRuleConflict(ctx context.Context, fn func() error) error {
 	return retryOnAuthRuleConflict(ctx, defaultAuthRuleRetry(), fn)
 }

--- a/e2e/azrelay/runrules.go
+++ b/e2e/azrelay/runrules.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"regexp"
-	"sync"
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
@@ -13,65 +11,58 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/relay/armrelay"
 )
 
-// RunRuleNamePattern matches per-`go test` namespace authorization rules
-// created by AcquireRunRules. The janitor uses this exact pattern
-// (anchored) to identify orphaned run rules that should be cleaned up.
-// Listener and sender rules share the same 12-char suffix so a janitor
-// pass can trivially correlate the two halves of a run.
-var RunRuleNamePattern = regexp.MustCompile(`^e2e-run-[0-9a-f]{12}-(listener|sender)$`)
+// PermanentListenerRuleName is the well-known name of the Listen-only
+// namespace SAS authorization rule that every e2e test invocation reads
+// (never creates) at startup. Provisioned once per namespace by
+// e2e/infra/azure.Provisioner.EnsureRunRules (via `e2e-infra setup`).
+const PermanentListenerRuleName = "e2e-listener"
 
-// runRulePrefix is the common prefix of every run-scoped namespace
-// authorization rule. Listener and sender rules append the role
-// (and share the 12-char suffix) so the janitor can correlate the
-// two halves of a run.
-const runRulePrefix = "e2e-run-"
+// PermanentSenderRuleName is the well-known name of the Send-only
+// namespace SAS authorization rule that every e2e test invocation reads
+// at startup. See PermanentListenerRuleName.
+const PermanentSenderRuleName = "e2e-sender"
 
-// dataPlaneSettleAfterKeys gives Relay's data plane a brief grace
-// period to propagate a newly-created SAS auth rule after the control
-// plane (ListKeys) has acknowledged it. Without this, the first
-// handshake using the fresh key can observe a 401 before the rule has
-// converged across the data-plane nodes. Empirically a sub-second wait
-// suffices; 2s adds a comfortable margin. Paid once per RunRules
-// acquisition, not once per pair.
-const dataPlaneSettleAfterKeys = 2 * time.Second
+// readKeyMaxWait bounds how long readKey will retry ListKeys against a
+// transient ARM error. The permanent rules are long-lived, so the only
+// errors we expect to absorb here are regional control-plane blips.
+const readKeyMaxWait = 30 * time.Second
 
-// RunRules holds the two namespace-scoped authorization rules a single
-// `go test` invocation provisions: one Listen-only rule whose key the
-// relay-listener uses, and one Send-only rule whose key the
-// relay-sender uses. Both rules live at namespace scope, so the same
-// key authorizes the corresponding action against every hybrid
-// connection the run creates.
+// RunRules holds the two namespace-scoped SAS authorization rules every
+// e2e `go test` invocation shares: a Listen-only rule whose key the
+// relay-listener uses, and a Send-only rule whose key the relay-sender
+// uses. Both rules live at namespace scope, so the same key authorizes
+// the corresponding action against every hybrid connection the run
+// creates.
+//
+// The rules are permanent fixtures of the namespace (provisioned by
+// `e2e-infra setup` once, never deleted by tests). AcquireRunRules
+// reads their primary keys via ListKeys; it does NOT create or delete
+// rules. This keeps the e2e-owned authorization-rule count constant
+// at two regardless of how many parallel CI jobs target the
+// namespace, well within the Azure Relay namespace 12-rule cap.
 //
 // Two rules (not one combined Listen+Send rule) is deliberate: the
 // suite asserts that a listener key cannot be used to send and vice
 // versa (TestWrongSASClaim). A single rule with both rights would
 // silently pass that test.
 //
-// Acquire one with AcquireRunRules, propagate via Config.RunRules
-// into NewProvider, and defer Teardown from TestMain.
+// Acquire one with AcquireRunRules and propagate via Config.RunRules
+// into NewProvider.
 type RunRules struct {
 	ListenerName string
 	ListenerKey  string
 	SenderName   string
 	SenderKey    string
-
-	cfg    Config
-	ns     *armrelay.NamespacesClient
-	suffix string
-
-	teardownOnce sync.Once
-	teardownErr  error
 }
 
-// AcquireRunRules creates two namespace-scoped authorization rules in
-// cfg.Namespace — one Listen-only, one Send-only, both named
-// "e2e-run-<hex>-<role>" with a shared random 12-char suffix — reads
-// their primary keys, lets the data plane settle, and returns the
-// populated *RunRules.
+// AcquireRunRules reads the primary keys of the two permanent
+// namespace-scoped SAS authorization rules (PermanentListenerRuleName,
+// PermanentSenderRuleName) and returns a populated *RunRules.
 //
-// On any failure after a rule has been created, AcquireRunRules issues
-// a best-effort delete before returning the error, so the caller does
-// not need to handle partial state.
+// The rules must already exist in cfg.Namespace — provision them once
+// with `e2e-infra setup`. If either rule is missing, AcquireRunRules
+// returns an error whose message names the missing rule and points to
+// `e2e-infra setup`.
 //
 // cfg.RunRules is ignored by this function (the returned *RunRules is
 // what the caller would set on cfg.RunRules before constructing a
@@ -96,118 +87,54 @@ func AcquireRunRules(ctx context.Context, cfg Config) (*RunRules, error) {
 	if err != nil {
 		return nil, fmt.Errorf("new namespaces client: %w", err)
 	}
-	suffix, err := newSuffix()
+
+	listenerKey, err := readPermanentKey(ctx, ns, cfg, PermanentListenerRuleName)
 	if err != nil {
-		return nil, fmt.Errorf("generate suffix: %w", err)
+		return nil, err
 	}
-
-	r := &RunRules{
-		cfg:          cfg,
-		ns:           ns,
-		suffix:       suffix,
-		ListenerName: runRulePrefix + suffix + "-listener",
-		SenderName:   runRulePrefix + suffix + "-sender",
-	}
-
-	if err := r.createRule(ctx, r.ListenerName, armrelay.AccessRightsListen); err != nil {
-		r.bestEffortDelete(ctx, r.ListenerName)
-		return nil, fmt.Errorf("create %s: %w", r.ListenerName, err)
-	}
-	if err := r.createRule(ctx, r.SenderName, armrelay.AccessRightsSend); err != nil {
-		r.bestEffortDelete(ctx, r.ListenerName)
-		r.bestEffortDelete(ctx, r.SenderName)
-		return nil, fmt.Errorf("create %s: %w", r.SenderName, err)
-	}
-
-	listenerKey, err := r.readKey(ctx, r.ListenerName)
+	senderKey, err := readPermanentKey(ctx, ns, cfg, PermanentSenderRuleName)
 	if err != nil {
-		r.bestEffortDelete(ctx, r.ListenerName)
-		r.bestEffortDelete(ctx, r.SenderName)
-		return nil, fmt.Errorf("read %s key: %w", r.ListenerName, err)
+		return nil, err
 	}
-	senderKey, err := r.readKey(ctx, r.SenderName)
-	if err != nil {
-		r.bestEffortDelete(ctx, r.ListenerName)
-		r.bestEffortDelete(ctx, r.SenderName)
-		return nil, fmt.Errorf("read %s key: %w", r.SenderName, err)
-	}
-	r.ListenerKey = listenerKey
-	r.SenderKey = senderKey
-
-	select {
-	case <-ctx.Done():
-		r.bestEffortDelete(ctx, r.ListenerName)
-		r.bestEffortDelete(ctx, r.SenderName)
-		return nil, ctx.Err()
-	case <-time.After(dataPlaneSettleAfterKeys):
-	}
-
-	return r, nil
+	return &RunRules{
+		ListenerName: PermanentListenerRuleName,
+		ListenerKey:  listenerKey,
+		SenderName:   PermanentSenderRuleName,
+		SenderKey:    senderKey,
+	}, nil
 }
 
-// Teardown deletes both namespace authorization rules. Safe to call
-// multiple times: only the first call performs the deletes; subsequent
-// calls return the same error.
-//
-// Teardown strips cancellation from ctx (via context.WithoutCancel)
-// so cleanup completes even when ctx has been cancelled (e.g. on
-// TestMain timeout), but preserves any deadline the caller set. If
-// ctx has no deadline, Teardown applies a defensive 60s ceiling so a
-// stuck control plane cannot hang the run indefinitely.
-//
-// Individual delete failures are joined and returned. The janitor
-// (RunRuleNamePattern sweep) will reap anything we can't clean up
-// here.
-func (r *RunRules) Teardown(ctx context.Context) error {
-	r.teardownOnce.Do(func() {
-		ctx, cancel := detachAndBoundContext(ctx, 60*time.Second)
-		defer cancel()
-		var errs []error
-		if err := r.deleteRule(ctx, r.ListenerName); err != nil {
-			errs = append(errs, fmt.Errorf("delete %s: %w", r.ListenerName, err))
-		}
-		if err := r.deleteRule(ctx, r.SenderName); err != nil {
-			errs = append(errs, fmt.Errorf("delete %s: %w", r.SenderName, err))
-		}
-		if len(errs) > 0 {
-			r.teardownErr = errors.Join(errs...)
-		}
-	})
-	return r.teardownErr
-}
+// Teardown is a no-op: RunRules is read-only and the permanent rules
+// are owned by `e2e-infra setup`, surviving past every test invocation.
+// The method exists so callers can `defer rr.Teardown()` symmetrically
+// with other resource handles.
+func (r *RunRules) Teardown(ctx context.Context) error { return nil }
 
-func (r *RunRules) createRule(ctx context.Context, name string, right armrelay.AccessRights) error {
-	return retryOnAuthRuleConflict(ctx, defaultAuthRuleRetry(), func() error {
-		_, err := r.ns.CreateOrUpdateAuthorizationRule(ctx, r.cfg.ResourceGroup, r.cfg.Namespace, name, armrelay.AuthorizationRule{
-			Properties: &armrelay.AuthorizationRuleProperties{
-				Rights: []*armrelay.AccessRights{&right},
-			},
-		}, nil)
-		return err
-	})
-}
-
-// readKey fetches the primary key for the given namespace-scoped rule,
-// retrying on transient 404s that occasionally follow rule creation
-// before ARM has fully propagated the new entity. Bounded by
-// readinessMaxWait.
-func (r *RunRules) readKey(ctx context.Context, name string) (string, error) {
-	deadline := time.Now().Add(readinessMaxWait)
+// readPermanentKey fetches the primary key for the named permanent
+// rule, retrying briefly on transient ARM errors. A 404 is surfaced
+// with a hint pointing at `e2e-infra setup` — the most common cause is
+// running tests against a namespace that has not been provisioned yet.
+func readPermanentKey(ctx context.Context, ns *armrelay.NamespacesClient, cfg Config, name string) (string, error) {
+	deadline := time.Now().Add(readKeyMaxWait)
 	var lastErr error
 	for {
-		resp, err := r.ns.ListKeys(ctx, r.cfg.ResourceGroup, r.cfg.Namespace, name, nil)
+		resp, err := ns.ListKeys(ctx, cfg.ResourceGroup, cfg.Namespace, name, nil)
 		if err == nil {
 			if resp.PrimaryKey == nil {
-				return "", errors.New("ListKeys returned nil PrimaryKey")
+				return "", fmt.Errorf("ListKeys(%s) returned nil PrimaryKey", name)
 			}
 			return *resp.PrimaryKey, nil
 		}
 		lastErr = err
+		if isNotFound(err) {
+			return "", fmt.Errorf("permanent SAS rule %q (or its parent namespace %s/%s) not found — run `e2e-infra setup` to provision (or `e2e-infra ci` for CI setup): %w",
+				name, cfg.ResourceGroup, cfg.Namespace, err)
+		}
 		if !isTransient(err) {
-			return "", err
+			return "", fmt.Errorf("ListKeys(%s): %w", name, err)
 		}
 		if time.Now().After(deadline) {
-			return "", fmt.Errorf("ListKeys timed out after %s: %w", readinessMaxWait, lastErr)
+			return "", fmt.Errorf("ListKeys(%s) timed out after %s: %w", name, readKeyMaxWait, lastErr)
 		}
 		select {
 		case <-ctx.Done():
@@ -217,40 +144,8 @@ func (r *RunRules) readKey(ctx context.Context, name string) (string, error) {
 	}
 }
 
-func (r *RunRules) deleteRule(ctx context.Context, name string) error {
-	// Same per-scope serialization gate as createRule — back-to-back
-	// deletes on the namespace authorizationRules scope (listener
-	// immediately followed by sender) can race the gate and surface
-	// as 40901. The retry envelope is bounded; a stuck control plane
-	// still surfaces through retryOnAuthRuleConflict's "after N
-	// attempts" wrap.
-	return retryOnAuthRuleConflict(ctx, defaultAuthRuleRetry(), func() error {
-		_, err := r.ns.DeleteAuthorizationRule(ctx, r.cfg.ResourceGroup, r.cfg.Namespace, name, nil)
-		if err != nil && isNotFound(err) {
-			return nil
-		}
-		return err
-	})
-}
-
-// bestEffortDelete swallows errors. Used on the AcquireRunRules
-// failure path; the janitor will reap anything left behind. We also
-// retry 40901 here for the same reason createRule does — a not-yet-
-// committed create can race the cleanup delete.
-func (r *RunRules) bestEffortDelete(ctx context.Context, name string) {
-	ctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 30*time.Second)
-	defer cancel()
-	_ = retryOnAuthRuleConflict(ctx, defaultAuthRuleRetry(), func() error {
-		_, err := r.ns.DeleteAuthorizationRule(ctx, r.cfg.ResourceGroup, r.cfg.Namespace, name, nil)
-		if err != nil && isNotFound(err) {
-			return nil
-		}
-		return err
-	})
-}
-
 // validateForRunRules is the same as validate today (Subscription, RG,
-// Namespace required) but exists as a separate entry point so a future
+// Namespace required). Kept as a separate entry point so a future
 // addition of a "RunRules required" field on Config doesn't accidentally
 // short-circuit AcquireRunRules — which is what populates that field.
 func (c Config) validateForRunRules() error { return c.validate() }

--- a/e2e/azrelay/runrules_test.go
+++ b/e2e/azrelay/runrules_test.go
@@ -9,58 +9,32 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 )
 
-func TestRunRuleNamePattern(t *testing.T) {
-	cases := []struct {
-		name string
-		in   string
-		want bool
-	}{
-		{"valid listener", "e2e-run-0123456789ab-listener", true},
-		{"valid sender", "e2e-run-abcdef012345-sender", true},
-		{"missing role", "e2e-run-0123456789ab", false},
-		{"unknown role", "e2e-run-0123456789ab-admin", false},
-		{"short suffix", "e2e-run-0123456789a-listener", false},
-		{"long suffix", "e2e-run-0123456789abc-listener", false},
-		{"uppercase suffix", "e2e-run-0123456789AB-listener", false},
-		{"non-hex suffix", "e2e-run-0123456789xy-listener", false},
-		{"uppercase role", "e2e-run-0123456789ab-LISTENER", false},
-		{"wrong prefix", "e2e-rule-0123456789ab-listener", false},
-		{"unrelated name", "production-rule", false},
-		{"empty", "", false},
-		// Hyco names must NOT accidentally match.
-		{"hyco entra rejected", "e2e-entra-0123456789ab", false},
-		{"hyco sas rejected", "e2e-sas-0123456789ab", false},
+func TestPermanentRuleNamesAreStable(t *testing.T) {
+	// Pin the permanent rule names against accidental rename. The
+	// names are baked into operational tooling (`e2e-infra setup`
+	// provisions them; `az relay namespace authorization-rule …`
+	// is how maintainers manage them out-of-band), so changing
+	// them silently would orphan the existing rules and break
+	// every CI run.
+	if PermanentListenerRuleName != "e2e-listener" {
+		t.Errorf("PermanentListenerRuleName = %q, want %q (orphans the rule in every provisioned namespace if changed)",
+			PermanentListenerRuleName, "e2e-listener")
 	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			if got := RunRuleNamePattern.MatchString(tc.in); got != tc.want {
-				t.Errorf("RunRuleNamePattern.MatchString(%q) = %v, want %v", tc.in, got, tc.want)
-			}
-		})
+	if PermanentSenderRuleName != "e2e-sender" {
+		t.Errorf("PermanentSenderRuleName = %q, want %q (orphans the rule in every provisioned namespace if changed)",
+			PermanentSenderRuleName, "e2e-sender")
 	}
 }
 
-func TestRunRuleAndHycoPatternsAreDisjoint(t *testing.T) {
-	// Janitor relies on the two sweeps owning disjoint name spaces;
-	// regression-test the pair so a future rename can't silently
-	// cause one sweep to delete entities the other owns.
-	const suffix = "0123456789ab"
-	listener := "e2e-run-" + suffix + "-listener"
-	sender := "e2e-run-" + suffix + "-sender"
-	entra := "e2e-entra-" + suffix
-	sas := "e2e-sas-" + suffix
-
-	if !RunRuleNamePattern.MatchString(listener) || !RunRuleNamePattern.MatchString(sender) {
-		t.Fatalf("RunRuleNamePattern must match its own outputs (%s, %s)", listener, sender)
-	}
-	if HycoNamePattern.MatchString(listener) || HycoNamePattern.MatchString(sender) {
-		t.Fatalf("HycoNamePattern must not match run-rule names (%s, %s)", listener, sender)
-	}
-	if !HycoNamePattern.MatchString(entra) || !HycoNamePattern.MatchString(sas) {
-		t.Fatalf("HycoNamePattern must match its own outputs (%s, %s)", entra, sas)
-	}
-	if RunRuleNamePattern.MatchString(entra) || RunRuleNamePattern.MatchString(sas) {
-		t.Fatalf("RunRuleNamePattern must not match hyco names (%s, %s)", entra, sas)
+func TestPermanentRulesAreDistinctFromHycoPattern(t *testing.T) {
+	// The janitor sweeps hycos by HycoNamePattern. If a permanent
+	// rule name ever drifted into the hyco regex's match space, the
+	// janitor would attempt to delete the rule as a hyco — wrong
+	// resource type, but a regression worth pinning anyway.
+	for _, name := range []string{PermanentListenerRuleName, PermanentSenderRuleName} {
+		if HycoNamePattern.MatchString(name) {
+			t.Errorf("HycoNamePattern must not match permanent rule name %q", name)
+		}
 	}
 }
 
@@ -118,15 +92,36 @@ func TestValidateForRunRules_MirrorsValidate(t *testing.T) {
 	}
 }
 
+func TestTeardownIsNoOp(t *testing.T) {
+	// RunRules.Teardown is a no-op because the permanent rules are
+	// owned by `e2e-infra setup`. Pin that contract so a future
+	// refactor doesn't silently reintroduce delete-on-teardown —
+	// which would race every other in-flight CI run sharing the
+	// namespace.
+	rr := &RunRules{
+		ListenerName: PermanentListenerRuleName,
+		ListenerKey:  "listener-key",
+		SenderName:   PermanentSenderRuleName,
+		SenderKey:    "sender-key",
+	}
+	if err := rr.Teardown(t.Context()); err != nil {
+		t.Fatalf("Teardown should be a no-op, got error: %v", err)
+	}
+	// Idempotent — multiple calls remain safe.
+	if err := rr.Teardown(t.Context()); err != nil {
+		t.Fatalf("Teardown second call should still be a no-op, got error: %v", err)
+	}
+}
+
 // stubRunRules returns a non-nil *RunRules suitable only for satisfying
 // the Config.RunRules-required check in NewProvider for unit tests that
 // never reach the actual ARM rule-mutation path. Production callers
 // must go through AcquireRunRules.
 func stubRunRules() *RunRules {
 	return &RunRules{
-		ListenerName: "e2e-run-stubstubstub-listener",
+		ListenerName: PermanentListenerRuleName,
 		ListenerKey:  "stub-listener-key",
-		SenderName:   "e2e-run-stubstubstub-sender",
+		SenderName:   PermanentSenderRuleName,
 		SenderKey:    "stub-sender-key",
 	}
 }

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -18,10 +18,11 @@
 // via azrelay.Provider in TestMain and tears them down via t.Cleanup.
 // SAS keys are not configured by hand: TestMain acquires two namespace-
 // scoped authorization rules once per `go test` invocation (Listen-only
-// and Send-only, named e2e-run-<hex>-{listener,sender}) via
+// and Send-only, named e2e-listener and e2e-sender) via
 // azrelay.AcquireRunRules, and Provider.Provision stamps the resulting
-// keys onto every per-test SAS hyco. The run rules are torn down on
-// TestMain exit; the orphan janitor reaps anything left behind.
+// keys onto every per-test SAS hyco. The rules are permanent fixtures
+// of the namespace, not torn down on TestMain exit; the orphan janitor
+// sweeps stale hycos only.
 //
 // Functional tests run against all available auth methods (entra, sas)
 // unless E2E_AUTH=entra or E2E_AUTH=sas is set to pin one.
@@ -253,10 +254,10 @@ func TestSASKeyAuth(t *testing.T) {
 	env := requireDedicatedHyco(t)
 	// requireDedicatedHyco always returns a fully-populated SAS pair:
 	// the per-test SAS hyco is created by Provider.Provision, and the
-	// listener/sender keys are stamped from the run-scoped namespace
-	// rules acquired once by AcquireRunRules in TestMain. The defensive
-	// check here flags a Provider contract regression rather than a
-	// contributor mis-configuration.
+	// listener/sender keys are stamped from the permanent namespace
+	// rules whose keys were read once by AcquireRunRules in TestMain.
+	// The defensive check here flags a Provider contract regression
+	// rather than a contributor mis-configuration.
 	if env.sasHyco == "" || env.sasListenerKeyName == "" || env.sasListenerKey == "" || env.sasSenderKeyName == "" || env.sasSenderKey == "" {
 		var missing []string
 		if env.sasHyco == "" {

--- a/e2e/helpers_test.go
+++ b/e2e/helpers_test.go
@@ -43,9 +43,7 @@ type authConfig struct {
 // hycoProvisionTimeout bounds a single Provider.Provision call from
 // requireDedicatedHyco. The provisioner already retries 429s and
 // transient 5xx through azcore (MaxRetries=6, MaxRetryDelay=60s); per-
-// pair provisioning no longer mutates authorization rules, so the
-// 40901 retry loop in retryOnAuthRuleConflict is only paid once per
-// `go test` invocation (by AcquireRunRules), not per Provision. This
+// pair provisioning does not mutate authorization rules, so this
 // ceiling stops a genuinely stuck control plane from hanging the test
 // until the suite-wide go-test -timeout fires.
 const hycoProvisionTimeout = 3 * time.Minute

--- a/e2e/infra/azure/runrules.go
+++ b/e2e/infra/azure/runrules.go
@@ -1,0 +1,119 @@
+package azure
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"sort"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/relay/armrelay"
+
+	"github.com/philsphicas/aztunnel/e2e/azrelay"
+)
+
+// EnsureRunRules idempotently provisions the two permanent
+// namespace-scoped SAS authorization rules every e2e test invocation
+// reads at startup: PermanentListenerRuleName (Listen) and
+// PermanentSenderRuleName (Send). Both rules live at namespace scope
+// so the same key authorizes the corresponding action against every
+// hybrid connection the test suite creates.
+//
+// Two rules (not one combined Listen+Send rule): TestWrongSASClaim
+// asserts that a listener key cannot send and a sender key cannot
+// listen; a single rule with both rights would silently pass that
+// test.
+//
+// Permanent rules (not per-test or per-run rules): the Azure Relay
+// namespace caps at 12 SAS authorization rules, and a shared CI
+// namespace serving many parallel test invocations must keep its
+// rule count constant.
+//
+// EnsureRunRules is safe to call repeatedly. Existing rules with the
+// expected name and rights are left alone; rules with the expected
+// name but wrong rights are corrected via CreateOrUpdate (idempotent
+// upsert); missing rules are created. The namespace must already
+// exist — EnsureNamespace / DiscoverNamespace must be called first.
+func (p *Provisioner) EnsureRunRules(ctx context.Context) error {
+	relay, err := p.DiscoverNamespace(ctx)
+	if err != nil {
+		return fmt.Errorf("discover namespace: %w", err)
+	}
+	if err := p.ensureOneRunRule(ctx, relay, azrelay.PermanentListenerRuleName, armrelay.AccessRightsListen); err != nil {
+		return err
+	}
+	if err := p.ensureOneRunRule(ctx, relay, azrelay.PermanentSenderRuleName, armrelay.AccessRightsSend); err != nil {
+		return err
+	}
+	return nil
+}
+
+// ensureOneRunRule provisions a single permanent namespace SAS rule
+// with exactly one access right. It first GETs the rule to surface
+// whether it already exists with the expected rights (the common
+// no-op path on rerun); otherwise it CreateOrUpdate-upserts. Any
+// not-found from the GET is treated as "create"; any other error is
+// returned. The upsert path is wrapped in RetryOnAuthRuleConflict
+// to absorb Azure Relay's per-scope 40901 throttle, which can fire
+// when two parallel `e2e-infra setup` invocations race against each
+// other or when listener and sender upserts land back-to-back on a
+// fresh namespace.
+func (p *Provisioner) ensureOneRunRule(ctx context.Context, namespace, name string, right armrelay.AccessRights) error {
+	got, err := p.nsClient.GetAuthorizationRule(ctx, p.cfg.ResourceGroup, namespace, name, nil)
+	switch {
+	case err == nil:
+		if rightsMatch(got.AuthorizationRule, right) {
+			fmt.Fprintf(os.Stderr, "    · rule %s: already present with rights=%s\n", name, right)
+			return nil
+		}
+		fmt.Fprintf(os.Stderr, "    ! rule %s: rights drifted (%v); restoring to [%s]\n",
+			name, currentRights(got.AuthorizationRule), right)
+	case azrelay.IsNotFound(err):
+		fmt.Fprintf(os.Stderr, "    + rule %s: creating with rights=[%s]\n", name, right)
+	default:
+		return fmt.Errorf("get rule %s: %w", name, err)
+	}
+	rights := []*armrelay.AccessRights{&right}
+	if err := azrelay.RetryOnAuthRuleConflict(ctx, func() error {
+		_, err := p.nsClient.CreateOrUpdateAuthorizationRule(ctx, p.cfg.ResourceGroup, namespace, name, armrelay.AuthorizationRule{
+			Properties: &armrelay.AuthorizationRuleProperties{Rights: rights},
+		}, nil)
+		return err
+	}); err != nil {
+		return fmt.Errorf("ensure rule %s: %w", name, err)
+	}
+	fmt.Fprintf(os.Stderr, "    ✓ rule %s: ready (rights=[%s])\n", name, right)
+	return nil
+}
+
+// rightsMatch reports whether the rule's Rights slice contains exactly
+// `want` and nothing else, order-insensitive and duplicate-insensitive.
+// Duplicate-insensitive is on `currentRights`, which dedupes; ARM
+// theoretically returns each right once but we're defensive.
+func rightsMatch(rule armrelay.AuthorizationRule, want armrelay.AccessRights) bool {
+	got := currentRights(rule)
+	if len(got) != 1 {
+		return false
+	}
+	return got[0] == string(want)
+}
+
+// currentRights returns the rule's Rights as a sorted, deduplicated
+// slice of strings for diagnostic printing and comparison. Nil-safe.
+func currentRights(rule armrelay.AuthorizationRule) []string {
+	if rule.Properties == nil {
+		return nil
+	}
+	seen := make(map[string]struct{}, len(rule.Properties.Rights))
+	for _, r := range rule.Properties.Rights {
+		if r == nil {
+			continue
+		}
+		seen[string(*r)] = struct{}{}
+	}
+	out := make([]string, 0, len(seen))
+	for r := range seen {
+		out = append(out, r)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/e2e/infra/cmd/e2e-infra/main.go
+++ b/e2e/infra/cmd/e2e-infra/main.go
@@ -5,14 +5,12 @@
 //
 // Subcommands:
 //
-//	setup      — Create namespace + RG + grant self Azure Relay Owner
+//	setup      — Create namespace + permanent SAS rules + grant self Azure Relay Owner
 //	ci         — setup + create Entra app + federated credential + GitHub secrets
 //	clean      — Delete the resource group (and everything in it)
 //	grant      — Grant Azure Relay Owner to a principal
 //	env        — Print the env vars required to run e2e tests locally
-//	janitor    — Delete orphan e2e-{entra,sas}-<hex> hycos AND
-//	             e2e-run-<hex>-{listener,sender} namespace SAS rules
-//	             older than --max-age
+//	janitor    — Delete orphan e2e-{entra,sas}-<hex> hycos older than --max-age
 package main
 
 import (
@@ -36,12 +34,12 @@ var CLI struct {
 	ResourceGroup string `name:"resource-group" env:"RESOURCE_GROUP" default:"aztunnel-e2e" help:"Resource group containing the relay namespace."`
 	RelayName     string `name:"relay-name" env:"RELAY_NAME" help:"Relay namespace name (auto-generated from subscription + RG if empty)."`
 
-	Setup   SetupCmd   `cmd:"" help:"Create namespace + grant self Azure Relay Owner."`
-	CI      CICmd      `cmd:"" help:"Full CI setup: namespace + Entra app + GitHub secrets."`
+	Setup   SetupCmd   `cmd:"" help:"Create namespace + permanent SAS rules + grant self Azure Relay Owner."`
+	CI      CICmd      `cmd:"" help:"Full CI setup: namespace + permanent SAS rules + Entra app + GitHub secrets."`
 	Clean   CleanCmd   `cmd:"" help:"Delete the resource group."`
 	Grant   GrantCmd   `cmd:"" help:"Grant Azure Relay Owner to a principal."`
 	Env     EnvCmd     `cmd:"" help:"Print E2E_* env vars for local test runs."`
-	Janitor JanitorCmd `cmd:"" help:"Delete orphan e2e-{entra,sas}-<hex> hycos AND e2e-run-<hex>-{listener,sender} namespace SAS rules."`
+	Janitor JanitorCmd `cmd:"" help:"Delete orphan e2e-{entra,sas}-<hex> hycos."`
 }
 
 // SetupCmd creates the resource group + relay namespace and grants the
@@ -62,6 +60,9 @@ func (c *SetupCmd) Run(ctx context.Context) error {
 	}
 	if _, err := prov.EnsureNamespace(ctx); err != nil {
 		return fmt.Errorf("ensure namespace: %w", err)
+	}
+	if err := prov.EnsureRunRules(ctx); err != nil {
+		return fmt.Errorf("ensure run rules: %w", err)
 	}
 	if c.SkipRBAC {
 		fmt.Fprintln(os.Stderr, "    (skipping RBAC per --skip-rbac)")
@@ -95,6 +96,9 @@ func (c *CICmd) Run(ctx context.Context) error {
 	}
 	if _, err := prov.EnsureNamespace(ctx); err != nil {
 		return fmt.Errorf("ensure namespace: %w", err)
+	}
+	if err := prov.EnsureRunRules(ctx); err != nil {
+		return fmt.Errorf("ensure run rules: %w", err)
 	}
 	if err := prov.GrantOwnerSelf(ctx); err != nil {
 		return fmt.Errorf("grant self: %w", err)
@@ -200,10 +204,9 @@ func (c *EnvCmd) Run(ctx context.Context) error {
 	return nil
 }
 
-// JanitorCmd deletes orphan per-invocation hycos and per-run namespace
-// SAS rules older than --max-age.
+// JanitorCmd deletes orphan per-invocation hycos older than --max-age.
 type JanitorCmd struct {
-	MaxAge time.Duration `name:"max-age" default:"4h" help:"Delete e2e-{entra,sas}-<hex> hycos AND e2e-run-<hex>-{listener,sender} rules older than this."`
+	MaxAge time.Duration `name:"max-age" default:"4h" help:"Delete e2e-{entra,sas}-<hex> hycos older than this."`
 	DryRun bool          `name:"dry-run" help:"Print what would be deleted without deleting."`
 }
 

--- a/e2e/infra/janitor/janitor.go
+++ b/e2e/infra/janitor/janitor.go
@@ -1,7 +1,6 @@
-// Package janitor deletes orphan per-invocation hybrid connections and
-// per-`go test`-run namespace authorization rules from the aztunnel E2E
-// relay namespace. Names are matched against azrelay.HycoNamePattern
-// and azrelay.RunRuleNamePattern so static bootstrap entities and any
+// Package janitor deletes orphan per-invocation hybrid connections from
+// the aztunnel E2E relay namespace. Names are matched against
+// azrelay.HycoNamePattern so static bootstrap entities and any
 // unrelated entities in the namespace are not touched.
 package janitor
 
@@ -32,11 +31,11 @@ type Config struct {
 	Cred azcore.TokenCredential
 }
 
-// Run lists hycos AND namespace authorization rules in the namespace,
-// filters by name pattern and age, and deletes the matching orphans.
-// Per-delete errors are logged but do not abort the run; the function
-// returns the first list-time error or nil if everything succeeded
-// (a non-zero per-delete failure count surfaces as the return error).
+// Run lists hycos in the namespace, filters by name pattern and age,
+// and deletes the matching orphans. Per-delete errors are logged but
+// do not abort the run; the function returns the first list-time
+// error or nil if everything succeeded (a non-zero per-delete failure
+// count surfaces as the return error).
 func Run(ctx context.Context, cfg Config) error {
 	if cfg.SubscriptionID == "" || cfg.ResourceGroup == "" || cfg.Namespace == "" {
 		return fmt.Errorf("janitor: SubscriptionID, ResourceGroup, Namespace are required")
@@ -51,10 +50,6 @@ func Run(ctx context.Context, cfg Config) error {
 	if err != nil {
 		return fmt.Errorf("new hybrid connections client: %w", err)
 	}
-	nsClient, err := armrelay.NewNamespacesClient(cfg.SubscriptionID, cfg.Cred, nil)
-	if err != nil {
-		return fmt.Errorf("new namespaces client: %w", err)
-	}
 	now := time.Now().UTC()
 	threshold := now.Add(-cfg.MaxAge)
 
@@ -65,12 +60,8 @@ func Run(ctx context.Context, cfg Config) error {
 	if err != nil {
 		return err
 	}
-	ruleFailed, err := sweepRunRules(ctx, nsClient, cfg, now, threshold)
-	if err != nil {
-		return err
-	}
-	if total := hycoFailed + ruleFailed; total > 0 {
-		return fmt.Errorf("%d delete(s) failed", total)
+	if hycoFailed > 0 {
+		return fmt.Errorf("%d delete(s) failed", hycoFailed)
 	}
 	return nil
 }
@@ -136,81 +127,9 @@ func sweepHycos(ctx context.Context, client *armrelay.HybridConnectionsClient, c
 	return failed, nil
 }
 
-func sweepRunRules(ctx context.Context, client *armrelay.NamespacesClient, cfg Config, now, threshold time.Time) (failed int, err error) {
-	pager := client.NewListAuthorizationRulesPager(cfg.ResourceGroup, cfg.Namespace, nil)
-	var matched, deleted, missingCreatedAt int
-	for pager.More() {
-		page, err := pager.NextPage(ctx)
-		if err != nil {
-			return 0, fmt.Errorf("list authorization rules: %w", err)
-		}
-		for _, rule := range page.Value {
-			if rule == nil || rule.Name == nil {
-				continue
-			}
-			name := *rule.Name
-			if !azrelay.RunRuleNamePattern.MatchString(name) {
-				continue
-			}
-			matched++
-			created := ruleCreatedAt(rule)
-			if created.IsZero() {
-				full, getErr := client.GetAuthorizationRule(ctx, cfg.ResourceGroup, cfg.Namespace, name, nil)
-				if getErr != nil {
-					fmt.Fprintf(os.Stderr, "    ? rule %s: list missing createdAt; GET failed: %v; skipping\n", name, getErr)
-					missingCreatedAt++
-					continue
-				}
-				created = ruleCreatedAt(&full.AuthorizationRule)
-				if created.IsZero() {
-					fmt.Fprintf(os.Stderr, "    ? rule %s: createdAt unavailable after GET; skipping\n", name)
-					missingCreatedAt++
-					continue
-				}
-			}
-			age := now.Sub(created)
-			if created.After(threshold) {
-				fmt.Fprintf(os.Stderr, "    · rule %s: age=%s < max-age; skipping\n", name, age.Round(time.Second))
-				continue
-			}
-			if cfg.DryRun {
-				fmt.Fprintf(os.Stderr, "    - rule %s: age=%s; would delete (dry-run)\n", name, age.Round(time.Second))
-				continue
-			}
-			if err := azrelay.RetryOnAuthRuleConflict(ctx, func() error {
-				_, err := client.DeleteAuthorizationRule(ctx, cfg.ResourceGroup, cfg.Namespace, name, nil)
-				if err != nil && azrelay.IsNotFound(err) {
-					return nil
-				}
-				return err
-			}); err != nil {
-				fmt.Fprintf(os.Stderr, "    ! rule %s: delete failed: %v\n", name, err)
-				failed++
-				continue
-			}
-			fmt.Fprintf(os.Stderr, "    ✓ rule %s: age=%s; deleted\n", name, age.Round(time.Second))
-			deleted++
-		}
-	}
-	fmt.Fprintf(os.Stderr, "==> janitor rules: matched=%d deleted=%d failed=%d missing-createdAt=%d\n",
-		matched, deleted, failed, missingCreatedAt)
-	if missingCreatedAt > 0 {
-		fmt.Fprintf(os.Stderr, "==> janitor: WARNING: %d of %d matched rule(s) were missing createdAt and could not be aged — orphan-reaping is degraded\n",
-			missingCreatedAt, matched)
-	}
-	return failed, nil
-}
-
 func hcCreatedAt(hc *armrelay.HybridConnection) time.Time {
 	if hc == nil || hc.Properties == nil || hc.Properties.CreatedAt == nil {
 		return time.Time{}
 	}
 	return hc.Properties.CreatedAt.UTC()
-}
-
-func ruleCreatedAt(rule *armrelay.AuthorizationRule) time.Time {
-	if rule == nil || rule.SystemData == nil || rule.SystemData.CreatedAt == nil {
-		return time.Time{}
-	}
-	return rule.SystemData.CreatedAt.UTC()
 }

--- a/e2e/testmain_test.go
+++ b/e2e/testmain_test.go
@@ -26,24 +26,18 @@ import (
 // own their own Teardown via t.Cleanup in requireDedicatedHyco.
 var relayProvider *azrelay.Provider
 
-// runRules holds the two namespace-scoped SAS authorization rules
-// (Listen-only + Send-only) provisioned once at TestMain startup and
-// shared by every PairToken's Result. Teardown is deferred from
-// testMain so the rules are released on every normal exit path; the
-// janitor reaps anything we leak (e.g. on os.Exit before defers).
+// runRules holds the two permanent namespace-scoped SAS authorization
+// rules (Listen-only + Send-only) provisioned out-of-band by
+// `e2e-infra setup`. The keys are read once at TestMain startup and
+// shared by every PairToken's Result. There is no per-run teardown —
+// the rules outlive every test invocation.
 var runRules *azrelay.RunRules
 
-// runRuleAcquireTimeout bounds the namespace-rule provisioning step
-// in TestMain. Two CreateOrUpdateAuthorizationRule + two ListKeys
-// + the 2 s data-plane settle; with the SDK's 6-retry tail factored
-// in, the worst-case observed wall-clock is well under a minute. 90 s
-// gives comfortable headroom for a regional blip without letting a
+// runRuleAcquireTimeout bounds the namespace-rule key-fetch step in
+// TestMain. Two ListKeys round-trips against permanent rules. 90 s
+// gives comfortable headroom for a regional ARM blip without letting a
 // stuck control plane hang the suite.
 const runRuleAcquireTimeout = 90 * time.Second
-
-// runRuleTeardownTimeout bounds the deferred Teardown call. Two
-// DeleteAuthorizationRule round-trips against the namespace.
-const runRuleTeardownTimeout = 60 * time.Second
 
 // TestMain constructs the process-scoped relay Provider so every
 // test can call requireDedicatedHyco to provision its own private
@@ -111,12 +105,13 @@ func testMain(m *testing.M) int {
 		Concurrency:    conc,
 	}
 
-	// Acquire the run-scoped namespace SAS rules. Two rules
-	// (e2e-run-<hex>-listener with Listen, e2e-run-<hex>-sender with
-	// Send) are created once here and stamped onto every PairToken
-	// Result by Provider.Provision; per-test provisioning no longer
-	// touches authorizationRules. Failures here are fatal — without
-	// the rules the SAS auth path can't function. No defers earlier
+	// Acquire the namespace SAS rule keys. The rules
+	// (e2e-listener with Listen, e2e-sender with Send) are permanent
+	// fixtures of the namespace provisioned once by `e2e-infra setup`;
+	// AcquireRunRules only reads their ListKeys output and never
+	// creates or deletes rules. Hyco provisioning never mutates
+	// authorization rules either. Failures here are fatal — without
+	// the keys the SAS auth path can't function. No defers earlier
 	// than this point need to skip on the fatal path because nothing
 	// has been provisioned yet.
 	acquireCtx, acquireCancel := context.WithTimeout(context.Background(), runRuleAcquireTimeout)
@@ -129,27 +124,10 @@ func testMain(m *testing.M) int {
 	fmt.Fprintf(os.Stderr, "==> e2e: run rules ready (listener=%s, sender=%s)\n",
 		rr.ListenerName, rr.SenderName)
 
-	// Defer rule teardown FIRST so it runs LAST on the LIFO stack —
-	// every subsequently-deferred cleanup (e.g. drainBenchLease,
-	// below) gets to use the SAS rules while it still tears down
-	// in-flight state. The janitor reaps anything we leak (os.Exit
-	// paths skip defers).
-	defer func() {
-		ctx, cancel := context.WithTimeout(context.Background(), runRuleTeardownTimeout)
-		defer cancel()
-		if err := rr.Teardown(ctx); err != nil {
-			fmt.Fprintf(os.Stderr, "==> e2e: teardown run rules %s/%s: %v\n",
-				rr.ListenerName, rr.SenderName, err)
-		}
-	}()
-
 	// Drain the shared bench hyco lease on every exit path, including
-	// panics that the testing framework recovers from. Registered
-	// AFTER the run-rule teardown defer so it runs BEFORE rule
-	// teardown (Go defers are LIFO) — keeps the SAS rules alive for
-	// any hyco-cleanup-time data-plane work the benchmark teardown
-	// path may grow in the future. Today tok.Teardown is ARM-only,
-	// so the order is currently not load-bearing.
+	// panics that the testing framework recovers from. The permanent
+	// SAS rules are not torn down here (they outlive the test
+	// invocation), so this is the only TestMain-level cleanup defer.
 	defer drainBenchLease()
 
 	cfg.RunRules = rr


### PR DESCRIPTION
## Summary

Promotes the two namespace-scoped SAS authorization rules
(`Listen` and `Send`) used by the e2e suite from per-`go test`-run
ephemeral lifecycle to **permanent fixtures** of the Azure Relay
namespace, eliminating the Azure Relay
`UpdateManifestFailedWithAuthorizationRulesCountExceeded` race against
the 12-rule-per-namespace cap that we hit under parallel CI load.

## Behavior change

Before: every `go test ./e2e/...` invocation creates
`e2e-run-<hex>-listener` and `e2e-run-<hex>-sender` once in `TestMain`,
then tears them down on exit. With per-ref CI concurrency (not
per-namespace), 6+ parallel PRs * 2 rules each + the default root rule
saturates the namespace's 12-rule budget and at least one job fails
with HTTP 400 `UpdateManifestFailedWithAuthorizationRulesCountExceeded`.

After: the two rules (`e2e-listener` and `e2e-sender`) are provisioned
**once** by `e2e-infra setup` / `e2e-infra ci`, persist across every
test invocation, and are read-only from the test path. Regardless of
how many concurrent CI jobs target the shared namespace, the namespace
always holds exactly three rules (root + listener + sender). The
two-rule split (rather than one combined Listen+Send rule) is
deliberately preserved because `TestWrongSASClaim` asserts a listener
key cannot send and vice versa.

## What's in here

- `e2e-infra setup` and `e2e-infra ci` now also call
  `EnsureRunRules`, which is idempotent (GET → match-no-op /
  drift-CreateOrUpdate / missing-CreateOrUpdate) and wrapped in the
  existing 40901-conflict retry envelope to absorb Azure Relay's
  per-scope throttle on fresh provisioning.
- `azrelay.AcquireRunRules` is now read-only (ListKeys against two
  known names; no Create, no Delete, no suffix generation).
- `RunRules.Teardown` is a no-op for source compatibility, pinned by
  `TestTeardownIsNoOp` to prevent a future refactor from silently
  reintroducing delete-on-teardown.
- Janitor's `sweepRunRules` pass is removed; only hyco sweeping
  remains. Janitor `--max-age` retention now applies exclusively to
  hybrid connections.
- Error messages on missing permanent rules point operators at
  `e2e-infra setup` and acknowledge that the same 404 can come from
  a missing parent namespace.
- `e2e/README.md` rewritten in the three places that described the
  retired per-run rule lifecycle.

## Net diff

`+321 / -410` across 11 files; most of the net deletion comes from
runrules.go, testmain_test.go, and janitor.go (less rule-lifecycle
machinery to maintain).

## Roll-forward note

The permanent rules are already provisioned on the live CI namespace
(`aztunnel-84ca56512bfa` in `aztunnel-e2e`); this PR is safe to merge
in any order relative to in-flight test PRs. After merge, in-flight
PRs that previously hit the 12-rule cap can rerun e2e and will pass
with zero rule creation.

## Verification

- [x] `go build ./...` clean on both modules
- [x] `go test ./...` passes on both modules
- [x] `go vet ./...` clean on both modules
- [x] `golangci-lint run ./...` clean on both modules
- [x] Live `e2e-infra setup` against the CI namespace is idempotent
- [x] Live `TestWrongSASClaim` against the CI namespace PASSES via the
      read-only ListKeys path; zero rule churn observed.
