### PR TITLE
feat(obs): classify bridge end-cause via cancel-cause sentinels

### DIFF
--- a/cmd/aztunnel/arc_connect.go
+++ b/cmd/aztunnel/arc_connect.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/philsphicas/aztunnel/internal/arc"
 	"github.com/philsphicas/aztunnel/internal/metrics"
+	"github.com/philsphicas/aztunnel/internal/relay"
 )
 
 // ArcConnectCmd connects stdin/stdout through an Arc relay.
@@ -71,7 +72,20 @@ func (c *ArcConnectCmd) Run(globals *Globals, arcCmd *ArcCmd) error {
 	logger.Debug("connected to arc relay", "resource", resourceID)
 
 	stdio := &arcStdioConn{in: os.Stdin, out: os.Stdout}
-	_, bridgeErr := m.TrackedBridge(ctx, ws, stdio, "sender", target)
+	stats, bridgeErr := m.TrackedBridge(ctx, ws, stdio, "sender", target)
+	attrs := []any{
+		"target", target,
+		"cause", stats.Cause,
+		"tcp_to_ws", stats.TCPToWS,
+		"ws_to_tcp", stats.WSToTCP,
+	}
+	if bridgeErr != nil {
+		attrs = append(attrs, "error", bridgeErr)
+	}
+	if code, ok := relay.WSCloseCode(bridgeErr); ok {
+		attrs = append(attrs, "close_code", code)
+	}
+	logger.Debug("bridge ended", attrs...)
 	return bridgeErr
 }
 

--- a/cmd/aztunnel/arc_port_forward.go
+++ b/cmd/aztunnel/arc_port_forward.go
@@ -119,14 +119,20 @@ func (p *ArcPortForwardCmd) Run(globals *Globals, arcCmd *ArcCmd) error {
 			}
 			defer func() { _ = ws.CloseNow() }()
 
-			_, bridgeErr := m.TrackedBridge(ctx, ws, conn, "sender", target)
-			if bridgeErr != nil {
-				attrs := []any{"error", bridgeErr}
-				if code, ok := relay.WSCloseCode(bridgeErr); ok {
-					attrs = append(attrs, "close_code", code)
-				}
-				logger.Debug("bridge ended", attrs...)
+			stats, bridgeErr := m.TrackedBridge(ctx, ws, conn, "sender", target)
+			attrs := []any{
+				"target", target,
+				"cause", stats.Cause,
+				"tcp_to_ws", stats.TCPToWS,
+				"ws_to_tcp", stats.WSToTCP,
 			}
+			if bridgeErr != nil {
+				attrs = append(attrs, "error", bridgeErr)
+			}
+			if code, ok := relay.WSCloseCode(bridgeErr); ok {
+				attrs = append(attrs, "close_code", code)
+			}
+			logger.Debug("bridge ended", attrs...)
 		}()
 	}
 }

--- a/e2e/azure_backend_test.go
+++ b/e2e/azure_backend_test.go
@@ -73,7 +73,10 @@ func (b *azureBackend) Setup(t testing.TB, opts relayparity.SetupOptions) *relay
 	env := b.acquireEnv(t)
 	auth := authFromEnv(t, env, b.authName)
 
-	listenerArgs := []string{"--metrics-addr", "127.0.0.1:0"}
+	// Parity backend runs at debug log level so observability
+	// scenarios can assert on Debug-level lifecycle lines
+	// (e.g. "bridge ended") without per-scenario log-level overrides.
+	listenerArgs := []string{"--metrics-addr", "127.0.0.1:0", "--log-level", "debug"}
 	for _, target := range opts.AllowedTargets {
 		listenerArgs = append(listenerArgs, "--allow", target)
 	}
@@ -101,7 +104,7 @@ func (b *azureBackend) Setup(t testing.TB, opts relayparity.SetupOptions) *relay
 		}
 	}
 
-	senderArgs := []string{"--metrics-addr", "127.0.0.1:0"}
+	senderArgs := []string{"--metrics-addr", "127.0.0.1:0", "--log-level", "debug"}
 
 	listeners := make([]*relayparity.Listener, 0, opts.NumListeners)
 	for i := 0; i < opts.NumListeners; i++ {

--- a/internal/bridgecause/causes.go
+++ b/internal/bridgecause/causes.go
@@ -1,0 +1,99 @@
+// Package bridgecause defines sentinel errors that classify why a
+// bridge ended. Cancel sites that abort a bridge stamp their sentinel
+// via context.WithCancelCause; the bridge resolves the final cause
+// via context.Cause(ctx) and surfaces a stable short name through
+// Name() so listener/sender bridge-end log lines carry a structured
+// cause attribute operators can grep on.
+package bridgecause
+
+import (
+	"context"
+	"errors"
+)
+
+// Sentinels covering every cause a bridge end can be classified as.
+// Match exactly one of the labels returned by Name. Wrap with %w for
+// callers that want richer messages — Name uses errors.Is.
+//
+// The "Cause" prefix (vs. the conventional "Err") names the runtime
+// concept: these sentinels are passed to context.WithCancelCause and
+// recovered through context.Cause(ctx); they are not user-facing
+// errors operators inspect directly, only via Name's structured-log
+// label. Hence the lint override below.
+//
+//nolint:staticcheck // ST1012: intentional Cause* naming to match cancel-cause runtime semantics.
+var (
+	// CausePeerClose indicates the remote WebSocket peer closed the
+	// bridge: a Close frame (normal or otherwise), an abrupt drop the
+	// websocket layer surfaces as a CloseError, or a ws.Write failure
+	// that proves the peer is no longer reachable.
+	CausePeerClose = errors.New("bridge: peer close")
+
+	// CauseLocalClose indicates the local end of the bridge closed:
+	// the TCP target EOF'd, or a local write/read failed because the
+	// local socket went away. On the sender side this is the client
+	// hanging up; on the listener side this is the upstream target
+	// closing.
+	CauseLocalClose = errors.New("bridge: local close")
+
+	// CauseUserCancel indicates the bridge ended because the user
+	// (or the process) cancelled the parent context. Name(...) also
+	// reports user_cancel for plain context.Canceled, so signal-
+	// driven shutdown paths surface the same label without callers
+	// having to wrap their context with WithCancelCause.
+	CauseUserCancel = errors.New("bridge: user cancel")
+
+	// CauseRenewFailure indicates the control channel tore the bridge
+	// down because token renewal failed. Stamped by the listener's
+	// renewLoop when GetToken or the renewToken write fail.
+	CauseRenewFailure = errors.New("bridge: control renew failure")
+
+	// CauseControlError indicates a non-renew control-channel failure
+	// (control ping failure, control read failure, bad frame) tore
+	// the bridge down. Stamped by the listener's pingLoop and by the
+	// control-loop main read on a non-cancel error.
+	CauseControlError = errors.New("bridge: control error")
+
+	// CauseTimeout indicates a timeout (idle, read, dial deadline)
+	// ended the bridge. Name(...) also reports timeout for plain
+	// context.DeadlineExceeded so deadline-driven shutdown paths
+	// surface the same label without explicit wrapping.
+	CauseTimeout = errors.New("bridge: timeout")
+
+	// CauseUnknown is the fallback when no specific cause was stamped
+	// and the context error does not match any classified sentinel.
+	CauseUnknown = errors.New("bridge: unknown")
+)
+
+// Name returns a short, stable, structured-log-friendly label for
+// err: one of peer_close, local_close, user_cancel, renew_failure,
+// control_error, timeout, unknown.
+//
+// Recognised inputs include the bridgecause sentinels (matched via
+// errors.Is so wrapped errors work), context.Canceled (user_cancel),
+// and context.DeadlineExceeded (timeout). nil and any unrecognised
+// error map to unknown.
+func Name(err error) string {
+	switch {
+	case err == nil:
+		return "unknown"
+	case errors.Is(err, CausePeerClose):
+		return "peer_close"
+	case errors.Is(err, CauseLocalClose):
+		return "local_close"
+	case errors.Is(err, CauseUserCancel):
+		return "user_cancel"
+	case errors.Is(err, CauseRenewFailure):
+		return "renew_failure"
+	case errors.Is(err, CauseControlError):
+		return "control_error"
+	case errors.Is(err, CauseTimeout):
+		return "timeout"
+	case errors.Is(err, context.DeadlineExceeded):
+		return "timeout"
+	case errors.Is(err, context.Canceled):
+		return "user_cancel"
+	default:
+		return "unknown"
+	}
+}

--- a/internal/bridgecause/causes_test.go
+++ b/internal/bridgecause/causes_test.go
@@ -1,0 +1,100 @@
+package bridgecause
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+)
+
+func TestName_NilIsUnknown(t *testing.T) {
+	if got := Name(nil); got != "unknown" {
+		t.Errorf("Name(nil) = %q, want %q", got, "unknown")
+	}
+}
+
+func TestName_Sentinels(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want string
+	}{
+		{"PeerClose", CausePeerClose, "peer_close"},
+		{"LocalClose", CauseLocalClose, "local_close"},
+		{"UserCancel", CauseUserCancel, "user_cancel"},
+		{"RenewFailure", CauseRenewFailure, "renew_failure"},
+		{"ControlError", CauseControlError, "control_error"},
+		{"Timeout", CauseTimeout, "timeout"},
+		{"Unknown", CauseUnknown, "unknown"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := Name(tc.err); got != tc.want {
+				t.Errorf("Name(%v) = %q, want %q", tc.err, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestName_Wrapped(t *testing.T) {
+	// errors.Is unwrapping must keep classification stable so callers
+	// can wrap with %w for context without losing the cause label.
+	wrapped := fmt.Errorf("renew at attempt 3: %w", CauseRenewFailure)
+	if got := Name(wrapped); got != "renew_failure" {
+		t.Errorf("Name(wrapped renew) = %q, want %q", got, "renew_failure")
+	}
+}
+
+func TestName_DoubleWrapped(t *testing.T) {
+	inner := fmt.Errorf("get token: %w", CauseRenewFailure)
+	outer := fmt.Errorf("control loop: %w", inner)
+	if got := Name(outer); got != "renew_failure" {
+		t.Errorf("Name(double wrapped) = %q, want %q", got, "renew_failure")
+	}
+}
+
+func TestName_StdlibCanceledIsUserCancel(t *testing.T) {
+	// The production CLI's signal.NotifyContext uses plain
+	// context.WithCancel, so the descendant bridge ctx ends up with
+	// context.Canceled (no cause). Name must surface user_cancel for
+	// that case so operator-visible logs carry the intended label.
+	if got := Name(context.Canceled); got != "user_cancel" {
+		t.Errorf("Name(context.Canceled) = %q, want %q", got, "user_cancel")
+	}
+}
+
+func TestName_StdlibDeadlineExceededIsTimeout(t *testing.T) {
+	if got := Name(context.DeadlineExceeded); got != "timeout" {
+		t.Errorf("Name(context.DeadlineExceeded) = %q, want %q", got, "timeout")
+	}
+}
+
+func TestName_WrappedStdlibCanceledIsUserCancel(t *testing.T) {
+	wrapped := fmt.Errorf("ws.Read: %w", context.Canceled)
+	if got := Name(wrapped); got != "user_cancel" {
+		t.Errorf("Name(wrapped Canceled) = %q, want %q", got, "user_cancel")
+	}
+}
+
+func TestName_UnclassifiedError(t *testing.T) {
+	if got := Name(errors.New("synthetic")); got != "unknown" {
+		t.Errorf("Name(synthetic) = %q, want %q", got, "unknown")
+	}
+}
+
+func TestSentinels_AllDistinct(t *testing.T) {
+	// Defensive against future copy-paste regressions: every sentinel
+	// must be a distinct identity so errors.Is classification stays
+	// unambiguous.
+	sentinels := []error{
+		CausePeerClose, CauseLocalClose, CauseUserCancel,
+		CauseRenewFailure, CauseControlError, CauseTimeout, CauseUnknown,
+	}
+	for i := range sentinels {
+		for j := i + 1; j < len(sentinels); j++ {
+			if errors.Is(sentinels[i], sentinels[j]) {
+				t.Errorf("sentinel %d and %d are not distinct", i, j)
+			}
+		}
+	}
+}

--- a/internal/listener/listener.go
+++ b/internal/listener/listener.go
@@ -190,14 +190,20 @@ func handleConnection(ctx context.Context, ws *websocket.Conn, cfg Config) {
 	}
 
 	// Bridge data.
-	_, bridgeErr := cfg.Metrics.TrackedBridge(ctx, ws, conn, "listener", env.Target)
-	if bridgeErr != nil {
-		attrs := []any{"target", env.Target, "error", bridgeErr}
-		if code, ok := relay.WSCloseCode(bridgeErr); ok {
-			attrs = append(attrs, "close_code", code)
-		}
-		logger.Debug("bridge ended", attrs...)
+	stats, bridgeErr := cfg.Metrics.TrackedBridge(ctx, ws, conn, "listener", env.Target)
+	attrs := []any{
+		"target", env.Target,
+		"cause", stats.Cause,
+		"tcp_to_ws", stats.TCPToWS,
+		"ws_to_tcp", stats.WSToTCP,
 	}
+	if bridgeErr != nil {
+		attrs = append(attrs, "error", bridgeErr)
+	}
+	if code, ok := relay.WSCloseCode(bridgeErr); ok {
+		attrs = append(attrs, "close_code", code)
+	}
+	logger.Debug("bridge ended", attrs...)
 }
 
 func sendResponse(ctx context.Context, ws *websocket.Conn, cfg Config, ok bool, errMsg string) error {

--- a/internal/relay/bridge.go
+++ b/internal/relay/bridge.go
@@ -9,6 +9,8 @@ import (
 	"time"
 
 	"github.com/coder/websocket"
+
+	"github.com/philsphicas/aztunnel/internal/bridgecause"
 )
 
 const (
@@ -18,38 +20,68 @@ const (
 	bridgePingTimeout  = 10 * time.Second
 )
 
-// BridgeStats holds byte counters for a completed bridge.
+// BridgeStats holds the post-mortem of a completed bridge: bidirectional
+// byte counts and a short classifier ("peer_close", "local_close",
+// "renew_failure", ...) that operators log to triage why the bridge
+// ended. Cause is one of the labels returned by bridgecause.Name.
 type BridgeStats struct {
-	TCPToWS int64 // bytes copied from the TCP/local side to the WebSocket
-	WSToTCP int64 // bytes copied from the WebSocket to the TCP/local side
+	TCPToWS int64  // bytes copied from the TCP/local side to the WebSocket
+	WSToTCP int64  // bytes copied from the WebSocket to the TCP/local side
+	Cause   string // classifier from bridgecause.Name(context.Cause(...))
 }
 
-// Bridge copies data bidirectionally between a WebSocket connection and a
-// TCP connection until one side closes or the context is cancelled.
-// It returns byte-transfer statistics and the first error from either direction.
+// pumpResult identifies which I/O operation a bridge pump exited on
+// so the cause classifier can distinguish a peer-side failure
+// (ws.Write to a dead peer) from a local-side failure (tcp.Read EOF)
+// when the two pumps share a single error channel.
+type pumpResult struct {
+	op  string // "ws_read" / "ws_write" / "tcp_read" / "tcp_write"
+	err error
+}
+
+// Bridge copies data bidirectionally between a WebSocket connection
+// and a TCP connection until one side closes or the context is
+// cancelled. It returns byte-transfer statistics including a Cause
+// classifier and the first error from either direction.
+//
+// The classifier comes from context.Cause on an internal
+// WithCancelCause-derived child context. Cause-cancel is first-cancel-
+// wins: whichever site cancels the child ctx first sets the cause for
+// the rest of the bridge's lifetime, and subsequent cancels are no-ops.
+//
+//   - If a pump returns first (peer close, local EOF, I/O error), the
+//     bridge stamps peer_close / local_close / timeout via cancel(...)
+//     before draining the other pump.
+//   - If the parent ctx is cancelled with a cause (e.g.
+//     CauseRenewFailure from the control loop) while both pumps are
+//     still running, that cause propagates down to the child first;
+//     the bridge's later pump-exit cancel is then the no-op, and the
+//     parent's cause wins.
 func Bridge(ctx context.Context, ws *websocket.Conn, tcp net.Conn) (BridgeStats, error) {
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
+	ctx, cancel := context.WithCancelCause(ctx)
+	defer cancel(nil)
 
 	var tcpToWSBytes, wsToTCPBytes atomic.Int64
-	errc := make(chan error, 2)
+	errc := make(chan pumpResult, 2)
 
 	// WebSocket → TCP
 	go func() {
-		errc <- wsToTCP(ctx, ws, tcp, &wsToTCPBytes)
+		op, err := wsToTCP(ctx, ws, tcp, &wsToTCPBytes)
+		errc <- pumpResult{op: op, err: err}
 	}()
 
 	// TCP → WebSocket
 	go func() {
-		errc <- tcpToWS(ctx, ws, tcp, &tcpToWSBytes)
+		op, err := tcpToWS(ctx, ws, tcp, &tcpToWSBytes)
+		errc <- pumpResult{op: op, err: err}
 	}()
 
 	// WebSocket keepalive pings to prevent Azure Relay idle timeout.
 	go bridgePingLoop(ctx, ws)
 
 	// Wait for the first direction to finish, then cancel the other.
-	err := <-errc
-	cancel()
+	first := <-errc
+	cancel(causeFromPumpExit(first.op, first.err))
 	// Unblock tcp.Read in tcpToWS by closing the read side.
 	_ = tcp.SetReadDeadline(time.Now())
 	<-errc
@@ -57,8 +89,55 @@ func Bridge(ctx context.Context, ws *websocket.Conn, tcp net.Conn) (BridgeStats,
 	stats := BridgeStats{
 		TCPToWS: tcpToWSBytes.Load(),
 		WSToTCP: wsToTCPBytes.Load(),
+		Cause:   bridgecause.Name(context.Cause(ctx)),
 	}
-	return stats, err
+	return stats, first.err
+}
+
+// causeFromPumpExit picks the sentinel a pump's exit should stamp on
+// the bridge ctx. The bridge ctx's cancel is idempotent, so the
+// returned sentinel only wins when the bridge ctx has not already
+// been cancelled (e.g. by a WithCancelCause parent).
+//
+// Classification rules:
+//
+//   - nil + ws_read: the WebSocket peer closed cleanly → peer_close.
+//   - nil + tcp_read: the local TCP side EOF'd → local_close.
+//   - net.Error.Timeout(): timeout regardless of side.
+//   - websocket.CloseError: the peer surfaced a close frame
+//     (including the synthetic 1006 the websocket layer reports on
+//     abrupt drop) → peer_close.
+//   - ws_read/ws_write non-nil: an I/O failure on the peer-facing
+//     half of the bridge → peer_close.
+//   - tcp_read/tcp_write non-nil: an I/O failure on the local half →
+//     local_close.
+//   - context.Canceled / DeadlineExceeded: return as-is; the bridge
+//     ctx's existing cause (or the stdlib alias mapping in
+//     bridgecause.Name) wins.
+func causeFromPumpExit(op string, err error) error {
+	if err == nil {
+		if op == "ws_read" {
+			return bridgecause.CausePeerClose
+		}
+		return bridgecause.CauseLocalClose
+	}
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return err
+	}
+	var netErr net.Error
+	if errors.As(err, &netErr) && netErr.Timeout() {
+		return bridgecause.CauseTimeout
+	}
+	var closeErr websocket.CloseError
+	if errors.As(err, &closeErr) {
+		return bridgecause.CausePeerClose
+	}
+	switch op {
+	case "ws_read", "ws_write":
+		return bridgecause.CausePeerClose
+	default:
+		return bridgecause.CauseLocalClose
+	}
 }
 
 // bridgePingLoop sends periodic WebSocket pings to keep the data channel alive.
@@ -77,32 +156,40 @@ func bridgePingLoop(ctx context.Context, ws *websocket.Conn) {
 	}
 }
 
-func wsToTCP(ctx context.Context, ws *websocket.Conn, tcp net.Conn, count *atomic.Int64) error {
+// wsToTCP pumps data from the WebSocket to the local TCP side and
+// returns the operation tag plus its terminating error. The op tag
+// is what causeFromPumpExit consults to distinguish a peer-side
+// failure (ws_read) from a local-side failure (tcp_write).
+func wsToTCP(ctx context.Context, ws *websocket.Conn, tcp net.Conn, count *atomic.Int64) (string, error) {
 	for {
 		_, r, err := ws.Reader(ctx)
 		if err != nil {
-			return ignoreNormalClose(err)
+			return "ws_read", ignoreNormalClose(err)
 		}
 		n, err := io.Copy(tcp, r)
 		count.Add(n)
 		if err != nil {
-			return err
+			return "tcp_write", err
 		}
 	}
 }
 
-func tcpToWS(ctx context.Context, ws *websocket.Conn, tcp net.Conn, count *atomic.Int64) error {
+// tcpToWS pumps data from the local TCP side to the WebSocket and
+// returns the operation tag plus its terminating error. ws.Write
+// failures here are peer-side (the peer's read half died), not
+// local-side; the op tag preserves that distinction.
+func tcpToWS(ctx context.Context, ws *websocket.Conn, tcp net.Conn, count *atomic.Int64) (string, error) {
 	buf := make([]byte, 32*1024)
 	for {
 		n, err := tcp.Read(buf)
 		if n > 0 {
 			if wErr := ws.Write(ctx, websocket.MessageBinary, buf[:n]); wErr != nil {
-				return wErr
+				return "ws_write", wErr
 			}
 			count.Add(int64(n))
 		}
 		if err != nil {
-			return ignoreEOF(err)
+			return "tcp_read", ignoreEOF(err)
 		}
 	}
 }

--- a/internal/relay/bridge_test.go
+++ b/internal/relay/bridge_test.go
@@ -13,6 +13,8 @@ import (
 	"time"
 
 	"github.com/coder/websocket"
+
+	"github.com/philsphicas/aztunnel/internal/bridgecause"
 )
 
 func TestBridge(t *testing.T) {
@@ -312,5 +314,204 @@ func TestWSCloseCode_WrappedCloseError(t *testing.T) {
 	}
 	if code != 1011 {
 		t.Errorf("code=%d; want 1011", code)
+	}
+}
+
+// TestBridge_Cause_PeerNormalClose drives a bridge where the WS server
+// sends a normal close frame. The wsToTCP pump returns first with op=ws_read
+// and a nil error (normal close is filtered to nil by ignoreNormalClose),
+// so the bridge stamps CausePeerClose.
+func TestBridge_Cause_PeerNormalClose(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ws, err := websocket.Accept(w, r, nil)
+		if err != nil {
+			return
+		}
+		// Send a normal close to the client and exit. The bridge's
+		// wsToTCP pump observes a normal close and returns (ws_read, nil).
+		_ = ws.Close(websocket.StatusNormalClosure, "bye")
+	}))
+	defer srv.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(srv.URL, "http")
+	ws, _, err := websocket.Dial(context.Background(), wsURL, nil)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer ws.CloseNow()
+
+	clientConn, serverConn := net.Pipe()
+	defer clientConn.Close()
+	defer serverConn.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	stats, _ := Bridge(ctx, ws, serverConn)
+	if stats.Cause != "peer_close" {
+		t.Errorf("Cause = %q, want %q", stats.Cause, "peer_close")
+	}
+}
+
+// TestBridge_Cause_LocalEOF closes the local TCP side; the tcpToWS pump
+// reads EOF and returns (tcp_read, nil), stamping CauseLocalClose.
+func TestBridge_Cause_LocalEOF(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ws, err := websocket.Accept(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer ws.CloseNow()
+		for {
+			if _, _, err := ws.Read(r.Context()); err != nil {
+				return
+			}
+		}
+	}))
+	defer srv.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(srv.URL, "http")
+	ws, _, err := websocket.Dial(context.Background(), wsURL, nil)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer ws.CloseNow()
+
+	clientConn, serverConn := net.Pipe()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	type result struct {
+		stats BridgeStats
+		err   error
+	}
+	ch := make(chan result, 1)
+	go func() {
+		s, e := Bridge(ctx, ws, serverConn)
+		ch <- result{s, e}
+	}()
+
+	// Close the local side; tcp.Read returns EOF, tcpToWS returns
+	// (tcp_read, nil) after ignoreEOF, and the bridge stamps
+	// CauseLocalClose.
+	_ = clientConn.Close()
+
+	select {
+	case res := <-ch:
+		if res.stats.Cause != "local_close" {
+			t.Errorf("Cause = %q, want %q", res.stats.Cause, "local_close")
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("bridge did not terminate")
+	}
+	_ = serverConn.Close()
+}
+
+// TestBridge_Cause_ParentCanceled cancels the bridge's parent context
+// with CauseUserCancel via WithCancelCause. The cause propagates down
+// to Bridge's internal child ctx, so context.Cause(internalCtx) returns
+// CauseUserCancel and bridgecause.Name maps it to "user_cancel".
+func TestBridge_Cause_ParentCanceled(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ws, err := websocket.Accept(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer ws.CloseNow()
+		for {
+			if _, _, err := ws.Read(r.Context()); err != nil {
+				return
+			}
+		}
+	}))
+	defer srv.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(srv.URL, "http")
+	ws, _, err := websocket.Dial(context.Background(), wsURL, nil)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer ws.CloseNow()
+
+	clientConn, serverConn := net.Pipe()
+	defer clientConn.Close()
+	defer serverConn.Close()
+
+	parent, parentCancel := context.WithCancelCause(context.Background())
+
+	type result struct {
+		stats BridgeStats
+		err   error
+	}
+	ch := make(chan result, 1)
+	go func() {
+		s, e := Bridge(parent, ws, serverConn)
+		ch <- result{s, e}
+	}()
+
+	parentCancel(bridgecause.CauseUserCancel)
+
+	select {
+	case res := <-ch:
+		if res.stats.Cause != "user_cancel" {
+			t.Errorf("Cause = %q, want %q", res.stats.Cause, "user_cancel")
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("bridge did not terminate after parent cancel")
+	}
+}
+
+// TestBridge_Cause_ExternalSiteCancel simulates the control loop tearing
+// the bridge down on renew failure: the caller cancels the bridge ctx
+// with CauseRenewFailure mid-flight. The Bridge sees its internal ctx
+// done with that cause and reports stats.Cause == "renew_failure".
+func TestBridge_Cause_ExternalSiteCancel(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ws, err := websocket.Accept(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer ws.CloseNow()
+		for {
+			if _, _, err := ws.Read(r.Context()); err != nil {
+				return
+			}
+		}
+	}))
+	defer srv.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(srv.URL, "http")
+	ws, _, err := websocket.Dial(context.Background(), wsURL, nil)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer ws.CloseNow()
+
+	clientConn, serverConn := net.Pipe()
+	defer clientConn.Close()
+	defer serverConn.Close()
+
+	bridgeCtx, bridgeCancel := context.WithCancelCause(context.Background())
+
+	type result struct {
+		stats BridgeStats
+		err   error
+	}
+	ch := make(chan result, 1)
+	go func() {
+		s, e := Bridge(bridgeCtx, ws, serverConn)
+		ch <- result{s, e}
+	}()
+
+	bridgeCancel(bridgecause.CauseRenewFailure)
+
+	select {
+	case res := <-ch:
+		if res.stats.Cause != "renew_failure" {
+			t.Errorf("Cause = %q, want %q", res.stats.Cause, "renew_failure")
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("bridge did not terminate after external cancel")
 	}
 }

--- a/internal/relay/control.go
+++ b/internal/relay/control.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/coder/websocket"
 
+	"github.com/philsphicas/aztunnel/internal/bridgecause"
 	"github.com/philsphicas/aztunnel/internal/idgen"
 )
 
@@ -233,14 +234,22 @@ func runControlLoop(ctx context.Context, cfg ControlConfig) (connected bool, err
 	}
 	connected = true
 
-	// Cancel used by ping/renew failure to force reconnect.
-	loopCtx, loopCancel := context.WithCancel(ctx)
-	defer loopCancel()
+	// Cancel used by ping/renew failure to force reconnect. The
+	// internal cancel carries a bridgecause sentinel so in-flight
+	// bridges observe context.Cause(ctx) == CauseRenewFailure or
+	// CauseControlError when the control loop tears them down,
+	// rather than the unclassified context.Canceled.
+	loopCtx, loopCancel := context.WithCancelCause(ctx)
 
 	sem := newConnSemaphore(cfg.MaxConnections)
 
 	var wg sync.WaitGroup
+	// Cancel ordering matters: the deferred loopCancel must run
+	// BEFORE wg.Wait so in-flight bridges observe loopCtx done and
+	// can exit. Defers run LIFO, so register wg.Wait FIRST (runs
+	// last) and loopCancel SECOND (runs first).
 	defer wg.Wait()
+	defer loopCancel(nil)
 
 	renewInterval := cfg.RenewInterval
 	if renewInterval == 0 {
@@ -258,21 +267,25 @@ func runControlLoop(ctx context.Context, cfg ControlConfig) (connected bool, err
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		pingLoop(loopCtx, ws, logger, loopCancel, state)
+		pingLoop(loopCtx, ws, logger, loopCancel, state, pingInterval)
 	}()
 
 	// Read accept messages from the control channel.
 	for {
 		_, data, readErr := ws.Read(loopCtx)
 		if readErr != nil {
-			// Cancel renew/ping immediately so the deferred
-			// wg.Wait below unblocks promptly; otherwise it
-			// would sit until the ping ticker (~30s) noticed
-			// the dead socket and called loopCancel itself.
+			// Stamp ControlEndedReadFailed for the deferred
+			// control_ended emit, then cancel with
+			// CauseControlError so in-flight bridges observe
+			// context.Cause == CauseControlError rather than the
+			// unclassified context.Canceled. setEnd is
+			// first-writer-wins; if renew/ping already stamped a
+			// more specific cause, that wins and we don't
+			// overwrite.
 			if loopCtx.Err() == nil {
 				state.setEnd(ControlEndedReadFailed, readErr)
 			}
-			loopCancel()
+			loopCancel(bridgecause.CauseControlError)
 			return true, fmt.Errorf("read control: %w", readErr)
 		}
 
@@ -374,7 +387,7 @@ func handleAccept(ctx context.Context, addr string, cfg ControlConfig, logger *s
 
 const maxRenewRetries = 3
 
-func renewLoop(ctx context.Context, ws *websocket.Conn, resURI string, tp TokenProvider, logger *slog.Logger, cancel context.CancelFunc, state *loopState, interval time.Duration) {
+func renewLoop(ctx context.Context, ws *websocket.Conn, resURI string, tp TokenProvider, logger *slog.Logger, cancel context.CancelCauseFunc, state *loopState, interval time.Duration) {
 	// tokenMintedAt drives the expires_in_seconds attribute on
 	// renew_attempted and the new_expires_in_seconds attribute on
 	// renew_ok. The initial value is the entry time of this
@@ -401,7 +414,7 @@ func renewLoop(ctx context.Context, ws *websocket.Conn, resURI string, tp TokenP
 				if ctx.Err() == nil {
 					state.setEnd(ControlEndedRenewFailed, err)
 				}
-				cancel()
+				cancel(bridgecause.CauseRenewFailure)
 				return
 			}
 			tokenMintedAt = newMint
@@ -474,8 +487,8 @@ func renewOnce(ctx context.Context, ws *websocket.Conn, resURI string, tp TokenP
 	return time.Time{}, lastErr
 }
 
-func pingLoop(ctx context.Context, ws *websocket.Conn, logger *slog.Logger, cancel context.CancelFunc, state *loopState) {
-	ticker := time.NewTicker(pingInterval)
+func pingLoop(ctx context.Context, ws *websocket.Conn, logger *slog.Logger, cancel context.CancelCauseFunc, state *loopState, interval time.Duration) {
+	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
 	for {
 		select {
@@ -496,7 +509,7 @@ func pingLoop(ctx context.Context, ws *websocket.Conn, logger *slog.Logger, canc
 				// stashes (cause, err) atomically so the emit
 				// reads a consistent pair.
 				state.setEnd(ControlEndedPingFailed, err)
-				cancel()
+				cancel(bridgecause.CauseControlError)
 				return
 			}
 		}

--- a/internal/relay/control_test.go
+++ b/internal/relay/control_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/tls"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -15,6 +16,8 @@ import (
 	"time"
 
 	"github.com/coder/websocket"
+
+	"github.com/philsphicas/aztunnel/internal/bridgecause"
 )
 
 // mockTokenProvider is a simple TokenProvider for control tests.
@@ -395,16 +398,16 @@ func TestPingLoop(t *testing.T) {
 		srv.Close()
 
 		cancelCalled := make(chan struct{})
-		loopCtx, loopCancel := context.WithCancel(ctx)
-		defer loopCancel()
+		loopCtx, loopCancel := context.WithCancelCause(ctx)
+		defer loopCancel(nil)
 
 		done := make(chan struct{})
 		go func() {
 			defer close(done)
-			pingLoop(loopCtx, ws, discardLogger(), func() {
+			pingLoop(loopCtx, ws, discardLogger(), func(cause error) {
 				close(cancelCalled)
-				loopCancel()
-			}, &loopState{})
+				loopCancel(cause)
+			}, &loopState{}, pingInterval)
 		}()
 
 		select {
@@ -440,17 +443,17 @@ func TestPingLoop(t *testing.T) {
 		}
 		defer ws.CloseNow()
 
-		loopCtx, loopCancel := context.WithCancel(ctx)
+		loopCtx, loopCancel := context.WithCancelCause(ctx)
 
 		done := make(chan struct{})
 		go func() {
 			defer close(done)
-			pingLoop(loopCtx, ws, discardLogger(), func() {
-				t.Error("cancel should not be called on context cancel")
-			}, &loopState{})
+			pingLoop(loopCtx, ws, discardLogger(), func(cause error) {
+				t.Errorf("cancel should not be called on context cancel; cause=%v", cause)
+			}, &loopState{}, pingInterval)
 		}()
 
-		loopCancel()
+		loopCancel(nil)
 
 		select {
 		case <-done:
@@ -495,20 +498,20 @@ func TestRenewLoop(t *testing.T) {
 
 		tp := &mockTokenProvider{err: fmt.Errorf("always fails")}
 
-		loopCtx, loopCancel := context.WithCancel(ctx)
+		loopCtx, loopCancel := context.WithCancelCause(ctx)
 
 		done := make(chan struct{})
 		cancelCalled := make(chan struct{})
 		go func() {
 			defer close(done)
-			renewLoop(loopCtx, ws, "https://test.servicebus.windows.net/hc", tp, discardLogger(), func() {
+			renewLoop(loopCtx, ws, "https://test.servicebus.windows.net/hc", tp, discardLogger(), func(cause error) {
 				close(cancelCalled)
-				loopCancel()
+				loopCancel(cause)
 			}, &loopState{}, defaultRenewInterval)
 		}()
 
 		// Cancel the context; renewLoop should exit via <-ctx.Done().
-		loopCancel()
+		loopCancel(nil)
 
 		select {
 		case <-done:
@@ -520,6 +523,110 @@ func TestRenewLoop(t *testing.T) {
 }
 
 // ---------- TestRunControlLoop ----------
+
+// TestRenewLoop_StampsCauseRenewFailure verifies that when renewLoop's
+// per-tick renewOnce returns an error, the cancel callback is invoked
+// with bridgecause.CauseRenewFailure so that in-flight bridges resolve
+// context.Cause(ctx) to that sentinel rather than to context.Canceled.
+func TestRenewLoop_StampsCauseRenewFailure(t *testing.T) {
+	useInsecureTransport(t)
+
+	srv := tlsServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ws, err := websocket.Accept(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer ws.CloseNow()
+		for {
+			if _, _, err := ws.Read(r.Context()); err != nil {
+				return
+			}
+		}
+	}))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	ws, _, err := websocket.Dial(ctx, "wss://"+testEndpoint(srv), nil)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	// Close the WS first so the renewOnce ws.Write fails immediately
+	// (the only non-retried failure path; token errors retry with
+	// 5s/10s backoff and slow the test).
+	_ = ws.CloseNow()
+
+	tp := &mockTokenProvider{token: "valid-token"}
+
+	loopCtx, loopCancel := context.WithCancelCause(ctx)
+	defer loopCancel(nil)
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		renewLoop(loopCtx, ws, "https://test.servicebus.windows.net/hc", tp, discardLogger(), loopCancel, &loopState{}, 50*time.Millisecond)
+	}()
+
+	select {
+	case <-loopCtx.Done():
+		if cause := context.Cause(loopCtx); !errors.Is(cause, bridgecause.CauseRenewFailure) {
+			t.Errorf("context.Cause = %v, want CauseRenewFailure", cause)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("renewLoop did not cancel after write failure")
+	}
+	<-done
+}
+
+// TestPingLoop_StampsCauseControlError verifies that when pingLoop's
+// per-tick ws.Ping returns an error, the cancel callback is invoked
+// with bridgecause.CauseControlError.
+func TestPingLoop_StampsCauseControlError(t *testing.T) {
+	useInsecureTransport(t)
+
+	srv := tlsServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ws, err := websocket.Accept(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer ws.CloseNow()
+		for {
+			if _, _, err := ws.Read(r.Context()); err != nil {
+				return
+			}
+		}
+	}))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	ws, _, err := websocket.Dial(ctx, "wss://"+testEndpoint(srv), nil)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	// Close the WS so the next ws.Ping fails fast without waiting
+	// out pingTimeout.
+	_ = ws.CloseNow()
+
+	loopCtx, loopCancel := context.WithCancelCause(ctx)
+	defer loopCancel(nil)
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		pingLoop(loopCtx, ws, discardLogger(), loopCancel, &loopState{}, 50*time.Millisecond)
+	}()
+
+	select {
+	case <-loopCtx.Done():
+		if cause := context.Cause(loopCtx); !errors.Is(cause, bridgecause.CauseControlError) {
+			t.Errorf("context.Cause = %v, want CauseControlError", cause)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("pingLoop did not cancel after ping failure")
+	}
+	<-done
+}
 
 func TestRunControlLoop(t *testing.T) {
 	useInsecureTransport(t)

--- a/internal/sender/connect.go
+++ b/internal/sender/connect.go
@@ -50,6 +50,19 @@ func Connect(ctx context.Context, cfg ConnectConfig) error {
 	logAccept(logger, cfg.Target, listenerID)
 
 	stdio := &stdioConn{in: cfg.Stdin, out: cfg.Stdout}
-	_, bridgeErr := cfg.Metrics.TrackedBridge(ctx, ws, stdio, "sender", cfg.Target)
+	stats, bridgeErr := cfg.Metrics.TrackedBridge(ctx, ws, stdio, "sender", cfg.Target)
+	attrs := []any{
+		"target", cfg.Target,
+		"cause", stats.Cause,
+		"tcp_to_ws", stats.TCPToWS,
+		"ws_to_tcp", stats.WSToTCP,
+	}
+	if bridgeErr != nil {
+		attrs = append(attrs, "error", bridgeErr)
+	}
+	if code, ok := relay.WSCloseCode(bridgeErr); ok {
+		attrs = append(attrs, "close_code", code)
+	}
+	logger.Debug("bridge ended", attrs...)
 	return bridgeErr
 }

--- a/internal/sender/portforward.go
+++ b/internal/sender/portforward.go
@@ -112,13 +112,20 @@ func forwardConnection(ctx context.Context, conn net.Conn, target string, cfg Po
 	logAccept(logger, target, listenerID)
 
 	// Bridge data.
-	_, bridgeErr := cfg.Metrics.TrackedBridge(ctx, ws, conn, "sender", target)
+	stats, bridgeErr := cfg.Metrics.TrackedBridge(ctx, ws, conn, "sender", target)
+	attrs := []any{
+		"cause", stats.Cause,
+		"tcp_to_ws", stats.TCPToWS,
+		"ws_to_tcp", stats.WSToTCP,
+	}
+	if code, ok := relay.WSCloseCode(bridgeErr); ok {
+		attrs = append(attrs, "close_code", code)
+	}
 	if bridgeErr != nil {
-		attrs := []any{"error", bridgeErr}
-		if code, ok := relay.WSCloseCode(bridgeErr); ok {
-			attrs = append(attrs, "close_code", code)
-		}
-		logger.Warn("forward failed", attrs...)
+		errAttrs := append([]any{"error", bridgeErr}, attrs...)
+		logger.Warn("forward failed", errAttrs...)
+	} else {
+		logger.Debug("bridge ended", attrs...)
 	}
 	return bridgeErr
 }

--- a/internal/sender/socks5proxy.go
+++ b/internal/sender/socks5proxy.go
@@ -132,13 +132,20 @@ func handleSOCKS5(ctx context.Context, conn net.Conn, cfg SOCKS5Config) error {
 	_ = socks5.SendReply(conn, socks5.RepSuccess, tcpAddr)
 
 	// Bridge data.
-	_, bridgeErr := cfg.Metrics.TrackedBridge(ctx, ws, conn, "sender", target)
+	stats, bridgeErr := cfg.Metrics.TrackedBridge(ctx, ws, conn, "sender", target)
+	attrs := []any{
+		"cause", stats.Cause,
+		"tcp_to_ws", stats.TCPToWS,
+		"ws_to_tcp", stats.WSToTCP,
+	}
+	if code, ok := relay.WSCloseCode(bridgeErr); ok {
+		attrs = append(attrs, "close_code", code)
+	}
 	if bridgeErr != nil {
-		attrs := []any{"error", bridgeErr}
-		if code, ok := relay.WSCloseCode(bridgeErr); ok {
-			attrs = append(attrs, "close_code", code)
-		}
-		logger.Warn("socks5 failed", attrs...)
+		errAttrs := append([]any{"error", bridgeErr}, attrs...)
+		logger.Warn("socks5 failed", errAttrs...)
+	} else {
+		logger.Debug("bridge ended", attrs...)
 	}
 	return bridgeErr
 }

--- a/internal/testharness/relayparity/observability.go
+++ b/internal/testharness/relayparity/observability.go
@@ -28,6 +28,7 @@ func RunObservabilitySuite(t *testing.T, b Backend) {
 		{"ControlSessionID_OnConnectedLine", ScenarioControlSessionID_OnConnectedLine},
 		{"SenderLogsCode_OnConnectFailure", ScenarioSenderLogsCode_OnConnectFailure},
 		{"ListenerDialFailureLog_CarriesCode", ScenarioListenerDialFailureLog_CarriesCode},
+		{"BridgeCauseLogs", ScenarioBridgeCauseLogs},
 	}
 	for _, sc := range scenarios {
 		t.Run(sc.name, func(t *testing.T) {
@@ -414,4 +415,59 @@ func ScenarioListenerDialFailureLog_CarriesCode(t *testing.T, b Backend) {
 				accepted, line)
 		}
 	})
+}
+
+// ScenarioBridgeCauseLogs drives one port-forward bridge to completion
+// by writing+reading a short payload then closing the client side,
+// then asserts that the bridge-end slog lines on BOTH sides carry a
+// non-empty cause field that classifies which side terminated the
+// bridge. The client's close is the canonical local_close on the
+// sender's side; the listener observes the resulting WebSocket
+// teardown as a peer_close from its perspective.
+//
+// The scenario asserts the *shape* of the cause attribute rather
+// than exact close-code values: per-pump scheduling and per-backend
+// WebSocket close-code semantics can vary, but the cause field is
+// always populated to one of bridgecause.Name's stable labels.
+//
+// Cross-backend: identical on mock and Azure. The bridge cancel-
+// cause classifier sits inside relay.Bridge, so neither the relay
+// service nor the protocol layer affect what cause the operator
+// sees in the log.
+func ScenarioBridgeCauseLogs(t *testing.T, b Backend) {
+	t.Helper()
+	AssertNoLeaks(t)
+
+	echo := StartPlainEcho(t)
+	tun := b.Setup(t, SetupOptions{
+		NumListeners:   1,
+		SenderMode:     ModePortForward,
+		Target:         echo.Addr(),
+		AllowedTargets: []string{echo.Addr()},
+	})
+	requireLogs(t, tun)
+
+	conn := dialWithRetry(t, tun.SenderAddr, 5*time.Second)
+	want := []byte("p10 bridge cause\n")
+	writeAll(t, conn, want)
+	got := readN(t, conn, len(want), 10*time.Second)
+	if !bytes.Equal(got, want) {
+		t.Fatalf("echo mismatch: got=%q want=%q", got, want)
+	}
+	// Close the local client side: the sender's tcpToWS pump
+	// reads EOF and classifies as local_close. The sender then
+	// tears down the WebSocket, which the listener observes as
+	// peer_close (a peer-side WebSocket failure).
+	_ = conn.Close()
+
+	senderLine := waitForLogLineContaining(t, tun.Senders[0].Logs, 10*time.Second,
+		`msg="bridge ended"`, "cause=")
+	if !strings.Contains(senderLine, "cause=local_close") {
+		t.Fatalf("sender bridge-end cause not local_close:\n%s", senderLine)
+	}
+	listenerLine := waitForLogLineContaining(t, tun.Listeners[0].Logs, 10*time.Second,
+		`msg="bridge ended"`, "cause=")
+	if !strings.Contains(listenerLine, "cause=peer_close") {
+		t.Fatalf("listener bridge-end cause not peer_close:\n%s", listenerLine)
+	}
 }

--- a/mockrelay/testharness/parity/mock_backend.go
+++ b/mockrelay/testharness/parity/mock_backend.go
@@ -105,7 +105,7 @@ func (*MockBackend) Setup(t testing.TB, opts relayparity.SetupOptions) *relaypar
 			AllowList:      opts.AllowedTargets,
 			MaxConnections: opts.MaxConnections,
 			ConnectTimeout: opts.ConnectTimeout,
-			Logger:         slog.New(slog.NewTextHandler(logs, nil)),
+			Logger:         slog.New(slog.NewTextHandler(logs, &slog.HandlerOptions{Level: slog.LevelDebug})),
 			Metrics:        m,
 		}
 
@@ -161,7 +161,7 @@ func (*MockBackend) Setup(t testing.TB, opts relayparity.SetupOptions) *relaypar
 	startOneSender := func() *relayparity.Sender {
 		m := metrics.New()
 		logs := newCaptureBuffer()
-		senderLogger := slog.New(slog.NewTextHandler(logs, nil))
+		senderLogger := slog.New(slog.NewTextHandler(logs, &slog.HandlerOptions{Level: slog.LevelDebug}))
 		sctx, scancel := context.WithCancel(ctx)
 		done := make(chan struct{})
 		addrCh := make(chan net.Addr, 1)


### PR DESCRIPTION
Bridge-end log lines now carry a structured `cause=<label>` field on both listener and sender, drawn from a small set of stable sentinels in a new `internal/bridgecause` package: `peer_close`, `local_close`, `user_cancel`, `renew_failure`, `control_error`, `timeout`, `unknown`. Operators triaging a teardown can grep one field instead of reading code to interpret an opaque `error=...`.

The classifier sits inside `relay.Bridge`, which uses `context.WithCancelCause` for its internal child ctx. Each pump returns an operation tag (`ws_read`, `ws_write`, `tcp_read`, `tcp_write`) alongside its terminating error so a `tcpToWS` failure on `ws.Write` (peer dead) is classified `peer_close`, not `local_close`. The final label is computed as `bridgecause.Name(context.Cause(ctx))` and surfaced through a new `BridgeStats.Cause` field; callers read it without restructuring ctx ownership.

External cancel sites stamp causes through the parent. The control loop wraps its `loopCtx` with `WithCancelCause`; `renewLoop` stamps `CauseRenewFailure` on token-renewal failure, `pingLoop` stamps `CauseControlError` on ping failure, and the control-read error path stamps `CauseControlError` before returning. In-flight bridges resolve `context.Cause(bridgeCtx)` to the operator-meaningful sentinel rather than the bare `context.Canceled`. `bridgecause.Name` also maps stdlib `context.Canceled` to `user_cancel` and `context.DeadlineExceeded` to `timeout`, so the production CLI's `signal.NotifyContext` path classifies correctly without any ctx wrapping at the call site.

All six `TrackedBridge` call sites (`internal/listener`, `internal/sender/{portforward,socks5proxy,connect}`, `cmd/aztunnel/arc_{port_forward,connect}`) capture stats and log `cause` on every return; the existing `forward failed` / `socks5 failed` warn lines also gain a `cause` attribute.

## Test coverage

- `internal/bridgecause/causes_test.go` — 11 unit tests covering every sentinel, stdlib alias mapping, and wrapped-error matching via `errors.Is`.
- `internal/relay/bridge_test.go` — four cause tests: peer normal close, local TCP EOF, parent-stamped `CauseUserCancel`, and external-site `CauseRenewFailure`.
- `internal/relay/control_test.go` — `renewLoop` stamps `CauseRenewFailure` on write failure, `pingLoop` stamps `CauseControlError` on ping failure; `TestPingLoop` and `TestRenewLoop` adapted to the `context.CancelCauseFunc` signature.
- `internal/testharness/relayparity/observability.go` — new cross-backend `Scenario_BridgeCauseLogs` drives a port-forward bridge to completion and asserts `cause=local_close` on the sender's bridge-end log and `cause=peer_close` on the listener's. Both mockrelay and Azure backends now run at debug log level so the new bridge-end debug line is captured.

## Out of scope

- Per-direction error split (P11).
- Cause as a metric label (high cardinality).
- Protocol field changes.

## CI checks

build, test, e2e, format, lint, vulncheck.