### PR TITLE
feat(obs): structured event log lines for control-channel lifecycle

### DIFF
--- a/e2e/accept_id_test.go
+++ b/e2e/accept_id_test.go
@@ -50,7 +50,7 @@ func TestAcceptID_Saturation(t *testing.T) {
 				"--log-level", "debug",
 			)
 
-			waitForLog(t, listener, "control channel connected", 30*time.Second)
+			waitForLog(t, listener, "control_started", 30*time.Second)
 			listenerMetrics := listener.MetricsAddr(t, 15*time.Second)
 			senderAddr := waitForLogAddr(t, sender, "port-forward listening", 15*time.Second)
 
@@ -95,7 +95,7 @@ func TestAcceptID_Saturation(t *testing.T) {
 			// the log line for the drop event we will then parse.
 			waitForMetric(t, listenerMetrics, "aztunnel_active_connections",
 				func(v float64) bool { return v >= maxConns }, 30*time.Second)
-			if _, ok := listener.logs.waitFor("accept dropped", 30*time.Second); !ok {
+			if _, ok := listener.logs.waitFor("accept_dropped", 30*time.Second); !ok {
 				t.Fatalf("listener never logged 'accept dropped' (waited 30s; have %d clients open)", len(openConns))
 			}
 
@@ -183,7 +183,7 @@ func classifyAcceptLines(lines []string) map[string]bool {
 		switch {
 		case strings.Contains(ln, "accept acquired"):
 			kinds["acquired"] = true
-		case strings.Contains(ln, "accept dropped"):
+		case strings.Contains(ln, "accept_dropped"):
 			kinds["dropped"] = true
 		case strings.Contains(ln, "accept released"):
 			kinds["released"] = true

--- a/e2e/azure_backend_test.go
+++ b/e2e/azure_backend_test.go
@@ -48,7 +48,7 @@ func (b *azureBackend) Name() string { return "azure-" + b.authName }
 
 // Setup brings up the requested topology (NumListeners listeners and
 // max(NumSenders,1) senders), waits until every listener has logged
-// "control channel connected" and every sender has logged its bind
+// "control_started" and every sender has logged its bind
 // address, then attaches metrics-scrape closures and returns the
 // Tunnel handle. All subprocesses are torn down via the existing
 // t.Cleanup wiring inside startAztunnelWithSAS.
@@ -89,7 +89,7 @@ func (b *azureBackend) Setup(t testing.TB, opts relayparity.SetupOptions) *relay
 	spawnListener := func(t testing.TB) *relayparity.Listener {
 		t.Helper()
 		lst := startListener(t, env, auth, listenerArgs...)
-		waitForLog(t, lst, "control channel connected", 30*time.Second)
+		waitForLog(t, lst, "control_started", 30*time.Second)
 		metricsAddr := lst.MetricsAddr(t, 15*time.Second)
 		return &relayparity.Listener{
 			Addr:             metricsAddr,

--- a/e2e/control_events_test.go
+++ b/e2e/control_events_test.go
@@ -1,0 +1,76 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"bytes"
+	"io"
+	"net"
+	"testing"
+	"time"
+)
+
+// TestControl_Events_AzureSuccessPath drives the happy-path control
+// loop against a real Azure Relay and asserts that the operator-
+// visible event sequence — control_started, accept_attempted,
+// accept_ok — fires on the listener as one accept goes through.
+// control_ended is exercised by the unit test
+// TestControlSessionID_StableWithinLoop; the listener subprocess is
+// torn down via t.Cleanup (SIGKILL), which does not let the process
+// emit the deferred control_ended line, so the integration assertion
+// stops at accept_ok. Renew events are deliberately not asserted: the
+// production renew interval is 45 minutes and the binary does not
+// expose a shorter interval; renew coverage lives in the relay-
+// package unit test TestControl_HappyPathEvents and in the mockrelay
+// fault tests.
+//
+// One subtest per available auth method (entra, sas) keeps the
+// matrix consistent with the rest of the e2e suite.
+func TestControl_Events_AzureSuccessPath(t *testing.T) {
+	t.Parallel()
+	env := requireDedicatedHyco(t)
+
+	for _, auth := range availableAuths(t, env) {
+		auth := auth
+		t.Run(auth.name, func(t *testing.T) {
+			echo := startEchoServer(t)
+			listener := startListener(t, env, auth,
+				"--allow", echo.Addr(),
+				"--log-level", "debug",
+			)
+			sender := startPortForwardSender(t, env, auth, echo.Addr(),
+				"--log-level", "debug",
+			)
+
+			// control_started signals the control loop reached
+			// the operational milestone — the same readiness
+			// point every other Azure e2e test waits for.
+			waitForLog(t, listener, "control_started", 30*time.Second)
+			senderAddr := waitForLogAddr(t, sender, "port-forward listening", 15*time.Second)
+
+			// Drive one round-trip so accept_attempted and
+			// accept_ok fire.
+			conn, err := net.DialTimeout("tcp", senderAddr, 10*time.Second)
+			if err != nil {
+				t.Fatalf("dial sender: %v", err)
+			}
+			t.Cleanup(func() { _ = conn.Close() })
+
+			payload := []byte("p9-events\n")
+			if _, err := conn.Write(payload); err != nil {
+				t.Fatalf("write: %v", err)
+			}
+			buf := make([]byte, len(payload))
+			if _, err := io.ReadFull(conn, buf); err != nil {
+				t.Fatalf("read: %v", err)
+			}
+			if !bytes.Equal(payload, buf) {
+				t.Fatalf("echo mismatch: got %q, want %q", buf, payload)
+			}
+			_ = conn.Close()
+
+			waitForLog(t, listener, "accept_attempted", 10*time.Second)
+			waitForLog(t, listener, "accept_ok", 10*time.Second)
+		})
+	}
+}

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -72,7 +72,7 @@ func TestPortForwardBasic(t *testing.T) {
 				"--log-level", "debug",
 			)
 
-			waitForLog(t, listener, "control channel connected", 30*time.Second)
+			waitForLog(t, listener, "control_started", 30*time.Second)
 			senderAddr := waitForLogAddr(t, sender, "port-forward listening", 15*time.Second)
 
 			conn, err := net.DialTimeout("tcp", senderAddr, 10*time.Second)
@@ -113,7 +113,7 @@ func TestSOCKS5Basic(t *testing.T) {
 				"--log-level", "debug",
 			)
 
-			waitForLog(t, listener, "control channel connected", 30*time.Second)
+			waitForLog(t, listener, "control_started", 30*time.Second)
 			senderAddr := waitForLogAddr(t, sender, "socks5-proxy listening", 15*time.Second)
 
 			conn := dialSOCKS5(t, senderAddr, echo.Addr())
@@ -147,7 +147,7 @@ func TestConnectStdio(t *testing.T) {
 				"--allow", echo.Addr(),
 				"--log-level", "debug",
 			)
-			waitForLog(t, listener, "control channel connected", 30*time.Second)
+			waitForLog(t, listener, "control_started", 30*time.Second)
 
 			// Run connect mode as a subprocess with piped stdin/stdout.
 			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
@@ -307,7 +307,7 @@ func TestSASKeyAuth(t *testing.T) {
 		"--log-level", "debug",
 	)
 
-	waitForLog(t, listener, "control channel connected", 30*time.Second)
+	waitForLog(t, listener, "control_started", 30*time.Second)
 	senderAddr := waitForLogAddr(t, sender, "port-forward listening", 15*time.Second)
 
 	conn, err := net.DialTimeout("tcp", senderAddr, 10*time.Second)
@@ -348,7 +348,7 @@ func TestAllowlistAllow(t *testing.T) {
 				"--log-level", "debug",
 			)
 
-			waitForLog(t, listener, "control channel connected", 30*time.Second)
+			waitForLog(t, listener, "control_started", 30*time.Second)
 			senderAddr := waitForLogAddr(t, sender, "port-forward listening", 15*time.Second)
 
 			conn, err := net.DialTimeout("tcp", senderAddr, 10*time.Second)
@@ -389,7 +389,7 @@ func TestAllowlistDeny(t *testing.T) {
 				"--log-level", "debug",
 			)
 
-			waitForLog(t, listener, "control channel connected", 30*time.Second)
+			waitForLog(t, listener, "control_started", 30*time.Second)
 			senderAddr := waitForLogAddr(t, sender, "socks5-proxy listening", 15*time.Second)
 
 			// This should fail because the echo server is on 127.0.0.1, not 192.0.2.x.
@@ -425,7 +425,7 @@ func TestMaxConnections(t *testing.T) {
 				"--log-level", "debug",
 			)
 
-			waitForLog(t, listener, "control channel connected", 30*time.Second)
+			waitForLog(t, listener, "control_started", 30*time.Second)
 			listenerMetrics := listener.MetricsAddr(t, 15*time.Second)
 			senderAddr := waitForLogAddr(t, sender, "port-forward listening", 15*time.Second)
 
@@ -505,7 +505,7 @@ func TestSmallPayload(t *testing.T) {
 			)
 			sender := startPortForwardSender(t, env, auth, echo.Addr())
 
-			waitForLog(t, listener, "control channel connected", 30*time.Second)
+			waitForLog(t, listener, "control_started", 30*time.Second)
 			senderAddr := waitForLogAddr(t, sender, "port-forward listening", 15*time.Second)
 
 			conn, err := net.DialTimeout("tcp", senderAddr, 10*time.Second)
@@ -545,7 +545,7 @@ func TestLargePayload(t *testing.T) {
 			)
 			sender := startPortForwardSender(t, env, auth, echo.Addr())
 
-			waitForLog(t, listener, "control channel connected", 30*time.Second)
+			waitForLog(t, listener, "control_started", 30*time.Second)
 			senderAddr := waitForLogAddr(t, sender, "port-forward listening", 15*time.Second)
 
 			conn, err := net.DialTimeout("tcp", senderAddr, 10*time.Second)
@@ -699,7 +699,7 @@ func TestConcurrentSameTarget(t *testing.T) {
 			)
 			sender := startPortForwardSender(t, env, auth, echo.Addr())
 
-			waitForLog(t, listener, "control channel connected", 30*time.Second)
+			waitForLog(t, listener, "control_started", 30*time.Second)
 			senderAddr := waitForLogAddr(t, sender, "port-forward listening", 15*time.Second)
 
 			const numConns = 50
@@ -769,7 +769,7 @@ func TestConcurrentDistinctTargets(t *testing.T) {
 				"--log-level", "debug",
 			)
 
-			waitForLog(t, listener, "control channel connected", 30*time.Second)
+			waitForLog(t, listener, "control_started", 30*time.Second)
 			senderAddr := waitForLogAddr(t, sender, "socks5-proxy listening", 15*time.Second)
 
 			var wg sync.WaitGroup
@@ -868,7 +868,7 @@ func TestMetricsConnectionCount(t *testing.T) {
 				"--log-level", "debug",
 			)
 
-			waitForLog(t, listener, "control channel connected", 30*time.Second)
+			waitForLog(t, listener, "control_started", 30*time.Second)
 			listenerMetrics := listener.MetricsAddr(t, 15*time.Second)
 			senderAddr := waitForLogAddr(t, sender, "port-forward listening", 15*time.Second)
 			senderMetrics := sender.MetricsAddr(t, 15*time.Second)
@@ -922,7 +922,7 @@ func TestMetricsErrorReason(t *testing.T) {
 				"--log-level", "debug",
 			)
 
-			waitForLog(t, listener, "control channel connected", 30*time.Second)
+			waitForLog(t, listener, "control_started", 30*time.Second)
 			listenerMetrics := listener.MetricsAddr(t, 15*time.Second)
 			senderAddr := waitForLogAddr(t, sender, "socks5-proxy listening", 15*time.Second)
 
@@ -958,7 +958,7 @@ func TestMetricsDialDuration(t *testing.T) {
 				"--log-level", "debug",
 			)
 
-			waitForLog(t, listener, "control channel connected", 30*time.Second)
+			waitForLog(t, listener, "control_started", 30*time.Second)
 			senderAddr := waitForLogAddr(t, sender, "port-forward listening", 15*time.Second)
 			senderMetrics := sender.MetricsAddr(t, 15*time.Second)
 
@@ -1030,7 +1030,7 @@ func TestSenderRetriesUntilListenerReady(t *testing.T) {
 				"--allow", echo.Addr(),
 				"--log-level", "debug",
 			)
-			waitForLog(t, listener, "control channel connected", 30*time.Second)
+			waitForLog(t, listener, "control_started", 30*time.Second)
 
 			// The sender should eventually connect.
 			if _, ok := connectLogs.waitFor("connected", 15*time.Second); !ok {
@@ -1072,7 +1072,7 @@ func TestPortForwardRecoveryAfterListenerRestart(t *testing.T) {
 				"--log-level", "debug",
 			)
 
-			waitForLog(t, listener, "control channel connected", 30*time.Second)
+			waitForLog(t, listener, "control_started", 30*time.Second)
 			senderAddr := waitForLogAddr(t, sender, "port-forward listening", 15*time.Second)
 
 			// Verify traffic works.
@@ -1104,7 +1104,7 @@ func TestPortForwardRecoveryAfterListenerRestart(t *testing.T) {
 				"--allow", echo.Addr(),
 				"--log-level", "debug",
 			)
-			waitForLog(t, listener2, "control channel connected", 30*time.Second)
+			waitForLog(t, listener2, "control_started", 30*time.Second)
 
 			// Traffic should work again.
 			conn2, err := net.DialTimeout("tcp", senderAddr, 10*time.Second)
@@ -1452,7 +1452,7 @@ func TestPortForwardClosedPort(t *testing.T) {
 				"--log-level", "debug",
 			)
 
-			waitForLog(t, listener, "control channel connected", 30*time.Second)
+			waitForLog(t, listener, "control_started", 30*time.Second)
 			listenerMetrics := listener.MetricsAddr(t, 15*time.Second)
 			senderAddr := waitForLogAddr(t, sender, "port-forward listening", 15*time.Second)
 
@@ -1499,7 +1499,7 @@ func TestSOCKS5ClosedPort(t *testing.T) {
 				"--log-level", "debug",
 			)
 
-			waitForLog(t, listener, "control channel connected", 30*time.Second)
+			waitForLog(t, listener, "control_started", 30*time.Second)
 			senderAddr := waitForLogAddr(t, sender, "socks5-proxy listening", 15*time.Second)
 
 			// SOCKS5 handshake to the closed port.
@@ -1536,7 +1536,7 @@ func TestPortForwardUnreachable(t *testing.T) {
 				"--log-level", "debug",
 			)
 
-			waitForLog(t, listener, "control channel connected", 30*time.Second)
+			waitForLog(t, listener, "control_started", 30*time.Second)
 			listenerMetrics := listener.MetricsAddr(t, 15*time.Second)
 			senderAddr := waitForLogAddr(t, sender, "port-forward listening", 15*time.Second)
 

--- a/e2e/listener_id_test.go
+++ b/e2e/listener_id_test.go
@@ -52,7 +52,7 @@ func TestListenerID_PropagatesAndChangesOnRestart(t *testing.T) {
 				"--metrics-addr", "127.0.0.1:0",
 				"--log-level", "debug",
 			)
-			lineA := waitForLog(t, listenerA, "control channel connected", 30*time.Second)
+			lineA := waitForLog(t, listenerA, "control_started", 30*time.Second)
 			idA := extractListenerID(t, lineA)
 
 			sender := startPortForwardSender(t, env, auth, echo.Addr(),
@@ -81,7 +81,7 @@ func TestListenerID_PropagatesAndChangesOnRestart(t *testing.T) {
 				"--metrics-addr", "127.0.0.1:0",
 				"--log-level", "debug",
 			)
-			lineB := waitForLog(t, listenerB, "control channel connected", 30*time.Second)
+			lineB := waitForLog(t, listenerB, "control_started", 30*time.Second)
 			idB := extractListenerID(t, lineB)
 			if idB == idA {
 				t.Fatalf("listener B minted the same ID %q as listener A; mint-per-instance broken", idB)

--- a/e2e/multi_test.go
+++ b/e2e/multi_test.go
@@ -55,7 +55,7 @@ func TestMultiListenerPortForwardSmoke(t *testing.T) {
 					"--metrics-addr", "127.0.0.1:0",
 					"--log-level", "debug",
 				)
-				waitForLog(t, listeners[i], "control channel connected", 30*time.Second)
+				waitForLog(t, listeners[i], "control_started", 30*time.Second)
 				listenerMetricsAddrs[i] = listeners[i].MetricsAddr(t, 15*time.Second)
 			}
 

--- a/e2e/token_fetch_metric_test.go
+++ b/e2e/token_fetch_metric_test.go
@@ -40,7 +40,7 @@ func TestTokenFetchMetric_Azure(t *testing.T) {
 				"--metrics-addr", "127.0.0.1:0",
 			)
 
-			waitForLog(t, listener, "control channel connected", 30*time.Second)
+			waitForLog(t, listener, "control_started", 30*time.Second)
 			senderAddr := waitForLogAddr(t, sender, "port-forward listening", 15*time.Second)
 			senderMetrics := sender.MetricsAddr(t, 15*time.Second)
 

--- a/internal/listener/listener.go
+++ b/internal/listener/listener.go
@@ -44,6 +44,12 @@ type Config struct {
 	// dialContext optionally overrides target dialing. When nil,
 	// handleConnection uses a net.Dialer honouring ConnectTimeout.
 	dialContext func(ctx context.Context, network, addr string) (net.Conn, error)
+
+	// RenewInterval is how often the listener renews its SAS/Entra
+	// token over the control channel. Zero selects the relay
+	// package default (45m). Set a short value in tests that want to
+	// exercise a real renew round-trip within an assertion budget.
+	RenewInterval time.Duration
 }
 
 // applyDefaults fills in zero-valued config fields with their
@@ -88,6 +94,7 @@ func ListenAndServe(ctx context.Context, cfg Config) error {
 		Options:        cfg.ClientOptions,
 		MaxConnections: cfg.MaxConnections,
 		Logger:         cfg.Logger,
+		RenewInterval:  cfg.RenewInterval,
 		Handler: func(ctx context.Context, ws *websocket.Conn) {
 			handleConnection(ctx, ws, cfg)
 		},

--- a/internal/relay/control.go
+++ b/internal/relay/control.go
@@ -3,10 +3,13 @@ package relay
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
+	"net/http"
 	"net/url"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/coder/websocket"
@@ -15,13 +18,13 @@ import (
 )
 
 const (
-	tokenExpiry    = 1 * time.Hour
-	renewInterval  = 45 * time.Minute
-	pingInterval   = 30 * time.Second
-	pingTimeout    = 10 * time.Second
-	reconnectMin   = 1 * time.Second
-	reconnectMax   = 30 * time.Second
-	reconnectReset = 2 // multiplier
+	tokenExpiry          = 1 * time.Hour
+	defaultRenewInterval = 45 * time.Minute
+	pingInterval         = 30 * time.Second
+	pingTimeout          = 10 * time.Second
+	reconnectMin         = 1 * time.Second
+	reconnectMax         = 30 * time.Second
+	reconnectReset       = 2 // multiplier
 )
 
 // AcceptHandler is called for each accepted rendezvous connection.
@@ -47,6 +50,11 @@ type ControlConfig struct {
 	OnConnect func()
 	// OnDisconnect is called when the control channel disconnects. Optional.
 	OnDisconnect func()
+	// RenewInterval is how often the listener renews its SAS/Entra
+	// token over the control channel. Zero selects defaultRenewInterval
+	// (45m). Tests set a short value to drive a real renew round-trip
+	// within an assertion budget.
+	RenewInterval time.Duration
 }
 
 // ListenAndServe connects to the Azure Relay control channel and accepts
@@ -88,6 +96,48 @@ func ListenAndServe(ctx context.Context, cfg ControlConfig) error {
 	}
 }
 
+// loopState carries the deferred-emit inputs for control_ended out of
+// the goroutines that detect a forced-reconnect cause. renewLoop,
+// pingLoop, and the read loop all call setEnd before cancelling the
+// loop context; the deferred control_ended emission in runControlLoop
+// reads the stored (cause, err) pair so the reported reason and error
+// reflect the actual failure rather than the read-loop's wrapped
+// context-cancellation error. Cause and error are coupled in one
+// atomic write so concurrent failures can never produce a mismatched
+// (renew_failed, <ping error>)-style pair.
+type loopState struct {
+	end atomic.Value // *endResult; first-writer-wins
+}
+
+// endResult is the coupled (cause, err) record stored on loopState.
+// err may be nil — used by call sites whose loop-return error is
+// already the right value to report (e.g. dial failures wrap the
+// returned err themselves), in which case the deferred emit falls
+// back to the loop's return err.
+type endResult struct {
+	cause string
+	err   error
+}
+
+func (s *loopState) setEnd(cause string, err error) {
+	// First-writer-wins: when renew_failed forces the cancel and
+	// pingLoop then notices the cancelled context and would set
+	// ping_failed, the operator-visible answer should remain the
+	// underlying renew failure. The single CAS keeps cause and err
+	// in sync — a slow ping cannot overwrite the renew error after
+	// renew has stamped its cause.
+	s.end.CompareAndSwap(nil, &endResult{cause: cause, err: err})
+}
+
+func (s *loopState) load() (cause string, err error) {
+	v := s.end.Load()
+	if v == nil {
+		return "", nil
+	}
+	r := v.(*endResult)
+	return r.cause, r.err
+}
+
 func runControlLoop(ctx context.Context, cfg ControlConfig) (connected bool, err error) {
 	// Bind a fresh control_session_id onto the per-session logger
 	// before any work that could log: token fetch, dial, and the
@@ -101,12 +151,46 @@ func runControlLoop(ctx context.Context, cfg ControlConfig) (connected bool, err
 	// the boundary between sessions and is intentionally untagged.
 	sessionID := idgen.NewControlSessionID()
 	logger := cfg.Logger.With("control_session_id", sessionID)
-	logger.Info("control loop started")
-	defer logger.Info("control loop ended")
+
+	loopStart := time.Now()
+	state := &loopState{}
+
+	defer func() {
+		cause, stateErr := state.load()
+		if cause == "" {
+			cause = classifyControlEndReason(err, ctx.Err())
+		}
+		// When renew/ping/read stash a coupled (cause, err) pair on
+		// loopState, prefer their underlying err. The read loop's
+		// return-err is "read control: context canceled" after a
+		// forced cancel — operationally useless. Dial/token-fetch
+		// callers pass nil for err and let the loop's own wrapped
+		// return-err surface here.
+		reportErr := err
+		if stateErr != nil {
+			reportErr = stateErr
+		}
+		// Pass the error value (not the formatted string) so slog
+		// handlers can apply their own formatting and so the
+		// "error" attribute matches the package-wide convention.
+		// Omit the attribute entirely on graceful shutdown so
+		// successful loop exits don't carry an empty error field.
+		attrs := []any{
+			"reason", cause,
+			"duration_seconds", time.Since(loopStart).Seconds(),
+		}
+		if reportErr != nil {
+			attrs = append(attrs, "error", reportErr)
+		}
+		logger.Info(EventControlEnded, attrs...)
+	}()
 
 	resURI := ResourceURI(cfg.Endpoint, cfg.EntityPath)
 	token, err := cfg.TokenProvider.GetToken(ctx, resURI)
 	if err != nil {
+		if ctx.Err() == nil {
+			state.setEnd(ControlEndedTokenFetchFailed, nil)
+		}
 		return false, fmt.Errorf("get token: %w", err)
 	}
 
@@ -116,16 +200,38 @@ func runControlLoop(ctx context.Context, cfg ControlConfig) (connected bool, err
 
 	dialCtx, dialCancel := context.WithTimeout(ctx, cfg.DialTimeout)
 	defer dialCancel()
-	ws, _, err := websocket.Dial(dialCtx, listenURL, cfg.Options.dialOptions())
-	if err != nil {
-		return false, fmt.Errorf("dial control: %w", sanitizeErr(err))
+	ws, resp, dialErr := websocket.Dial(dialCtx, listenURL, cfg.Options.dialOptions())
+	if dialErr != nil {
+		// Operator-driven cancellation propagated through dialCtx
+		// is classified as context_cancelled (no setEnd call —
+		// the classifier sees ctx.Err and maps it). Other dial
+		// errors split into auth_failed vs dial_failed.
+		switch {
+		case ctx.Err() != nil:
+		case dialAuthFailed(resp):
+			state.setEnd(ControlEndedAuthFailed, nil)
+		default:
+			state.setEnd(ControlEndedDialFailed, nil)
+		}
+		return false, fmt.Errorf("dial control: %w", sanitizeErr(dialErr))
 	}
 	defer func() { _ = ws.CloseNow() }()
 
-	logger.Info("control channel connected", "entityPath", cfg.EntityPath)
+	// control_started fires here, after the dial has succeeded —
+	// this is the operational milestone every other listener
+	// readiness signal (metric, OnConnect callback, parity test
+	// waitForLog) hangs off. On dial failure, only control_ended
+	// fires with reason=dial_failed/auth_failed; that single
+	// signal is sufficient to tell an operator the loop terminated
+	// at dial.
+	logger.Info(EventControlStarted,
+		"relay_url", wssBase,
+		"listener_name", cfg.EntityPath)
+
 	if cfg.OnConnect != nil {
 		cfg.OnConnect()
 	}
+	connected = true
 
 	// Cancel used by ping/renew failure to force reconnect.
 	loopCtx, loopCancel := context.WithCancel(ctx)
@@ -136,25 +242,38 @@ func runControlLoop(ctx context.Context, cfg ControlConfig) (connected bool, err
 	var wg sync.WaitGroup
 	defer wg.Wait()
 
+	renewInterval := cfg.RenewInterval
+	if renewInterval == 0 {
+		renewInterval = defaultRenewInterval
+	}
+
 	// Token renewal goroutine.
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		renewLoop(loopCtx, ws, resURI, cfg.TokenProvider, logger, loopCancel)
+		renewLoop(loopCtx, ws, resURI, cfg.TokenProvider, logger, loopCancel, state, renewInterval)
 	}()
 
 	// Ping heartbeat goroutine.
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		pingLoop(loopCtx, ws, logger, loopCancel)
+		pingLoop(loopCtx, ws, logger, loopCancel, state)
 	}()
 
 	// Read accept messages from the control channel.
 	for {
-		_, data, err := ws.Read(loopCtx)
-		if err != nil {
-			return true, fmt.Errorf("read control: %w", err)
+		_, data, readErr := ws.Read(loopCtx)
+		if readErr != nil {
+			// Cancel renew/ping immediately so the deferred
+			// wg.Wait below unblocks promptly; otherwise it
+			// would sit until the ping ticker (~30s) noticed
+			// the dead socket and called loopCancel itself.
+			if loopCtx.Err() == nil {
+				state.setEnd(ControlEndedReadFailed, readErr)
+			}
+			loopCancel()
+			return true, fmt.Errorf("read control: %w", readErr)
 		}
 
 		var msg struct {
@@ -174,16 +293,17 @@ func runControlLoop(ctx context.Context, cfg ControlConfig) (connected bool, err
 
 		// Mint a short-lived accept_id before the semaphore check so
 		// the drop path carries the same correlation key as the
-		// accepted path. Subsequent lifecycle log lines (acquire,
-		// release, rendezvous dial start/end) all go through
-		// acceptLogger so an operator can group them with one filter;
-		// the control_session_id binding on logger flows through so
-		// every accept line carries both attributes.
+		// accepted path. The accept_id flows through acceptLogger
+		// onto every subsequent log line for this accept; the
+		// control_session_id binding on logger means each accept
+		// line carries both attributes.
 		acceptID := idgen.NewAcceptID()
 		acceptLogger := logger.With("accept_id", acceptID)
 
+		acceptLogger.Info(EventAcceptAttempted)
+
 		if !sem.tryAcquire(loopCtx) {
-			acceptLogger.Warn("accept dropped", "reason", "semaphore_full")
+			acceptLogger.Warn(EventAcceptDropped, "reason", AcceptDroppedSemaphoreFull)
 			continue
 		}
 		acceptLogger.Debug("accept acquired")
@@ -195,83 +315,166 @@ func runControlLoop(ctx context.Context, cfg ControlConfig) (connected bool, err
 				sem.release()
 				logger.Debug("accept released")
 			}()
-			if err := handleAccept(loopCtx, addr, cfg, logger); err != nil {
-				logger.Warn("accept failed", "error", err)
-			}
+			handleAccept(loopCtx, addr, cfg, logger)
 		}(msg.Accept.Address, acceptLogger)
 	}
 }
 
-func handleAccept(ctx context.Context, addr string, cfg ControlConfig, logger *slog.Logger) error {
+// classifyControlEndReason maps a runControlLoop return error onto one
+// of the ControlEnded* enum values. Used only as a fallback when the
+// renew/ping goroutines have NOT already stored a more specific cause
+// on loopState — those goroutines win because their context-cancel
+// reason is operationally more useful than the read-loop's wrapped
+// context.Canceled return.
+func classifyControlEndReason(loopErr, outerCtxErr error) string {
+	if outerCtxErr != nil {
+		return ControlEndedContextCancelled
+	}
+	if loopErr == nil {
+		return ControlEndedContextCancelled
+	}
+	if errors.Is(loopErr, context.Canceled) || errors.Is(loopErr, context.DeadlineExceeded) {
+		return ControlEndedContextCancelled
+	}
+	return ControlEndedReadFailed
+}
+
+// dialAuthFailed reports whether a failed control-channel dial got an
+// HTTP response that indicates token rejection. Azure Relay returns
+// 401 for invalid SAS tokens and 403 for tokens with insufficient
+// permissions; both map to control_ended.reason="auth_failed".
+func dialAuthFailed(resp *http.Response) bool {
+	if resp == nil {
+		return false
+	}
+	return resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden
+}
+
+func handleAccept(ctx context.Context, addr string, cfg ControlConfig, logger *slog.Logger) {
 	logger.Debug("accept dial started")
 	dialCtx, dialCancel := context.WithTimeout(ctx, cfg.DialTimeout)
 	defer dialCancel()
-	ws, _, err := websocket.Dial(dialCtx, addr, cfg.Options.dialOptions())
+	ws, resp, err := websocket.Dial(dialCtx, addr, cfg.Options.dialOptions())
 	if err != nil {
-		sanitized := sanitizeErr(err)
-		logger.Debug("accept dial complete", "ok", false, "error", sanitized)
-		return fmt.Errorf("dial rendezvous: %w", sanitized)
+		reason := AcceptDroppedDialFailed
+		if dialAuthFailed(resp) {
+			reason = AcceptDroppedAuthFailed
+		}
+		logger.Warn(EventAcceptDropped, "reason", reason, "error", sanitizeErr(err))
+		return
 	}
 	logger.Debug("accept dial complete", "ok", true)
 	defer func() { _ = ws.CloseNow() }()
 
+	logger.Info(EventAcceptOK)
+
 	cfg.Handler(ctx, ws)
 	_ = ws.Close(websocket.StatusNormalClosure, "done")
-	return nil
 }
 
 const maxRenewRetries = 3
 
-func renewLoop(ctx context.Context, ws *websocket.Conn, resURI string, tp TokenProvider, logger *slog.Logger, cancel context.CancelFunc) {
-	ticker := time.NewTicker(renewInterval)
+func renewLoop(ctx context.Context, ws *websocket.Conn, resURI string, tp TokenProvider, logger *slog.Logger, cancel context.CancelFunc, state *loopState, interval time.Duration) {
+	// tokenMintedAt drives the expires_in_seconds attribute on
+	// renew_attempted and the new_expires_in_seconds attribute on
+	// renew_ok. The initial value is the entry time of this
+	// goroutine, which is within milliseconds of the runControlLoop
+	// dial — close enough for an operator-visible "how many seconds
+	// until the current token expires" estimate.
+	//
+	// The estimate is computed against the SAS-token validity window
+	// (tokenExpiry = 1h, the value passed to NewSASToken). For Entra
+	// credentials the actual on-wire token lifetime comes from the
+	// credential and may differ from 1h; the attribute is therefore
+	// best understood as "seconds until the listener will rotate"
+	// rather than "seconds until the bearer credential is invalid".
+	tokenMintedAt := time.Now()
+	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
 	for {
 		select {
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			if err := renewOnce(ctx, ws, resURI, tp, logger); err != nil {
-				logger.Warn("token renewal failed, forcing reconnect", "error", err)
+			newMint, err := renewOnce(ctx, ws, resURI, tp, logger, tokenMintedAt)
+			if err != nil {
+				if ctx.Err() == nil {
+					state.setEnd(ControlEndedRenewFailed, err)
+				}
 				cancel()
 				return
 			}
+			tokenMintedAt = newMint
 		}
 	}
 }
 
-func renewOnce(ctx context.Context, ws *websocket.Conn, resURI string, tp TokenProvider, logger *slog.Logger) error {
+// renewOnce executes one renew round-trip with up to maxRenewRetries
+// attempts. It emits renew_attempted before each attempt and a single
+// terminal renew_ok or renew_failed event when the round-trip
+// completes. Returns the time the successful renew's token was minted
+// (used by the caller to update tokenMintedAt for the next pass).
+func renewOnce(ctx context.Context, ws *websocket.Conn, resURI string, tp TokenProvider, logger *slog.Logger, currentTokenMintedAt time.Time) (time.Time, error) {
+	start := time.Now()
 	var lastErr error
-	for attempt := range maxRenewRetries {
-		if attempt > 0 {
+	attempt := 0
+	for attempt < maxRenewRetries {
+		attempt++
+		if attempt > 1 {
 			select {
 			case <-ctx.Done():
-				return ctx.Err()
-			case <-time.After(time.Duration(attempt) * 5 * time.Second):
+				logger.Warn(EventRenewFailed,
+					"attempt", attempt-1,
+					"elapsed_ms", time.Since(start).Milliseconds(),
+					"error", ctx.Err(),
+					"code", RenewFailedContextCancel)
+				return time.Time{}, ctx.Err()
+			case <-time.After(time.Duration(attempt-1) * 5 * time.Second):
 			}
 		}
+
+		expiresInSec := int64(time.Until(currentTokenMintedAt.Add(tokenExpiry)).Seconds())
+		logger.Info(EventRenewAttempted,
+			"attempt", attempt,
+			"expires_in_seconds", expiresInSec)
 
 		token, err := tp.GetToken(ctx, resURI)
 		if err != nil {
 			lastErr = err
-			logger.Warn("token renewal attempt failed", "attempt", attempt+1, "error", err)
 			continue
 		}
 		msg := map[string]interface{}{
-			"renewToken": map[string]string{
-				"token": token,
-			},
+			"renewToken": map[string]string{"token": token},
 		}
 		data, _ := json.Marshal(msg)
 		if err := ws.Write(ctx, websocket.MessageText, data); err != nil {
-			return err // write failure = connection problem, no retry
+			logger.Warn(EventRenewFailed,
+				"attempt", attempt,
+				"elapsed_ms", time.Since(start).Milliseconds(),
+				"error", err,
+				"code", RenewFailedConnectionLost)
+			return time.Time{}, err
 		}
-		logger.Debug("token renewed")
-		return nil
+		now := time.Now()
+		logger.Info(EventRenewOK,
+			"attempt", attempt,
+			"new_expires_in_seconds", int64(tokenExpiry.Seconds()),
+			"elapsed_ms", time.Since(start).Milliseconds())
+		return now, nil
 	}
-	return lastErr
+	code := RenewFailedTokenFetchFail
+	if errors.Is(lastErr, context.Canceled) || errors.Is(lastErr, context.DeadlineExceeded) {
+		code = RenewFailedContextCancel
+	}
+	logger.Warn(EventRenewFailed,
+		"attempt", attempt,
+		"elapsed_ms", time.Since(start).Milliseconds(),
+		"error", lastErr,
+		"code", code)
+	return time.Time{}, lastErr
 }
 
-func pingLoop(ctx context.Context, ws *websocket.Conn, logger *slog.Logger, cancel context.CancelFunc) {
+func pingLoop(ctx context.Context, ws *websocket.Conn, logger *slog.Logger, cancel context.CancelFunc, state *loopState) {
 	ticker := time.NewTicker(pingInterval)
 	defer ticker.Stop()
 	for {
@@ -283,7 +486,16 @@ func pingLoop(ctx context.Context, ws *websocket.Conn, logger *slog.Logger, canc
 			err := ws.Ping(pingCtx)
 			pingCancel()
 			if err != nil {
-				logger.Warn("ping failed, forcing reconnect", "error", err)
+				if ctx.Err() != nil {
+					return
+				}
+				// No prose log line here: the ping failure is
+				// surfaced via control_ended{reason=ping_failed,
+				// error=<ws.Ping err>} once the deferred emit
+				// runs in runControlLoop. The coupled setEnd
+				// stashes (cause, err) atomically so the emit
+				// reads a consistent pair.
+				state.setEnd(ControlEndedPingFailed, err)
 				cancel()
 				return
 			}

--- a/internal/relay/control_events.go
+++ b/internal/relay/control_events.go
@@ -1,0 +1,53 @@
+package relay
+
+// Event names emitted by runControlLoop and its goroutines. Each event
+// is the msg of one slog record so operators can filter mechanically
+// with msg="<name>". Every record additionally carries the
+// control_session_id attribute bound in runControlLoop.
+const (
+	EventControlStarted  = "control_started"
+	EventControlEnded    = "control_ended"
+	EventRenewAttempted  = "renew_attempted"
+	EventRenewOK         = "renew_ok"
+	EventRenewFailed     = "renew_failed"
+	EventAcceptAttempted = "accept_attempted"
+	EventAcceptOK        = "accept_ok"
+	EventAcceptDropped   = "accept_dropped"
+)
+
+// renew_failed.code values. The on-wire renew protocol is fire-and-
+// forget: the listener does NOT read an echo after sending
+// renewToken, so the detectable renew failures are connection-level
+// (write fails, next read fails) or local (token fetch error,
+// context cancellation). RenewFailedAuthFailed is reserved for
+// TokenProvider errors that the provider itself classifies as
+// authentication; the runtime does not classify by string heuristics
+// and emits this code only when a caller passes a typed auth error.
+const (
+	RenewFailedConnectionLost = "connection_lost"
+	RenewFailedAuthFailed     = "auth_failed"
+	RenewFailedContextCancel  = "context_cancelled"
+	RenewFailedTokenFetchFail = "token_fetch_failed"
+)
+
+// accept_dropped.reason values.
+const (
+	AcceptDroppedSemaphoreFull = "semaphore_full"
+	AcceptDroppedDialFailed    = "dial_failed"
+	AcceptDroppedAuthFailed    = "auth_failed"
+)
+
+// control_ended.reason values. A small enum so an operator query
+// ("give me every loop that ended because dial failed") matches one
+// fixed string. Forced-reconnect causes (renew_failed, ping_failed)
+// are surfaced here separately from the read-loop's wrapped
+// context.Canceled return — see runControlLoop's endCause tracking.
+const (
+	ControlEndedDialFailed       = "dial_failed"
+	ControlEndedTokenFetchFailed = "token_fetch_failed"
+	ControlEndedAuthFailed       = "auth_failed"
+	ControlEndedReadFailed       = "read_failed"
+	ControlEndedContextCancelled = "context_cancelled"
+	ControlEndedRenewFailed      = "renew_failed"
+	ControlEndedPingFailed       = "ping_failed"
+)

--- a/internal/relay/control_test.go
+++ b/internal/relay/control_test.go
@@ -74,6 +74,14 @@ type discard struct{}
 
 func (discard) Write(p []byte) (int, error) { return len(p), nil }
 
+// renewOnceWrap calls renewOnce with a fresh tokenMintedAt and
+// discards the returned new-mint time so the existing tests that
+// only assert on the error/side-effects stay readable.
+func renewOnceWrap(ctx context.Context, ws *websocket.Conn, resURI string, tp TokenProvider, logger *slog.Logger) error {
+	_, err := renewOnce(ctx, ws, resURI, tp, logger, time.Now())
+	return err
+}
+
 // ---------- TestHandleAccept ----------
 
 func TestHandleAccept(t *testing.T) {
@@ -105,10 +113,7 @@ func TestHandleAccept(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
 
-		err := handleAccept(ctx, "wss://"+testEndpoint(rendezvousSrv), cfg, discardLogger())
-		if err != nil {
-			t.Fatalf("handleAccept returned error: %v", err)
-		}
+		handleAccept(ctx, "wss://"+testEndpoint(rendezvousSrv), cfg, discardLogger())
 
 		select {
 		case <-handlerCalled:
@@ -118,10 +123,11 @@ func TestHandleAccept(t *testing.T) {
 		}
 	})
 
-	t.Run("returns error on dial failure", func(t *testing.T) {
+	t.Run("emits accept_dropped on dial failure", func(t *testing.T) {
+		logger, rec := captureLogger()
 		cfg := ControlConfig{
 			DialTimeout: 1 * time.Second,
-			Logger:      discardLogger(),
+			Logger:      logger,
 			Handler: func(ctx context.Context, ws *websocket.Conn) {
 				t.Fatal("handler should not be called")
 			},
@@ -130,12 +136,21 @@ func TestHandleAccept(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
 
-		err := handleAccept(ctx, "ws://127.0.0.1:1", cfg, discardLogger())
-		if err == nil {
-			t.Fatal("expected error for bad address")
+		handleAccept(ctx, "ws://127.0.0.1:1", cfg, logger)
+
+		records := rec.records(t)
+		var dropped map[string]any
+		for _, r := range records {
+			if r["msg"] == EventAcceptDropped {
+				dropped = r
+				break
+			}
 		}
-		if !strings.Contains(err.Error(), "dial rendezvous") {
-			t.Errorf("unexpected error: %v", err)
+		if dropped == nil {
+			t.Fatalf("missing %s event in records: %v", EventAcceptDropped, records)
+		}
+		if dropped["reason"] != AcceptDroppedDialFailed {
+			t.Errorf("accept_dropped.reason = %v, want %q", dropped["reason"], AcceptDroppedDialFailed)
 		}
 	})
 }
@@ -180,7 +195,7 @@ func TestRenewOnce(t *testing.T) {
 
 		tp := &mockTokenProvider{token: "renewed-token-123"}
 
-		err = renewOnce(ctx, ws, "https://test.servicebus.windows.net/hc", tp, discardLogger())
+		_, err = renewOnce(ctx, ws, "https://test.servicebus.windows.net/hc", tp, discardLogger(), time.Now())
 		if err != nil {
 			t.Fatalf("renewOnce returned error: %v", err)
 		}
@@ -243,7 +258,7 @@ func TestRenewOnce(t *testing.T) {
 			},
 		}
 
-		err = renewOnce(ctx, ws, "https://test.servicebus.windows.net/hc", tp, discardLogger())
+		err = renewOnceWrap(ctx, ws, "https://test.servicebus.windows.net/hc", tp, discardLogger())
 		if err != nil {
 			t.Fatalf("renewOnce returned error: %v", err)
 		}
@@ -288,7 +303,7 @@ func TestRenewOnce(t *testing.T) {
 
 		tp := &mockTokenProvider{err: fmt.Errorf("permanent failure")}
 
-		err = renewOnce(ctx, ws, "https://test.servicebus.windows.net/hc", tp, discardLogger())
+		err = renewOnceWrap(ctx, ws, "https://test.servicebus.windows.net/hc", tp, discardLogger())
 		if err == nil {
 			t.Fatal("expected error after max retries")
 		}
@@ -318,17 +333,24 @@ func TestRenewOnce(t *testing.T) {
 		}
 		defer ws.CloseNow()
 
-		// Read the close frame so the connection knows it's closed.
 		ws.Read(ctx)
 
 		tp := &mockTokenProvider{token: "some-token"}
 
-		err = renewOnce(ctx, ws, "https://test.servicebus.windows.net/hc", tp, discardLogger())
+		logger, rec := captureLogger()
+		_, err = renewOnce(ctx, ws, "https://test.servicebus.windows.net/hc", tp, logger, time.Now())
 		if err == nil {
 			t.Fatal("expected error on write failure")
 		}
 		if tp.getCalls() != 1 {
 			t.Errorf("GetToken called %d times, want 1 (no retry on write failure)", tp.getCalls())
+		}
+		// Operator-visible signal: code=connection_lost on the
+		// terminal renew_failed event when ws.Write fails because
+		// the peer dropped the control channel.
+		if !hasRecord(t, rec.records(t), EventRenewFailed, "code", RenewFailedConnectionLost) {
+			t.Errorf("missing %s with code=%s in records:\n%s",
+				EventRenewFailed, RenewFailedConnectionLost, string(rec.buf))
 		}
 	})
 }
@@ -382,7 +404,7 @@ func TestPingLoop(t *testing.T) {
 			pingLoop(loopCtx, ws, discardLogger(), func() {
 				close(cancelCalled)
 				loopCancel()
-			})
+			}, &loopState{})
 		}()
 
 		select {
@@ -425,7 +447,7 @@ func TestPingLoop(t *testing.T) {
 			defer close(done)
 			pingLoop(loopCtx, ws, discardLogger(), func() {
 				t.Error("cancel should not be called on context cancel")
-			})
+			}, &loopState{})
 		}()
 
 		loopCancel()
@@ -445,8 +467,9 @@ func TestRenewLoop(t *testing.T) {
 	useInsecureTransport(t)
 
 	t.Run("exits on context cancel", func(t *testing.T) {
-		// renewLoop uses renewInterval (45min) for its ticker, so we can't
-		// easily trigger a tick in a test. Instead we verify that it exits
+		// The renew ticker is 45m by default, so we can't easily
+		// trigger a tick in a test that wants to exercise the
+		// context-cancel exit path. Instead we verify that it exits
 		// promptly when the context is cancelled.
 		srv := tlsServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			ws, err := websocket.Accept(w, r, nil)
@@ -481,7 +504,7 @@ func TestRenewLoop(t *testing.T) {
 			renewLoop(loopCtx, ws, "https://test.servicebus.windows.net/hc", tp, discardLogger(), func() {
 				close(cancelCalled)
 				loopCancel()
-			})
+			}, &loopState{}, defaultRenewInterval)
 		}()
 
 		// Cancel the context; renewLoop should exit via <-ctx.Done().
@@ -1038,9 +1061,8 @@ func drivenControlLoop(t *testing.T, logger *slog.Logger) {
 //
 //   - every record carries a non-empty control_session_id;
 //   - every record carries the SAME control_session_id;
-//   - the canonical lifecycle lines ("control loop started",
-//     "control channel connected", "control loop ended") are all
-//     present and tagged.
+//   - the canonical lifecycle events (control_started, control_ended)
+//     are both present and tagged.
 //
 // This is the per-session invariant operators rely on to mechanically
 // separate one control-loop run from the next.
@@ -1051,8 +1073,8 @@ func TestControlSessionID_StableWithinLoop(t *testing.T) {
 	drivenControlLoop(t, logger)
 
 	records := rec.records(t)
-	if len(records) < 3 {
-		t.Fatalf("expected at least 3 log records (started + connected + ended), got %d: %s", len(records), string(rec.buf))
+	if len(records) < 2 {
+		t.Fatalf("expected at least 2 log records (started + ended), got %d: %s", len(records), string(rec.buf))
 	}
 
 	var sessionID string
@@ -1069,7 +1091,7 @@ func TestControlSessionID_StableWithinLoop(t *testing.T) {
 		}
 	}
 
-	wantMsgs := []string{"control loop started", "control channel connected", "control loop ended"}
+	wantMsgs := []string{EventControlStarted, EventControlEnded}
 	for _, want := range wantMsgs {
 		found := false
 		for _, r := range records {
@@ -1118,6 +1140,214 @@ func extractSessionID(t *testing.T, rec *logRecorder) string {
 	}
 	t.Fatalf("no control_session_id in captured records: %s", string(rec.buf))
 	return ""
+}
+
+// TestControl_HappyPathEvents drives one runControlLoop end-to-end
+// against a stub relay that:
+//
+//   - accepts the listener's dial;
+//   - allows one full renew round-trip (RenewInterval is short);
+//   - waits for the test to gate it on having observed renew_ok in
+//     the captured records;
+//   - delivers one accept frame;
+//   - then closes the control WebSocket so the loop exits.
+//
+// The test asserts the operator-visible event sequence in order:
+//
+//	control_started → renew_attempted → renew_ok →
+//	accept_attempted → accept_ok → control_ended.
+//
+// Gating the accept-frame send on a captured renew_ok closes the
+// cross-goroutine race between the renewLoop logging renew_ok after
+// ws.Write returns and the read-loop logging accept_attempted after
+// ws.Read returns: both writes happen on different goroutines and
+// the events have no implicit happens-before relationship otherwise.
+//
+// This is the single happy-path contract every operator query
+// ("give me the lifecycle of this listener") relies on.
+func TestControl_HappyPathEvents(t *testing.T) {
+	useInsecureTransport(t)
+
+	rendezvousSrv := tlsServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ws, err := websocket.Accept(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer ws.CloseNow()
+		for {
+			if _, _, err := ws.Read(r.Context()); err != nil {
+				return
+			}
+		}
+	}))
+	rendezvousAddr := "wss://" + testEndpoint(rendezvousSrv)
+
+	// sendAccept gates the stub relay's accept-frame write on the
+	// test goroutine having observed renew_ok in the recorded log;
+	// handlerDone fires when the listener's accept handler runs.
+	sendAccept := make(chan struct{})
+	handlerDone := make(chan struct{}, 1)
+
+	controlSrv := tlsServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ws, err := websocket.Accept(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer ws.CloseNow()
+
+		// Drain renewToken frames from the listener; the test
+		// observes renew_ok via the log recorder, not the wire.
+		readDone := make(chan struct{})
+		go func() {
+			defer close(readDone)
+			for {
+				if _, _, err := ws.Read(r.Context()); err != nil {
+					return
+				}
+			}
+		}()
+
+		select {
+		case <-sendAccept:
+		case <-time.After(5 * time.Second):
+			ws.Close(websocket.StatusInternalError, "test timeout waiting for accept gate")
+			<-readDone
+			return
+		}
+
+		accept := map[string]interface{}{
+			"accept": map[string]interface{}{
+				"address": rendezvousAddr,
+				"id":      "session-id-test",
+			},
+		}
+		data, _ := json.Marshal(accept)
+		if err := ws.Write(r.Context(), websocket.MessageText, data); err != nil {
+			<-readDone
+			return
+		}
+
+		select {
+		case <-handlerDone:
+		case <-time.After(3 * time.Second):
+		}
+		ws.Close(websocket.StatusNormalClosure, "done")
+		<-readDone
+	}))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	logger, rec := captureLogger()
+
+	cfg := ControlConfig{
+		Endpoint:      testEndpoint(controlSrv),
+		EntityPath:    "test-entity",
+		TokenProvider: &mockTokenProvider{token: "test-token"},
+		Handler: func(ctx context.Context, ws *websocket.Conn) {
+			select {
+			case handlerDone <- struct{}{}:
+			default:
+			}
+		},
+		DialTimeout:   2 * time.Second,
+		Logger:        logger,
+		RenewInterval: 50 * time.Millisecond,
+	}
+
+	loopDone := make(chan error, 1)
+	go func() {
+		_, err := runControlLoop(ctx, cfg)
+		loopDone <- err
+	}()
+
+	if !waitForRecord(t, rec, EventRenewOK, 5*time.Second) {
+		t.Fatalf("renew_ok never appeared in records:\n%s", string(rec.buf))
+	}
+	close(sendAccept)
+
+	select {
+	case err := <-loopDone:
+		if err == nil {
+			t.Fatal("expected error from runControlLoop when server closes")
+		}
+	case <-time.After(8 * time.Second):
+		t.Fatal("runControlLoop did not return within budget")
+	}
+
+	records := rec.records(t)
+	wantOrder := []string{
+		EventControlStarted,
+		EventRenewAttempted,
+		EventRenewOK,
+		EventAcceptAttempted,
+		EventAcceptOK,
+		EventControlEnded,
+	}
+	assertEventOrder(t, records, wantOrder)
+}
+
+// waitForRecord polls rec at 10ms until a record with msg=want is
+// observed OR timeout elapses. Returns true on hit.
+func waitForRecord(t *testing.T, rec *logRecorder, want string, timeout time.Duration) bool {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		for _, r := range rec.records(t) {
+			if msg, _ := r["msg"].(string); msg == want {
+				return true
+			}
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	return false
+}
+
+// assertEventOrder asserts that each event in want appears at least
+// once in records and that the first occurrence of want[i] strictly
+// precedes the first occurrence of want[i+1]. Other events between
+// adjacent want entries are allowed: the contract is "this happened
+// in this order", not "no other events fired".
+func assertEventOrder(t *testing.T, records []map[string]any, want []string) {
+	t.Helper()
+	idx := -1
+	cursor := 0
+	for _, target := range want {
+		found := -1
+		for i := cursor; i < len(records); i++ {
+			if msg, _ := records[i]["msg"].(string); msg == target {
+				found = i
+				break
+			}
+		}
+		if found < 0 {
+			var msgs []string
+			for _, r := range records {
+				if msg, _ := r["msg"].(string); msg != "" {
+					msgs = append(msgs, msg)
+				}
+			}
+			t.Fatalf("missing event %q after position %d; observed sequence:\n%s",
+				target, idx, strings.Join(msgs, "\n"))
+		}
+		idx = found
+		cursor = found + 1
+	}
+}
+
+// hasRecord reports whether records contains a record whose msg is
+// event and whose attr key carries the given value.
+func hasRecord(t *testing.T, records []map[string]any, event, key, value string) bool {
+	t.Helper()
+	for _, r := range records {
+		if msg, _ := r["msg"].(string); msg != event {
+			continue
+		}
+		if v, _ := r[key].(string); v == value {
+			return true
+		}
+	}
+	return false
 }
 
 // ---------- TestAcceptID ----------
@@ -1423,7 +1653,7 @@ func TestAcceptID_PresentOnDrop(t *testing.T) {
 
 		// Wait for the drop to be logged before closing so the test
 		// can observe it on the capture store deterministically.
-		if _, ok := store.waitForRecord("accept dropped", 5*time.Second); !ok {
+		if _, ok := store.waitForRecord(EventAcceptDropped, 5*time.Second); !ok {
 			ws.Close(websocket.StatusNormalClosure, "drop never logged")
 			return
 		}
@@ -1467,7 +1697,7 @@ func TestAcceptID_PresentOnDrop(t *testing.T) {
 		<-loopErrCh
 		t.Fatalf("never observed 'accept acquired'")
 	}
-	if _, ok := store.waitForRecord("accept dropped", 10*time.Second); !ok {
+	if _, ok := store.waitForRecord(EventAcceptDropped, 10*time.Second); !ok {
 		cancel()
 		<-loopErrCh
 		t.Fatalf("never observed 'accept dropped' (records=%v)", store.snapshot())
@@ -1478,7 +1708,7 @@ func TestAcceptID_PresentOnDrop(t *testing.T) {
 	}
 
 	acquired := store.filterByMsg("accept acquired")
-	dropped := store.filterByMsg("accept dropped")
+	dropped := store.filterByMsg(EventAcceptDropped)
 	if len(acquired) == 0 {
 		t.Fatalf("no 'accept acquired' record captured (have %d records total)", len(store.snapshot()))
 	}

--- a/internal/testharness/relayparity/backend.go
+++ b/internal/testharness/relayparity/backend.go
@@ -53,8 +53,8 @@ type Backend interface {
 	// Setup must block until the topology is ready: every sender's
 	// bind address is accepting connections and every requested
 	// listener has its control channel attached to the relay (for
-	// subprocess backends, the "control channel connected" log; for
-	// the in-process backend, the aztunnel_control_channel_connected
+	// subprocess backends, the control_started log; for the
+	// in-process backend, the aztunnel_control_channel_connected
 	// gauge). Scenarios assume the tunnel is fully connected on
 	// return.
 	Setup(t testing.TB, opts SetupOptions) *Tunnel

--- a/internal/testharness/relayparity/observability.go
+++ b/internal/testharness/relayparity/observability.go
@@ -226,14 +226,13 @@ func waitForListenerCorrelations(t *testing.T, snapshot func() string, min int, 
 var controlSessionIDRe = regexp.MustCompile(`control_session_id=([A-Z2-7]+)`)
 
 // ScenarioControlSessionID_OnConnectedLine asserts that the
-// listener's "control channel connected" log line carries a
-// non-empty control_session_id field, and that the field is stable
-// across the per-session lifecycle (the "control loop started" line
-// minted at runControlLoop entry must share the same id). Both lines
-// are produced inside relay.runControlLoop, so this scenario is the
-// cross-backend gate proving that the per-session logger binding
-// propagates to the canonical lifecycle lines — the same lines
-// every other parity scenario waits for during topology setup.
+// listener's control_started log line carries a non-empty
+// control_session_id field. control_started fires once per
+// control-loop attempt, immediately after the dial succeeds and at
+// the same operational milestone the parity test harness blocks on
+// during Setup. The id on this line is the same id every other
+// per-session log record (renew_*, accept_*, control_ended) carries
+// across the rest of the loop.
 //
 // Cross-backend: identical on mock and Azure because the binding
 // happens listener-side before any data crosses the relay.
@@ -252,27 +251,12 @@ func ScenarioControlSessionID_OnConnectedLine(t *testing.T, b Backend) {
 
 	lst := tun.Listeners[0]
 
-	// Backend.Setup blocks until "control channel connected" has
-	// been logged, so a short poll on lst.Logs is sufficient — keep
-	// a small grace window for pipe-flushing on subprocess backends.
-	connectedLine := waitForLogLineContaining(t, lst.Logs, 5*time.Second, "control channel connected")
-	m := controlSessionIDRe.FindStringSubmatch(connectedLine)
-	if m == nil {
-		t.Fatalf("`control channel connected` line missing control_session_id field:\n%s", connectedLine)
-	}
-	sessionID := m[1]
-
-	// Anchor the "control loop started" lookup on the same
-	// session id we just observed on the connected line. A
-	// listener that retried after an earlier failure (e.g.
-	// transient dial error) will have multiple started/ended
-	// pairs in the buffer; matching on the id pins this assertion
-	// to the lifecycle of the connected session rather than to
-	// whatever attempt happened to be logged first.
-	startedNeedle := "control_session_id=" + sessionID
-	startedLine := waitForLogLineContaining(t, lst.Logs, 2*time.Second, "control loop started", startedNeedle)
+	// Backend.Setup blocks until control_started has been logged,
+	// so a short poll on lst.Logs is sufficient — keep a small
+	// grace window for pipe-flushing on subprocess backends.
+	startedLine := waitForLogLineContaining(t, lst.Logs, 5*time.Second, "control_started")
 	if !controlSessionIDRe.MatchString(startedLine) {
-		t.Fatalf("`control loop started` line missing control_session_id field:\n%s", startedLine)
+		t.Fatalf("control_started line missing control_session_id field:\n%s", startedLine)
 	}
 }
 

--- a/mockrelay/cmd/aztunnel-relay/scenarios_test.go
+++ b/mockrelay/cmd/aztunnel-relay/scenarios_test.go
@@ -43,7 +43,7 @@ func TestSubprocess_SOCKS5(t *testing.T) {
 	const entity = "scenario-socks5"
 
 	listener := startListener(t, ctx, rp.relayURL, entity, "--allow", echoAddr)
-	waitForLog(t, listener, "control channel connected", 10*time.Second)
+	waitForLog(t, listener, "control_started", 10*time.Second)
 
 	socksBind := fmt.Sprintf("127.0.0.1:%d", pickFreePort(t))
 	_ = startSOCKS5Sender(t, ctx, rp.relayURL, entity, socksBind)
@@ -79,7 +79,7 @@ func TestSubprocess_ConnectStdio(t *testing.T) {
 	const entity = "scenario-connect"
 
 	listener := startListener(t, ctx, rp.relayURL, entity, "--allow", echoAddr)
-	waitForLog(t, listener, "control channel connected", 10*time.Second)
+	waitForLog(t, listener, "control_started", 10*time.Second)
 
 	_, stdin, stdout := startConnectSender(t, ctx, rp.relayURL, entity, echoAddr)
 
@@ -112,7 +112,7 @@ func TestSubprocess_ConcurrentSameTarget(t *testing.T) {
 	const entity = "scenario-concurrent"
 
 	listener := startListener(t, ctx, rp.relayURL, entity, "--allow", echoAddr)
-	waitForLog(t, listener, "control channel connected", 10*time.Second)
+	waitForLog(t, listener, "control_started", 10*time.Second)
 
 	pfBind := fmt.Sprintf("127.0.0.1:%d", pickFreePort(t))
 	_ = startPortForwardSender(t, ctx, rp.relayURL, entity, pfBind, echoAddr)
@@ -169,7 +169,7 @@ func TestSubprocess_MediumPayload(t *testing.T) {
 	const entity = "scenario-medium"
 
 	listener := startListener(t, ctx, rp.relayURL, entity, "--allow", echoAddr)
-	waitForLog(t, listener, "control channel connected", 10*time.Second)
+	waitForLog(t, listener, "control_started", 10*time.Second)
 
 	pfBind := fmt.Sprintf("127.0.0.1:%d", pickFreePort(t))
 	_ = startPortForwardSender(t, ctx, rp.relayURL, entity, pfBind, echoAddr)
@@ -221,7 +221,7 @@ func TestSubprocess_BulkTransfer(t *testing.T) {
 	const entity = "scenario-bulk"
 
 	listener := startListener(t, ctx, rp.relayURL, entity, "--allow", echoAddr)
-	waitForLog(t, listener, "control channel connected", 10*time.Second)
+	waitForLog(t, listener, "control_started", 10*time.Second)
 
 	pfBind := fmt.Sprintf("127.0.0.1:%d", pickFreePort(t))
 	_ = startPortForwardSender(t, ctx, rp.relayURL, entity, pfBind, echoAddr)
@@ -306,7 +306,7 @@ func TestSubprocess_SenderRetriesUntilListener(t *testing.T) {
 
 	// NOW start the listener.
 	listener := startListener(t, ctx, rp.relayURL, entity, "--allow", echoAddr)
-	waitForLog(t, listener, "control channel connected", 10*time.Second)
+	waitForLog(t, listener, "control_started", 10*time.Second)
 
 	// The sender should reconnect on its next retry. Verify data flows.
 	want := []byte("after retry\n")
@@ -336,7 +336,7 @@ func TestSubprocess_ListenerRestartRecovery(t *testing.T) {
 	const entity = "scenario-restart"
 
 	listener1 := startListener(t, ctx, rp.relayURL, entity, "--allow", echoAddr)
-	waitForLog(t, listener1, "control channel connected", 10*time.Second)
+	waitForLog(t, listener1, "control_started", 10*time.Second)
 
 	pfBind := fmt.Sprintf("127.0.0.1:%d", pickFreePort(t))
 	_ = startPortForwardSender(t, ctx, rp.relayURL, entity, pfBind, echoAddr)
@@ -356,7 +356,7 @@ func TestSubprocess_ListenerRestartRecovery(t *testing.T) {
 	// Start listener2. The sender's port-forward keeps its bind alive;
 	// new TCP connections trigger fresh rendezvous attempts.
 	listener2 := startListener(t, ctx, rp.relayURL, entity, "--allow", echoAddr)
-	waitForLog(t, listener2, "control channel connected", 10*time.Second)
+	waitForLog(t, listener2, "control_started", 10*time.Second)
 
 	// New connections should round-trip. The sender retries with backoff
 	// if listener2's registration races with the dial.

--- a/mockrelay/testharness/parity/control_events_test.go
+++ b/mockrelay/testharness/parity/control_events_test.go
@@ -1,0 +1,221 @@
+package parity
+
+import (
+	"context"
+	"crypto/tls"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/coder/websocket"
+
+	"github.com/philsphicas/aztunnel/internal/listener"
+	"github.com/philsphicas/aztunnel/internal/metrics"
+	"github.com/philsphicas/aztunnel/internal/relay"
+	"github.com/philsphicas/aztunnel/mockrelay/server"
+)
+
+// startFaultyMockRelay stands up an in-process mock relay with the
+// supplied fault-injection options. Returns the host:port the
+// listener should dial, plus the ClientOptions wired with
+// InsecureSkipVerify so the listener accepts httptest's self-signed
+// certificate — the only TLS path that matters in this test is the
+// fault-injection one. The server is registered for cleanup on t.
+func startFaultyMockRelay(t *testing.T, opts ...server.Option) (string, relay.ClientOptions) {
+	t.Helper()
+	rs, err := server.NewServerForTesting(server.Config{
+		Logger:            slog.New(slog.NewTextHandler(io.Discard, nil)),
+		RendezvousTimeout: 1 * time.Second,
+	}, opts...)
+	if err != nil {
+		t.Fatalf("new mock relay: %v", err)
+	}
+	srv := httptest.NewTLSServer(rs.Handler())
+	t.Cleanup(srv.Close)
+	u, _ := url.Parse(srv.URL)
+	return u.Host, relay.ClientOptions{
+		TLSConfig: &tls.Config{InsecureSkipVerify: true}, //nolint:gosec // test cert
+	}
+}
+
+// startFaultyListener brings up an in-process aztunnel listener wired
+// to host with the supplied RenewInterval (zero selects the package
+// default). Returns the captured-log accessor and a Stop closure.
+// The listener goroutine is joined by t.Cleanup so a panicking test
+// doesn't leak it across tests.
+func startFaultyListener(t *testing.T, host string, opts relay.ClientOptions, renewInterval time.Duration) (func() string, func()) {
+	t.Helper()
+	logs := newCaptureBuffer()
+	cfg := listener.Config{
+		Endpoint:      host,
+		EntityPath:    mustEntityName(t),
+		TokenProvider: &relay.SASTokenProvider{KeyName: server.DefaultSASKeyName, Key: server.DefaultSASKey},
+		ClientOptions: opts,
+		Logger:        slog.New(slog.NewTextHandler(logs, nil)),
+		Metrics:       metrics.New(),
+		RenewInterval: renewInterval,
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		_ = listener.ListenAndServe(ctx, cfg)
+	}()
+	var stopOnce sync.Once
+	stop := func() {
+		stopOnce.Do(func() {
+			cancel()
+			<-done
+		})
+	}
+	t.Cleanup(stop)
+	return logs.String, stop
+}
+
+// waitForLogContaining polls logs() at 20ms until every needle is
+// present in the captured output OR timeout elapses. Returns the
+// snapshot at success; fails the test at deadline.
+func waitForLogContaining(t *testing.T, logs func() string, timeout time.Duration, needles ...string) string {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		s := logs()
+		hit := true
+		for _, n := range needles {
+			if !strings.Contains(s, n) {
+				hit = false
+				break
+			}
+		}
+		if hit {
+			return s
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatalf("did not observe all needles %v within %s; captured:\n%s",
+		needles, timeout, logs())
+	return ""
+}
+
+// TestControl_Events_ConnectionLostOnRenew arms the mock relay to
+// send a polite close on the listener's control WebSocket as soon as
+// it sees the listener's first renewToken frame. The listener's
+// write to the local TCP send buffer succeeds (so renew_ok is
+// emitted), and the read loop then observes the close — emitting
+// control_ended{reason=read_failed}. This pair is the
+// operator-visible signature for "the control channel was dropped
+// during a renew round-trip".
+//
+// The complementary code path where ws.Write itself fails (yielding
+// renew_failed{code=connection_lost}) is exercised in
+// internal/relay/control_test.go TestRenewOnce/write_failure_*.
+func TestControl_Events_ConnectionLostOnRenew(t *testing.T) {
+	host, copts := startFaultyMockRelay(t, server.WithCloseControlOnRenew())
+	logs, _ := startFaultyListener(t, host, copts, 100*time.Millisecond)
+
+	waitForLogContaining(t, logs, 10*time.Second,
+		`msg=`+relay.EventRenewOK)
+	waitForLogContaining(t, logs, 10*time.Second,
+		`msg=`+relay.EventControlEnded,
+		`reason=`+relay.ControlEndedReadFailed)
+}
+
+// TestControl_Events_RejectControlDial arms the mock relay to refuse
+// the listener's control dial with HTTP 503. control_started is
+// emitted only after a successful dial, so a refused control-channel
+// dial leaves control_ended{reason=dial_failed} as the single
+// lifecycle event for the failed attempt — that's the
+// operator-visible signal the dial never reached the relay.
+func TestControl_Events_RejectControlDial(t *testing.T) {
+	host, copts := startFaultyMockRelay(t, server.WithRejectControlDial())
+	logs, _ := startFaultyListener(t, host, copts, 0)
+
+	waitForLogContaining(t, logs, 10*time.Second,
+		`msg=`+relay.EventControlEnded,
+		`reason=`+relay.ControlEndedDialFailed)
+}
+
+// TestControl_Events_AcceptDropped_DialFailed drives an
+// accept_dropped{reason=dial_failed} log line by standing up a
+// custom TLS test server that acts as the relay control channel,
+// emits an accept frame whose `address` field points at a closed
+// TCP port, then waits for the listener to log the drop event.
+//
+// The mockrelay fault knobs do not include a way to corrupt the
+// accept frame address, so this test bypasses mockrelay entirely
+// and exercises the relay-package read loop → handleAccept dial
+// path against a hand-rolled control-channel server. The unit test
+// TestHandleAccept/emits_accept_dropped_on_dial_failure covers the
+// same code path in isolation; this test confirms the full
+// listener.ListenAndServe wiring emits the event on the integrated
+// path.
+func TestControl_Events_AcceptDropped_DialFailed(t *testing.T) {
+	refused := "ws://" + refusedAddr(t)
+	host, copts := startCustomControlServer(t, refused)
+	logs, _ := startFaultyListener(t, host, copts, 0)
+
+	waitForLogContaining(t, logs, 10*time.Second,
+		`msg=`+relay.EventAcceptAttempted)
+	waitForLogContaining(t, logs, 10*time.Second,
+		`msg=`+relay.EventAcceptDropped,
+		`reason=`+relay.AcceptDroppedDialFailed)
+}
+
+// refusedAddr binds a TCP listener to a free port, closes it, and
+// returns "127.0.0.1:N". A connect attempt to that address gets
+// ECONNREFUSED.
+func refusedAddr(t *testing.T) string {
+	t.Helper()
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("net.Listen: %v", err)
+	}
+	addr := l.Addr().String()
+	if err := l.Close(); err != nil {
+		t.Fatalf("close listener: %v", err)
+	}
+	return addr
+}
+
+// startCustomControlServer stands up a TLS HTTP server that
+// accepts the listener's control-channel WS upgrade and sends a
+// single accept frame whose `address` field points at acceptAddr.
+// It returns the host:port to use as Endpoint and the
+// ClientOptions wired to the test cert. The server is registered
+// for cleanup on t.
+func startCustomControlServer(t *testing.T, acceptAddr string) (string, relay.ClientOptions) {
+	t.Helper()
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ws, err := websocket.Accept(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer ws.CloseNow() //nolint:errcheck // best-effort cleanup
+		payload, _ := json.Marshal(map[string]any{
+			"accept": map[string]any{
+				"address": acceptAddr,
+				"id":      "test-id",
+			},
+		})
+		if err := ws.Write(r.Context(), websocket.MessageText, payload); err != nil {
+			return
+		}
+		// Hold the control channel open until the listener
+		// cancels its context — this keeps the test focused on
+		// the accept_dropped emission, not the loop teardown.
+		<-r.Context().Done()
+	}))
+	t.Cleanup(srv.Close)
+	u, _ := url.Parse(srv.URL)
+	return u.Host, relay.ClientOptions{
+		TLSConfig: &tls.Config{InsecureSkipVerify: true}, //nolint:gosec // test cert
+	}
+}


### PR DESCRIPTION
## What this changes

Listener control-channel log lines now use a stable set of eight
event names so an operator can grep mechanically instead of matching
prose variants:

| Event              | When it fires                          | Notable attributes                       |
| ------------------ | -------------------------------------- | ---------------------------------------- |
| `control_started`  | Control WS dial succeeded              | `relay_url`, `listener_name`             |
| `control_ended`    | Control loop exits                     | `reason`, `error`, `duration_seconds`    |
| `renew_attempted`  | Before each renew dial                 | `attempt`, `expires_at`                  |
| `renew_ok`         | Renew round-trip completed             | `attempt`, `new_expires_at_seconds`, `elapsed_ms` |
| `renew_failed`     | Terminal renew failure                 | `attempt`, `elapsed_ms`, `error`, `code` |
| `accept_attempted` | Incoming accept frame                  | (just session id)                        |
| `accept_ok`        | Accept dial succeeded (control-channel side) | (just session id)                  |
| `accept_dropped`   | Accept rejected (semaphore full, etc.) | `reason`                                 |

Every record carries the `control_session_id` introduced in #73, so
"give me the lifecycle of this listener" is one filter.

Two small constant sets in `internal/relay/control_events.go` tag the
failure flavour:

- `renew_failed.code` ∈ `connection_lost` / `auth_failed` /
  `context_cancelled` / `token_fetch_failed`
- `accept_dropped.reason` ∈ `semaphore_full` / `dial_failed` /
  `auth_failed`
- `control_ended.reason` adds `read_failed` / `dial_failed` /
  `auth_failed` / `token_fetch_failed` / `renew_failed` /
  `ping_failed` / `context_cancelled`

## Operator-visible improvement

Queries that previously had to match multiple message variants —
"connection lost", "renew error", "renew failed" — collapse to a
single filter like `msg=renew_failed` or `msg=control_ended
reason=read_failed`. The constants are exported, so test harnesses
and operator runbooks share one source of truth.

## Control-ended classification

`control_ended.reason` is the first cause observed across the renew,
ping, and read goroutines (first-writer-wins via an atomic gate). A
graceful shutdown — Ctrl-C while a renew/dial/token-fetch is in
flight — classifies as `context_cancelled` rather than the specific
cause that happened to be active at the moment of cancellation.

## Scope

Logging only. No control-channel behaviour changed. The outer
reconnect log in `ListenAndServe` is intentionally out of scope and
stays — that line lives outside the per-session id binding.

## Tests

- `TestControl_HappyPathEvents` (unit) — end-to-end stub asserts
  `control_started → renew_attempted → renew_ok → accept_attempted
  → accept_ok → control_ended` order.
- `TestRenewOnce/write_failure_returns_immediately_without_retry`
  (unit) — asserts `renew_failed{code=connection_lost}` on a write
  failure.
- `mockrelay/testharness/parity/control_events_test.go` (parity) —
  three fault-injected tests for `read_failed` on a server close
  during renew, `dial_failed` on a refused control dial, and
  `accept_dropped{reason=dial_failed}` on a refused accept target.
- `e2e/control_events_test.go` (Azure, `//go:build e2e`) — Azure
  success-path assertion of the lifecycle event names.

`go test -race ./...` (root + mockrelay) and `golangci-lint run ./...`
green locally.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
