### PR TITLE
feat(obs): include classified code in listener dial-failure log

### DIFF
--- a/internal/listener/listener.go
+++ b/internal/listener/listener.go
@@ -40,6 +40,10 @@ type Config struct {
 	// startup. Tests that drive handleConnection directly may set it
 	// to a known string for deterministic assertions.
 	ListenerID string
+
+	// dialContext optionally overrides target dialing. When nil,
+	// handleConnection uses a net.Dialer honouring ConnectTimeout.
+	dialContext func(ctx context.Context, network, addr string) (net.Conn, error)
 }
 
 // applyDefaults fills in zero-valued config fields with their
@@ -149,16 +153,21 @@ func handleConnection(ctx context.Context, ws *websocket.Conn, cfg Config) {
 	}
 
 	// Dial the target.
-	dialer := &net.Dialer{Timeout: cfg.ConnectTimeout}
+	dial := cfg.dialContext
+	if dial == nil {
+		dialer := &net.Dialer{Timeout: cfg.ConnectTimeout}
+		dial = dialer.DialContext
+	}
 	dialCtx, cancel := context.WithTimeout(ctx, cfg.ConnectTimeout)
 	defer cancel()
 
 	dialStart := time.Now()
-	conn, err := dialer.DialContext(dialCtx, "tcp", env.Target)
+	conn, err := dial(dialCtx, "tcp", env.Target)
 	cfg.Metrics.ObserveDialDuration("listener", time.Since(dialStart).Seconds())
 	if err != nil {
-		logger.Warn("dial target failed", "target", env.Target, "error", err)
-		_ = sendResponseWithCode(ctx, ws, cfg, false, "connection failed", classifyDialError(err))
+		code := classifyDialError(err)
+		logger.Warn("dial target failed", "target", env.Target, "error", err, "code", code)
+		_ = sendResponseWithCode(ctx, ws, cfg, false, "connection failed", code)
 		cfg.Metrics.ConnectionError("listener", metrics.DialReason(err, metrics.ReasonDialFailed))
 		return
 	}

--- a/internal/listener/listener_test.go
+++ b/internal/listener/listener_test.go
@@ -477,3 +477,139 @@ func driveCustomHandshake(t *testing.T, cfg Config, send func(ctx context.Contex
 	}
 	return resp
 }
+
+// runDialFailureHandler drives one handleConnection invocation against
+// an in-process WebSocket pair, returning the captured slog output
+// after the handler has fully returned. The injected dial stub is the
+// seam these tests use to provoke specific dial outcomes without
+// touching the real network.
+//
+// Synchronisation contract: the test closes the client side, the
+// handler returns, the handler-side goroutine signals `done`, and
+// only then does this helper read the slog buffer — so the log
+// snapshot is happens-before-stable when callers grep it.
+func runDialFailureHandler(t *testing.T, target string,
+	dial func(ctx context.Context, network, addr string) (net.Conn, error),
+) string {
+	t.Helper()
+
+	var logBuf bytes.Buffer
+	cfg := Config{
+		ConnectTimeout: 5 * time.Second,
+		Logger:         slog.New(slog.NewTextHandler(&logBuf, nil)),
+		Metrics:        metrics.New(),
+		dialContext:    dial,
+	}
+
+	done := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defer close(done)
+		ws, err := websocket.Accept(w, r, nil)
+		if err != nil {
+			t.Errorf("server accept: %v", err)
+			return
+		}
+		defer ws.CloseNow() //nolint:errcheck // best-effort cleanup
+		handleConnection(r.Context(), ws, cfg)
+	}))
+	t.Cleanup(srv.Close)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	wsURL := "ws" + strings.TrimPrefix(srv.URL, "http")
+	ws, _, err := websocket.Dial(ctx, wsURL, nil)
+	if err != nil {
+		t.Fatalf("dial websocket: %v", err)
+	}
+	defer ws.CloseNow() //nolint:errcheck // best-effort cleanup
+
+	env := protocol.ConnectEnvelope{
+		Version:  protocol.CurrentVersion,
+		Target:   target,
+		BridgeID: "TESTBRIDGE2P25Z",
+	}
+	envBytes, err := json.Marshal(env)
+	if err != nil {
+		t.Fatalf("marshal envelope: %v", err)
+	}
+	if err := ws.Write(ctx, websocket.MessageText, envBytes); err != nil {
+		t.Fatalf("write envelope: %v", err)
+	}
+
+	// Read the failure response so the handler has a clean exit path
+	// rather than being torn down mid-write by the client close.
+	if _, _, err := ws.Read(ctx); err != nil {
+		t.Fatalf("read response: %v", err)
+	}
+	_ = ws.Close(websocket.StatusNormalClosure, "done")
+
+	select {
+	case <-done:
+	case <-ctx.Done():
+		t.Fatalf("handler did not return within deadline: %v", ctx.Err())
+	}
+	return logBuf.String()
+}
+
+func TestListener_DialFailed_LogIncludesCode_Refused(t *testing.T) {
+	stub := func(ctx context.Context, network, addr string) (net.Conn, error) {
+		return nil, &net.OpError{Op: "dial", Net: network, Err: syscall.ECONNREFUSED}
+	}
+	logs := runDialFailureHandler(t, "127.0.0.1:9", stub)
+
+	assertDialFailureLog(t, logs, "127.0.0.1:9", protocol.CodeConnectionRefused)
+}
+
+func TestListener_DialFailed_LogIncludesCode_Timeout(t *testing.T) {
+	stub := func(ctx context.Context, network, addr string) (net.Conn, error) {
+		return nil, &net.OpError{Op: "dial", Net: network, Err: context.DeadlineExceeded}
+	}
+	logs := runDialFailureHandler(t, "192.0.2.1:9", stub)
+
+	assertDialFailureLog(t, logs, "192.0.2.1:9", protocol.CodeTimeout)
+}
+
+func TestListener_DialFailed_LogIncludesCode_Unclassified(t *testing.T) {
+	stub := func(ctx context.Context, network, addr string) (net.Conn, error) {
+		return nil, errors.New("synthetic failure")
+	}
+	logs := runDialFailureHandler(t, "10.0.0.1:22", stub)
+
+	// Empty code means the classifier did not match; slog renders it
+	// as code="" so operators see explicit evidence rather than a
+	// silently absent attribute.
+	assertDialFailureLog(t, logs, "10.0.0.1:22", "")
+}
+
+// assertDialFailureLog requires the captured listener output to
+// contain at least one "dial target failed" line for the given target,
+// and that the first such line carries the expected code attribute
+// (rendered as code=VALUE for non-empty values and code="" for the
+// unclassified case). Each test drives exactly one failed dial through
+// runDialFailureHandler, so the helper does not need to enforce
+// single-match uniqueness explicitly.
+func assertDialFailureLog(t *testing.T, logs, target, code string) {
+	t.Helper()
+	var hit string
+	for _, line := range strings.Split(logs, "\n") {
+		if !strings.Contains(line, `msg="dial target failed"`) {
+			continue
+		}
+		if !strings.Contains(line, "target="+target) {
+			continue
+		}
+		hit = line
+		break
+	}
+	if hit == "" {
+		t.Fatalf("no 'dial target failed' line for target=%s in logs:\n%s", target, logs)
+	}
+	want := `code=` + code
+	if code == "" {
+		want = `code=""`
+	}
+	if !strings.Contains(hit, want) {
+		t.Fatalf("dial-failure log missing %q:\n%s", want, hit)
+	}
+}

--- a/internal/testharness/relayparity/observability.go
+++ b/internal/testharness/relayparity/observability.go
@@ -27,6 +27,7 @@ func RunObservabilitySuite(t *testing.T, b Backend) {
 		{"BridgeID_Correlation", ScenarioBridgeID_Correlation},
 		{"ControlSessionID_OnConnectedLine", ScenarioControlSessionID_OnConnectedLine},
 		{"SenderLogsCode_OnConnectFailure", ScenarioSenderLogsCode_OnConnectFailure},
+		{"ListenerDialFailureLog_CarriesCode", ScenarioListenerDialFailureLog_CarriesCode},
 	}
 	for _, sc := range scenarios {
 		t.Run(sc.name, func(t *testing.T) {
@@ -358,4 +359,75 @@ func ScenarioSenderLogsCode_OnConnectFailure(t *testing.T, b Backend) {
 		"target="+refused,
 		"code=connection_refused",
 	)
+}
+
+// ScenarioListenerDialFailureLog_CarriesCode asserts that the
+// listener's "dial target failed" slog line carries the same
+// machine-readable classification (code=...) the listener already
+// returns in its ConnectResponse. Operators triaging a dispatcher
+// trace can read this code straight from the log without round-
+// tripping through the metric surface or a packet capture.
+//
+// Two sub-cases share one tunnel:
+//
+//   - Refused: 127.0.0.1:<closed-port> always classifies to the
+//     exact code=connection_refused on every backend.
+//   - Unreachable: 192.0.2.1:9 (RFC 5737 TEST-NET-1) classifies to
+//     one of code=timeout / code=host_unreachable /
+//     code=network_unreachable depending on whether the host sees
+//     ICMP-unreachable before ConnectTimeout fires; all three are
+//     valid wirings of the field.
+func ScenarioListenerDialFailureLog_CarriesCode(t *testing.T, b Backend) {
+	t.Helper()
+	AssertNoLeaks(t)
+
+	refused := refusedAddr(t)
+	const unreachable = "192.0.2.1:9"
+	tun := b.Setup(t, SetupOptions{
+		NumListeners:   1,
+		SenderMode:     ModeSOCKS5,
+		AllowedTargets: []string{refused, unreachable},
+		ConnectTimeout: 4 * time.Second,
+	})
+	requireLogs(t, tun)
+
+	t.Run("Refused", func(t *testing.T) {
+		_, err := DialSOCKS5(tun.SenderAddr, refused, 15*time.Second)
+		var sErr *SOCKS5Error
+		if !errors.As(err, &sErr) {
+			t.Fatalf("socks5 dial refused: expected SOCKS5Error, got %T: %v", err, err)
+		}
+		if sErr.Rep != 0x05 {
+			t.Fatalf("socks5 REP for refused = %#x, want 0x05", sErr.Rep)
+		}
+
+		// waitForLogLineContaining is the assertion: it fails the test
+		// unless a single line contains all three needles.
+		waitForLogLineContaining(t, tun.Listeners[0].Logs, 10*time.Second,
+			`msg="dial target failed"`, "target="+refused, "code=connection_refused")
+	})
+
+	t.Run("Unreachable", func(t *testing.T) {
+		_, err := DialSOCKS5(tun.SenderAddr, unreachable, 30*time.Second)
+		var sErr *SOCKS5Error
+		if !errors.As(err, &sErr) {
+			t.Fatalf("socks5 dial unreachable: expected SOCKS5Error, got %T: %v", err, err)
+		}
+
+		line := waitForLogLineContaining(t, tun.Listeners[0].Logs, 10*time.Second,
+			`msg="dial target failed"`, "target="+unreachable)
+
+		accepted := []string{"code=timeout", "code=host_unreachable", "code=network_unreachable"}
+		ok := false
+		for _, want := range accepted {
+			if strings.Contains(line, want) {
+				ok = true
+				break
+			}
+		}
+		if !ok {
+			t.Fatalf("listener dial-failure log for unreachable carried no accepted code (want one of %v):\n%s",
+				accepted, line)
+		}
+	})
 }


### PR DESCRIPTION
The listener's `dial target failed` slog line now carries the same machine-readable failure code (`code=connection_refused`, `code=timeout`, …) that the listener already returns to the sender in its `ConnectResponse` and uses for the `connection_errors` metric reason.

Before this PR an operator tailing the listener log saw the human-readable error message but not the classified bucket, forcing a round-trip through `/metrics` or a packet capture to confirm which failure category fired. After this PR a single `grep 'dial target failed' | grep 'code='` reads the failure reason straight from the log line, and per-bridge correlation via `bridge_id=` continues to work alongside it.

Drive-by: `classifyDialError` is hoisted into a local so it runs once per failed dial instead of twice (the result feeds both the protocol response and the new log attribute).

### Verification

- `go test -race ./...` and `(cd mockrelay && go test -race ./...)` pass locally.
- Three new unit tests in `internal/listener/listener_test.go` cover refused, timeout, and unclassified codes via an injected dial stub.
- New parity scenario `ListenerDialFailureLog_CarriesCode` runs on both mockrelay (always-on) and Azure (under `//go:build e2e`), with sub-cases for refused (exact `code=connection_refused`) and unreachable (accepts any of `timeout`/`host_unreachable`/`network_unreachable` because the kernel's ICMP behaviour around RFC 5737 TEST-NET-1 varies).
