### PR TITLE
feat(obs): log WebSocket close code on bridge end

### DIFF
--- a/cmd/aztunnel/arc_port_forward.go
+++ b/cmd/aztunnel/arc_port_forward.go
@@ -121,7 +121,11 @@ func (p *ArcPortForwardCmd) Run(globals *Globals, arcCmd *ArcCmd) error {
 
 			_, bridgeErr := m.TrackedBridge(ctx, ws, conn, "sender", target)
 			if bridgeErr != nil {
-				logger.Debug("bridge ended", "error", bridgeErr)
+				attrs := []any{"error", bridgeErr}
+				if code, ok := relay.WSCloseCode(bridgeErr); ok {
+					attrs = append(attrs, "close_code", code)
+				}
+				logger.Debug("bridge ended", attrs...)
 			}
 		}()
 	}

--- a/internal/listener/listener.go
+++ b/internal/listener/listener.go
@@ -102,7 +102,11 @@ func handleConnection(ctx context.Context, ws *websocket.Conn, cfg Config) {
 	defer readCancel()
 	_, data, err := ws.Read(readCtx)
 	if err != nil {
-		logger.Warn("failed to read envelope", "error", err)
+		attrs := []any{"error", err}
+		if code, ok := relay.WSCloseCode(err); ok {
+			attrs = append(attrs, "close_code", code)
+		}
+		logger.Warn("failed to read envelope", attrs...)
 		cfg.Metrics.ConnectionError("listener", metrics.ReasonEnvelopeError)
 		return
 	}
@@ -172,7 +176,11 @@ func handleConnection(ctx context.Context, ws *websocket.Conn, cfg Config) {
 	// Bridge data.
 	_, bridgeErr := cfg.Metrics.TrackedBridge(ctx, ws, conn, "listener", env.Target)
 	if bridgeErr != nil {
-		logger.Debug("bridge ended", "target", env.Target, "error", bridgeErr)
+		attrs := []any{"target", env.Target, "error", bridgeErr}
+		if code, ok := relay.WSCloseCode(bridgeErr); ok {
+			attrs = append(attrs, "close_code", code)
+		}
+		logger.Debug("bridge ended", attrs...)
 	}
 }
 

--- a/internal/relay/bridge.go
+++ b/internal/relay/bridge.go
@@ -115,6 +115,28 @@ func ignoreNormalClose(err error) error {
 	return err
 }
 
+// WSCloseCode extracts the WebSocket close-status code from a Bridge
+// error when the error unwraps to a websocket.CloseError. Returns
+// (code, true) when it does, (0, false) for nil errors and for any
+// error that does not unwrap to a websocket.CloseError. The
+// websocket.CloseError set includes synthesised codes that the
+// library reports without an on-the-wire close frame (notably 1006
+// StatusAbnormalClosure when the connection drops). Use this on the
+// result of Bridge() to attach a structured close_code field to
+// bridge-end log lines so operators can distinguish remote-initiated
+// close from policy violation from relay server error without
+// parsing the error string.
+func WSCloseCode(err error) (int, bool) {
+	if err == nil {
+		return 0, false
+	}
+	var closeErr websocket.CloseError
+	if errors.As(err, &closeErr) {
+		return int(closeErr.Code), true
+	}
+	return 0, false
+}
+
 func ignoreEOF(err error) error {
 	if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
 		return nil

--- a/internal/relay/bridge_test.go
+++ b/internal/relay/bridge_test.go
@@ -2,6 +2,8 @@ package relay
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"io"
 	"net"
 	"net/http"
@@ -267,5 +269,48 @@ func TestBridge_ZeroLengthData(t *testing.T) {
 
 	if !strings.Contains(string(total), "after-empty") {
 		t.Errorf("did not receive expected data, got %q", string(total))
+	}
+}
+
+func TestWSCloseCode_Nil_ReturnsFalse(t *testing.T) {
+	code, ok := WSCloseCode(nil)
+	if ok {
+		t.Errorf("ok=true on nil error; want false")
+	}
+	if code != 0 {
+		t.Errorf("code=%d on nil error; want 0", code)
+	}
+}
+
+func TestWSCloseCode_Plain_ReturnsFalse(t *testing.T) {
+	code, ok := WSCloseCode(errors.New("synthetic"))
+	if ok {
+		t.Errorf("ok=true on plain error; want false")
+	}
+	if code != 0 {
+		t.Errorf("code=%d on plain error; want 0", code)
+	}
+}
+
+func TestWSCloseCode_DirectCloseError(t *testing.T) {
+	err := websocket.CloseError{Code: 1006, Reason: "abnormal"}
+	code, ok := WSCloseCode(err)
+	if !ok {
+		t.Fatalf("ok=false on websocket.CloseError; want true")
+	}
+	if code != 1006 {
+		t.Errorf("code=%d; want 1006", code)
+	}
+}
+
+func TestWSCloseCode_WrappedCloseError(t *testing.T) {
+	inner := websocket.CloseError{Code: 1011, Reason: "server error"}
+	wrapped := fmt.Errorf("read response: %w", inner)
+	code, ok := WSCloseCode(wrapped)
+	if !ok {
+		t.Fatalf("ok=false on wrapped CloseError; want true")
+	}
+	if code != 1011 {
+		t.Errorf("code=%d; want 1011", code)
 	}
 }

--- a/internal/sender/portforward.go
+++ b/internal/sender/portforward.go
@@ -114,7 +114,11 @@ func forwardConnection(ctx context.Context, conn net.Conn, target string, cfg Po
 	// Bridge data.
 	_, bridgeErr := cfg.Metrics.TrackedBridge(ctx, ws, conn, "sender", target)
 	if bridgeErr != nil {
-		logger.Warn("forward failed", "error", bridgeErr)
+		attrs := []any{"error", bridgeErr}
+		if code, ok := relay.WSCloseCode(bridgeErr); ok {
+			attrs = append(attrs, "close_code", code)
+		}
+		logger.Warn("forward failed", attrs...)
 	}
 	return bridgeErr
 }
@@ -220,6 +224,9 @@ func logRejection(logger *slog.Logger, target, listenerID string, err error) {
 	attrs := []any{"target", target, "error", err}
 	if listenerID != "" {
 		attrs = append(attrs, "listener_id", listenerID)
+	}
+	if code, ok := relay.WSCloseCode(err); ok {
+		attrs = append(attrs, "close_code", code)
 	}
 	logger.Warn("envelope exchange failed", attrs...)
 }

--- a/internal/sender/socks5proxy.go
+++ b/internal/sender/socks5proxy.go
@@ -134,7 +134,11 @@ func handleSOCKS5(ctx context.Context, conn net.Conn, cfg SOCKS5Config) error {
 	// Bridge data.
 	_, bridgeErr := cfg.Metrics.TrackedBridge(ctx, ws, conn, "sender", target)
 	if bridgeErr != nil {
-		logger.Warn("socks5 failed", "error", bridgeErr)
+		attrs := []any{"error", bridgeErr}
+		if code, ok := relay.WSCloseCode(bridgeErr); ok {
+			attrs = append(attrs, "close_code", code)
+		}
+		logger.Warn("socks5 failed", attrs...)
 	}
 	return bridgeErr
 }

--- a/mockrelay/testharness/parity/ws_close_code_test.go
+++ b/mockrelay/testharness/parity/ws_close_code_test.go
@@ -1,0 +1,252 @@
+package parity
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/tls"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"log/slog"
+	"net"
+	"net/http/httptest"
+	"net/url"
+	"regexp"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/philsphicas/aztunnel/internal/listener"
+	"github.com/philsphicas/aztunnel/internal/metrics"
+	"github.com/philsphicas/aztunnel/internal/relay"
+	"github.com/philsphicas/aztunnel/internal/sender"
+	"github.com/philsphicas/aztunnel/mockrelay/server"
+)
+
+// TestMockOnly_WSCloseCodeOnEnvelopeRead exercises the listener-side
+// "failed to read envelope" log enrichment by arming the mock relay's
+// WithCloseCodeOnAccept fault knob. Each subtest drives one
+// port-forward bridge attempt: the mock closes the listener-rendezvous
+// WebSocket with the configured close code before the listener can
+// read the connect envelope, and we assert the listener's
+// envelope-read failure log carries close_code=<code>.
+//
+// Mockrelay-only because the knob is a testing-only fault-injection
+// hook with no Azure analogue — Azure Relay does not surface
+// configurable non-normal close codes on demand.
+//
+// The mock's accept knob fires before envelope round-trip, so the
+// post-bridge "bridge ended" log path on the listener and the
+// post-bridge "forward failed" / "socks5 failed" paths on the sender
+// are NOT exercised here. Their close_code wiring is the same call
+// shape as the path covered here (relay.WSCloseCode + slog attr
+// append); the WSCloseCode helper itself is unit-tested in
+// internal/relay/bridge_test.go.
+func TestMockOnly_WSCloseCodeOnEnvelopeRead(t *testing.T) {
+	cases := []struct {
+		name string
+		code int
+	}{
+		{"Code1011_ServerError", 1011},
+		{"Code4400_AppDefined", 4400},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			runWSCloseCodeCase(t, tc.code)
+		})
+	}
+}
+
+// runWSCloseCodeCase brings up an in-process listener + port-forward
+// sender against a mock relay armed with WithCloseCodeOnAccept(code),
+// triggers one connection attempt, and asserts the listener's
+// "failed to read envelope" log line carries close_code=<code>.
+func runWSCloseCodeCase(t *testing.T, code int) {
+	t.Helper()
+
+	host, clientOpts := startMockRelayWithCloseCode(t, code)
+
+	entity := mockOnlyEntity(t)
+	tokenProvider := &relay.SASTokenProvider{
+		KeyName: server.DefaultSASKeyName,
+		Key:     server.DefaultSASKey,
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	var wg sync.WaitGroup
+	t.Cleanup(func() {
+		cancel()
+		wg.Wait()
+	})
+
+	echo := startCloseCodeEcho(t)
+
+	listenerLogs := newCaptureBuffer()
+	listenerMetrics := metrics.New()
+	listenerLogger := slog.New(slog.NewTextHandler(listenerLogs, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		err := listener.ListenAndServe(ctx, listener.Config{
+			Endpoint:      host,
+			EntityPath:    entity,
+			TokenProvider: tokenProvider,
+			ClientOptions: clientOpts,
+			AllowList:     []string{echo.Addr().String()},
+			Logger:        listenerLogger,
+			Metrics:       listenerMetrics,
+		})
+		if err != nil && ctx.Err() == nil {
+			t.Logf("listener exited: %v", err)
+		}
+	}()
+	if !waitForGauge(listenerMetrics, "aztunnel_control_channel_connected", 1, 15*time.Second) {
+		t.Fatalf("listener never reported control_channel_connected")
+	}
+
+	senderLogs := newCaptureBuffer()
+	senderLogger := slog.New(slog.NewTextHandler(senderLogs, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	senderAddrCh := make(chan net.Addr, 1)
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		err := sender.PortForward(ctx, sender.PortForwardConfig{
+			Endpoint:      host,
+			EntityPath:    entity,
+			TokenProvider: tokenProvider,
+			ClientOptions: clientOpts,
+			Target:        echo.Addr().String(),
+			BindAddress:   "127.0.0.1:0",
+			Logger:        senderLogger,
+			Metrics:       metrics.New(),
+			Ready: func(a net.Addr) {
+				select {
+				case senderAddrCh <- a:
+				default:
+				}
+			},
+		})
+		if err != nil && ctx.Err() == nil {
+			t.Logf("sender exited: %v", err)
+		}
+	}()
+
+	var senderAddr net.Addr
+	select {
+	case senderAddr = <-senderAddrCh:
+	case <-time.After(15 * time.Second):
+		t.Fatalf("sender Ready callback never fired")
+	}
+
+	// One bridge attempt is enough to consume the single-shot
+	// close-code fault. The TCP dial completes immediately at the
+	// sender bind; the relay-side failure surfaces later as a
+	// closed-WS error on both ends.
+	conn, err := net.DialTimeout("tcp", senderAddr.String(), 5*time.Second)
+	if err != nil {
+		t.Fatalf("dial sender: %v", err)
+	}
+	_, _ = conn.Write([]byte("ping\n"))
+	_ = conn.SetReadDeadline(time.Now().Add(2 * time.Second))
+	_, _ = io.ReadAll(conn)
+	_ = conn.Close()
+
+	pattern := `msg="failed to read envelope".* close_code=` + regexpInt(code)
+	line := waitForLogMatching(t, listenerLogs.String, 10*time.Second, pattern)
+	if !strings.Contains(line, fmt.Sprintf("close_code=%d", code)) {
+		t.Fatalf("listener envelope-read line missing expected close_code=%d:\n%s", code, line)
+	}
+}
+
+// startMockRelayWithCloseCode is a variant of startMockRelay that
+// constructs the server via NewServerForTesting with
+// WithCloseCodeOnAccept armed. Production callers cannot inject
+// faults; this lives in test code only.
+func startMockRelayWithCloseCode(t *testing.T, code int) (host string, opts relay.ClientOptions) {
+	t.Helper()
+	rs, err := server.NewServerForTesting(server.Config{
+		Logger:            slog.New(slog.NewTextHandler(io.Discard, nil)),
+		RendezvousTimeout: 1 * time.Second,
+	}, server.WithCloseCodeOnAccept(code))
+	if err != nil {
+		t.Fatalf("NewServerForTesting: %v", err)
+	}
+	srv := httptest.NewTLSServer(rs.Handler())
+	u, _ := url.Parse(srv.URL)
+	host = u.Host
+	opts = relay.ClientOptions{
+		TLSConfig: &tls.Config{InsecureSkipVerify: true}, //nolint:gosec // test cert
+	}
+	t.Cleanup(srv.Close)
+	return host, opts
+}
+
+// startCloseCodeEcho stands up a tiny TCP echo server local to the
+// test so the listener's AllowList has a real address to permit. The
+// echo behaviour is incidental — the listener never actually bridges
+// data through it because the WS gets force-closed by the fault knob
+// before any payload reaches the target.
+func startCloseCodeEcho(t *testing.T) net.Listener {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("echo listen: %v", err)
+	}
+	t.Cleanup(func() { _ = ln.Close() })
+	go func() {
+		for {
+			c, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			go func(c net.Conn) {
+				defer c.Close() //nolint:errcheck // best-effort cleanup
+				_, _ = io.Copy(c, c)
+			}(c)
+		}
+	}()
+	return ln
+}
+
+// mockOnlyEntity mints a short unique entity name without using the
+// shared mustEntityName helper, which embeds the full test name; for
+// table-driven subtests that produces values with characters we'd
+// rather keep out of the URL path.
+func mockOnlyEntity(t *testing.T) string {
+	t.Helper()
+	var b [4]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		t.Fatalf("rand: %v", err)
+	}
+	return "ws-close-" + hex.EncodeToString(b[:])
+}
+
+// waitForLogMatching polls logs() until any newline-delimited line
+// matches re, bounded by timeout. Returns the matching line. Fails
+// the test on deadline.
+func waitForLogMatching(t *testing.T, logs func() string, timeout time.Duration, pattern string) string {
+	t.Helper()
+	re := regexp.MustCompile(pattern)
+	deadline := time.Now().Add(timeout)
+	for {
+		snapshot := logs()
+		for _, line := range strings.Split(snapshot, "\n") {
+			if re.MatchString(line) {
+				return line
+			}
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("timed out after %v waiting for log line matching %q\n--- logs ---\n%s",
+				timeout, pattern, snapshot)
+			return ""
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+}
+
+// regexpInt returns the decimal form of n as a regexp-safe literal.
+// All callers pass small positive close codes, so the decimal form
+// contains no regex metacharacters and needs no escaping.
+func regexpInt(n int) string { return fmt.Sprintf("%d", n) }


### PR DESCRIPTION
## Operator-visible improvement

When the relay or peer closes the WebSocket with a non-normal status code (1011 server error, 4xxx app-defined, etc.), the code is now exposed as a structured `close_code=<int>` slog field on every bridge-end and envelope-failure log line. Operators can filter by specific codes without parsing free-form error strings:

```
$ aztunnel listen ... 2>&1 | grep 'close_code='
... msg="bridge ended" target=... close_code=1011
... msg="envelope exchange failed" target=... close_code=4400
```

When the error is not a WebSocket close frame, no `close_code` field is emitted and log levels / other fields are preserved.

## Where it lifts

| Component | Site | Level |
|---|---|---|
| listener | `failed to read envelope` | Warn |
| listener | `bridge ended` | Debug |
| sender (port-forward + socks5) | `envelope exchange failed` (via `logRejection`) | Warn |
| sender (port-forward) | `forward failed` (post-bridge) | Warn |
| sender (socks5) | `socks5 failed` (post-bridge) | Warn |
| arc port-forward | `bridge ended` | Debug |

The lift is a single exported helper, `relay.WSCloseCode(err) (int, bool)`, which uses `errors.As` on `websocket.CloseError` — the same unwrap idiom as the existing `ignoreNormalClose`.

## Scope notes

- The stdin/stdout sender entry points (`connect.go` paths) have no existing bridge-end log; adding one is out of scope here.
- The normal-close path on the listener bridge-end still produces no log line at all (filtered by `ignoreNormalClose`), so there is no spurious `close_code=1000`.

## Tests

- `internal/relay/bridge_test.go`: four unit tests for `WSCloseCode` (nil, plain error, direct `CloseError`, `fmt.Errorf("%w", …)`-wrapped).
- `mockrelay/testharness/parity/ws_close_code_test.go`: in-process listener + sender against a mock relay armed with `server.WithCloseCodeOnAccept(N)`. Rows for 1011 and 4400. Asserts the listener-side `failed to read envelope` Warn line carries `close_code=<N>`.

The mock's only close-code fault knob fires during accept (before the envelope round-trip), so the end-to-end test exercises the envelope-read site rather than the post-bridge site. The post-bridge enrichment uses the identical helper call pattern and is covered by the helper's unit tests plus code review.

## Verified

- `go test -race ./...` green on both root and `mockrelay` modules.
- `golangci-lint run` clean on both modules.
