### PR TITLE
feat(obs): return per-direction errors from Bridge

### DIFF
--- a/cmd/aztunnel/arc_connect.go
+++ b/cmd/aztunnel/arc_connect.go
@@ -72,15 +72,21 @@ func (c *ArcConnectCmd) Run(globals *Globals, arcCmd *ArcCmd) error {
 	logger.Debug("connected to arc relay", "resource", resourceID)
 
 	stdio := &arcStdioConn{in: os.Stdin, out: os.Stdout}
-	stats, bridgeErr := m.TrackedBridge(ctx, ws, stdio, "sender", target)
+	result, bridgeErr := m.TrackedBridge(ctx, ws, stdio, "sender", target)
 	attrs := []any{
 		"target", target,
-		"cause", stats.Cause,
-		"tcp_to_ws", stats.TCPToWS,
-		"ws_to_tcp", stats.WSToTCP,
+		"cause", result.EndCause,
+		"tcp_to_ws", result.Stats.TCPToWS,
+		"ws_to_tcp", result.Stats.WSToTCP,
 	}
 	if bridgeErr != nil {
 		attrs = append(attrs, "error", bridgeErr)
+	}
+	if result.TCPToWS != nil {
+		attrs = append(attrs, "tcp_to_ws_err", result.TCPToWS)
+	}
+	if result.WSToTCP != nil {
+		attrs = append(attrs, "ws_to_tcp_err", result.WSToTCP)
 	}
 	if code, ok := relay.WSCloseCode(bridgeErr); ok {
 		attrs = append(attrs, "close_code", code)

--- a/cmd/aztunnel/arc_port_forward.go
+++ b/cmd/aztunnel/arc_port_forward.go
@@ -119,15 +119,21 @@ func (p *ArcPortForwardCmd) Run(globals *Globals, arcCmd *ArcCmd) error {
 			}
 			defer func() { _ = ws.CloseNow() }()
 
-			stats, bridgeErr := m.TrackedBridge(ctx, ws, conn, "sender", target)
+			result, bridgeErr := m.TrackedBridge(ctx, ws, conn, "sender", target)
 			attrs := []any{
 				"target", target,
-				"cause", stats.Cause,
-				"tcp_to_ws", stats.TCPToWS,
-				"ws_to_tcp", stats.WSToTCP,
+				"cause", result.EndCause,
+				"tcp_to_ws", result.Stats.TCPToWS,
+				"ws_to_tcp", result.Stats.WSToTCP,
 			}
 			if bridgeErr != nil {
 				attrs = append(attrs, "error", bridgeErr)
+			}
+			if result.TCPToWS != nil {
+				attrs = append(attrs, "tcp_to_ws_err", result.TCPToWS)
+			}
+			if result.WSToTCP != nil {
+				attrs = append(attrs, "ws_to_tcp_err", result.WSToTCP)
 			}
 			if code, ok := relay.WSCloseCode(bridgeErr); ok {
 				attrs = append(attrs, "close_code", code)

--- a/internal/listener/listener.go
+++ b/internal/listener/listener.go
@@ -190,15 +190,21 @@ func handleConnection(ctx context.Context, ws *websocket.Conn, cfg Config) {
 	}
 
 	// Bridge data.
-	stats, bridgeErr := cfg.Metrics.TrackedBridge(ctx, ws, conn, "listener", env.Target)
+	result, bridgeErr := cfg.Metrics.TrackedBridge(ctx, ws, conn, "listener", env.Target)
 	attrs := []any{
 		"target", env.Target,
-		"cause", stats.Cause,
-		"tcp_to_ws", stats.TCPToWS,
-		"ws_to_tcp", stats.WSToTCP,
+		"cause", result.EndCause,
+		"tcp_to_ws", result.Stats.TCPToWS,
+		"ws_to_tcp", result.Stats.WSToTCP,
 	}
 	if bridgeErr != nil {
 		attrs = append(attrs, "error", bridgeErr)
+	}
+	if result.TCPToWS != nil {
+		attrs = append(attrs, "tcp_to_ws_err", result.TCPToWS)
+	}
+	if result.WSToTCP != nil {
+		attrs = append(attrs, "ws_to_tcp_err", result.WSToTCP)
 	}
 	if code, ok := relay.WSCloseCode(bridgeErr); ok {
 		attrs = append(attrs, "close_code", code)

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -312,16 +312,16 @@ func (t *ConnectionTracker) Done(durationSec float64, toRelayBytes, fromRelayByt
 
 // TrackedBridge wraps relay.Bridge with connection lifecycle tracking.
 // Safe to call on a nil receiver.
-func (m *Metrics) TrackedBridge(ctx context.Context, ws *websocket.Conn, rwc net.Conn, role, target string) (relay.BridgeStats, error) {
+func (m *Metrics) TrackedBridge(ctx context.Context, ws *websocket.Conn, rwc net.Conn, role, target string) (relay.BridgeResult, error) {
 	tracker := m.ConnectionOpened(role, target)
 	start := time.Now()
-	var stats relay.BridgeStats
+	var result relay.BridgeResult
 	var err error
 	defer func() {
-		tracker.Done(time.Since(start).Seconds(), stats.TCPToWS, stats.WSToTCP, err)
+		tracker.Done(time.Since(start).Seconds(), result.Stats.TCPToWS, result.Stats.WSToTCP, err)
 	}()
-	stats, err = relay.Bridge(ctx, ws, rwc)
-	return stats, err
+	result, err = relay.Bridge(ctx, ws, rwc)
+	return result, err
 }
 
 // InstrumentedDial wraps relay.DialWithRetry with duration and error metrics.

--- a/internal/relay/bridge.go
+++ b/internal/relay/bridge.go
@@ -20,20 +20,58 @@ const (
 	bridgePingTimeout  = 10 * time.Second
 )
 
-// BridgeStats holds the post-mortem of a completed bridge: bidirectional
-// byte counts and a short classifier ("peer_close", "local_close",
-// "renew_failure", ...) that operators log to triage why the bridge
-// ended. Cause is one of the labels returned by bridgecause.Name.
+// BridgeStats holds the bidirectional byte counts of a completed
+// bridge. The TCPToWS / WSToTCP fields tally bytes copied in each
+// direction across the bridge's lifetime; the end-cause classifier
+// lives on BridgeResult.EndCause so per-direction errors and the
+// overall cause sit on the same result struct.
 type BridgeStats struct {
-	TCPToWS int64  // bytes copied from the TCP/local side to the WebSocket
-	WSToTCP int64  // bytes copied from the WebSocket to the TCP/local side
-	Cause   string // classifier from bridgecause.Name(context.Cause(...))
+	TCPToWS int64 // bytes copied from the TCP/local side to the WebSocket
+	WSToTCP int64 // bytes copied from the WebSocket to the TCP/local side
+}
+
+// BridgeResult is the outcome of one completed bridge. It carries the
+// byte counters (Stats) plus the per-direction terminating errors and
+// the bridgecause classifier that ended the overall bridge.
+//
+// TCPToWS / WSToTCP are nil on a clean direction (normal close, EOF,
+// or an "induced cancellation" — see below). A non-nil value is the
+// terminating error of that direction's pump after the normal-close
+// filters (ignoreNormalClose, ignoreEOF) have run.
+//
+// Induced cancellations are suppressed to nil so the per-direction
+// fields surface only that direction's own failure: when the first
+// pump returns the bridge cancels its internal ctx (interrupting the
+// second pump's ws.Reader with context.Canceled) and calls
+// tcp.SetReadDeadline(time.Now()) (interrupting the second pump's
+// tcp.Read with net.Error.Timeout()). Both shapes match
+// isInducedCancellation and are filtered out before BridgeResult is
+// returned. The same filter also catches both pumps' ctx.Canceled /
+// ctx.DeadlineExceeded under a parent-ctx cancel/timeout, so
+// user-cancel and timeout bridges report nil per-direction errors
+// alongside an EndCause of "user_cancel" / "timeout".
+//
+// EndCause is bridgecause.Name(context.Cause(bridgeCtx)) at return
+// time — one of the stable short labels operators grep on.
+type BridgeResult struct {
+	// Stats is the byte counters for this bridge.
+	Stats BridgeStats
+
+	// TCPToWS is the terminating error of the TCP→WebSocket
+	// direction (nil on normal close / induced cancellation).
+	TCPToWS error
+
+	// WSToTCP is the terminating error of the WebSocket→TCP
+	// direction (nil on normal close / induced cancellation).
+	WSToTCP error
+
+	// EndCause is the bridgecause label for the overall bridge end.
+	EndCause string
 }
 
 // pumpResult identifies which I/O operation a bridge pump exited on
 // so the cause classifier can distinguish a peer-side failure
-// (ws.Write to a dead peer) from a local-side failure (tcp.Read EOF)
-// when the two pumps share a single error channel.
+// (ws.Write to a dead peer) from a local-side failure (tcp.Read EOF).
 type pumpResult struct {
 	op  string // "ws_read" / "ws_write" / "tcp_read" / "tcp_write"
 	err error
@@ -41,8 +79,10 @@ type pumpResult struct {
 
 // Bridge copies data bidirectionally between a WebSocket connection
 // and a TCP connection until one side closes or the context is
-// cancelled. It returns byte-transfer statistics including a Cause
-// classifier and the first error from either direction.
+// cancelled. It returns a BridgeResult with byte counters, the
+// per-direction terminating errors, and an EndCause classifier; the
+// second return is the first non-nil pump error for backward-compat
+// with callers that just check `if err != nil`.
 //
 // The classifier comes from context.Cause on an internal
 // WithCancelCause-derived child context. Cause-cancel is first-cancel-
@@ -57,41 +97,125 @@ type pumpResult struct {
 //     still running, that cause propagates down to the child first;
 //     the bridge's later pump-exit cancel is then the no-op, and the
 //     parent's cause wins.
-func Bridge(ctx context.Context, ws *websocket.Conn, tcp net.Conn) (BridgeStats, error) {
+//
+// Bridge waits for every spawned goroutine (both pumps and the ping
+// loop) before returning, so it does not leak goroutines on its
+// caller.
+func Bridge(ctx context.Context, ws *websocket.Conn, tcp net.Conn) (BridgeResult, error) {
 	ctx, cancel := context.WithCancelCause(ctx)
 	defer cancel(nil)
 
 	var tcpToWSBytes, wsToTCPBytes atomic.Int64
-	errc := make(chan pumpResult, 2)
+	// One single-slot channel per direction so the bridge can
+	// attribute each error to the pump that produced it.
+	wsToTCPCh := make(chan pumpResult, 1)
+	tcpToWSCh := make(chan pumpResult, 1)
+	pingDone := make(chan struct{})
 
 	// WebSocket → TCP
 	go func() {
 		op, err := wsToTCP(ctx, ws, tcp, &wsToTCPBytes)
-		errc <- pumpResult{op: op, err: err}
+		wsToTCPCh <- pumpResult{op: op, err: err}
 	}()
 
 	// TCP → WebSocket
 	go func() {
 		op, err := tcpToWS(ctx, ws, tcp, &tcpToWSBytes)
-		errc <- pumpResult{op: op, err: err}
+		tcpToWSCh <- pumpResult{op: op, err: err}
 	}()
 
 	// WebSocket keepalive pings to prevent Azure Relay idle timeout.
-	go bridgePingLoop(ctx, ws)
+	// Wrapped in a tracking goroutine so Bridge can join it before
+	// returning and not leak this goroutine past the caller.
+	go func() {
+		defer close(pingDone)
+		bridgePingLoop(ctx, ws)
+	}()
 
-	// Wait for the first direction to finish, then cancel the other.
-	first := <-errc
-	cancel(causeFromPumpExit(first.op, first.err))
-	// Unblock tcp.Read in tcpToWS by closing the read side.
-	_ = tcp.SetReadDeadline(time.Now())
-	<-errc
-
-	stats := BridgeStats{
-		TCPToWS: tcpToWSBytes.Load(),
-		WSToTCP: wsToTCPBytes.Load(),
-		Cause:   bridgecause.Name(context.Cause(ctx)),
+	// Wait for the first direction to finish, stamp cause, then
+	// unblock the other pump.
+	var first, second pumpResult
+	var firstWasWSToTCP bool
+	select {
+	case r := <-wsToTCPCh:
+		first = r
+		firstWasWSToTCP = true
+	case r := <-tcpToWSCh:
+		first = r
 	}
-	return stats, first.err
+	cancel(causeFromPumpExit(first.op, first.err))
+	// Unblock tcp.Read in the second pump (if it was tcpToWS) by
+	// expiring its read deadline. The ws-side pump's ws.Reader sees
+	// the cancel via the internal ctx.
+	_ = tcp.SetReadDeadline(time.Now())
+
+	if firstWasWSToTCP {
+		second = <-tcpToWSCh
+	} else {
+		second = <-wsToTCPCh
+	}
+
+	// Join the ping loop before returning. ctx is already cancelled,
+	// so the loop's select returns on the next iteration; any
+	// in-flight ws.Ping aborts via its pingCtx (derived from ctx).
+	<-pingDone
+
+	var wsErr, tcpErr error
+	if firstWasWSToTCP {
+		wsErr = first.err
+		tcpErr = second.err
+	} else {
+		tcpErr = first.err
+		wsErr = second.err
+	}
+	if isInducedCancellation(wsErr) {
+		wsErr = nil
+	}
+	if isInducedCancellation(tcpErr) {
+		tcpErr = nil
+	}
+
+	result := BridgeResult{
+		Stats: BridgeStats{
+			TCPToWS: tcpToWSBytes.Load(),
+			WSToTCP: wsToTCPBytes.Load(),
+		},
+		TCPToWS:  tcpErr,
+		WSToTCP:  wsErr,
+		EndCause: bridgecause.Name(context.Cause(ctx)),
+	}
+
+	// Backward-compat primary error: the first pump's raw err.
+	// Returning nil on a normal close preserves the single-error
+	// callers' existing observable behavior (WARN-on-cancel sender
+	// callers still fire on a parent-ctx cancellation; a normal
+	// peer-close stays at DEBUG). The second pump's err is reported
+	// via result.{TCPToWS,WSToTCP} for the diagnostic log.
+	return result, first.err
+}
+
+// isInducedCancellation reports whether err is the artifact of the
+// bridge tearing the other direction down — context.Canceled /
+// context.DeadlineExceeded propagated to ws.Reader/ws.Write, or a
+// net.Error.Timeout() from tcp.Read after the bridge expired its
+// deadline. The bridge's only sources of pump-level timeouts are the
+// parent ctx deadline (also classified into EndCause) and the
+// SetReadDeadline call the bridge itself makes on the second pump;
+// in both cases the per-direction error is noise, so filtering it to
+// nil keeps BridgeResult.{TCPToWS,WSToTCP} focused on each direction's
+// own failure.
+func isInducedCancellation(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return true
+	}
+	var ne net.Error
+	if errors.As(err, &ne) && ne.Timeout() {
+		return true
+	}
+	return false
 }
 
 // causeFromPumpExit picks the sentinel a pump's exit should stamp on

--- a/internal/relay/bridge_test.go
+++ b/internal/relay/bridge_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -123,14 +124,14 @@ func TestBridge_ByteCounts(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	type bridgeResult struct {
-		stats BridgeStats
-		err   error
+	type bridgeOutcome struct {
+		result BridgeResult
+		err    error
 	}
-	ch := make(chan bridgeResult, 1)
+	ch := make(chan bridgeOutcome, 1)
 	go func() {
-		stats, err := Bridge(ctx, ws, serverConn)
-		ch <- bridgeResult{stats, err}
+		result, err := Bridge(ctx, ws, serverConn)
+		ch <- bridgeOutcome{result, err}
 	}()
 
 	// Send 100 bytes through the TCP side.
@@ -156,12 +157,12 @@ func TestBridge_ByteCounts(t *testing.T) {
 	select {
 	case res := <-ch:
 		// TCPToWS: 100 bytes sent from TCP to WS (the payload we wrote).
-		if res.stats.TCPToWS != 100 {
-			t.Errorf("TCPToWS = %d, want 100", res.stats.TCPToWS)
+		if res.result.Stats.TCPToWS != 100 {
+			t.Errorf("Stats.TCPToWS = %d, want 100", res.result.Stats.TCPToWS)
 		}
 		// WSToTCP: 100 bytes echoed back from WS to TCP.
-		if res.stats.WSToTCP != 100 {
-			t.Errorf("WSToTCP = %d, want 100", res.stats.WSToTCP)
+		if res.result.Stats.WSToTCP != 100 {
+			t.Errorf("Stats.WSToTCP = %d, want 100", res.result.Stats.WSToTCP)
 		}
 	case <-time.After(3 * time.Second):
 		t.Fatal("bridge did not terminate")
@@ -347,9 +348,9 @@ func TestBridge_Cause_PeerNormalClose(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	stats, _ := Bridge(ctx, ws, serverConn)
-	if stats.Cause != "peer_close" {
-		t.Errorf("Cause = %q, want %q", stats.Cause, "peer_close")
+	result, _ := Bridge(ctx, ws, serverConn)
+	if result.EndCause != "peer_close" {
+		t.Errorf("EndCause = %q, want %q", result.EndCause, "peer_close")
 	}
 }
 
@@ -382,14 +383,14 @@ func TestBridge_Cause_LocalEOF(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	type result struct {
-		stats BridgeStats
-		err   error
+	type outcome struct {
+		result BridgeResult
+		err    error
 	}
-	ch := make(chan result, 1)
+	ch := make(chan outcome, 1)
 	go func() {
-		s, e := Bridge(ctx, ws, serverConn)
-		ch <- result{s, e}
+		r, e := Bridge(ctx, ws, serverConn)
+		ch <- outcome{r, e}
 	}()
 
 	// Close the local side; tcp.Read returns EOF, tcpToWS returns
@@ -399,8 +400,8 @@ func TestBridge_Cause_LocalEOF(t *testing.T) {
 
 	select {
 	case res := <-ch:
-		if res.stats.Cause != "local_close" {
-			t.Errorf("Cause = %q, want %q", res.stats.Cause, "local_close")
+		if res.result.EndCause != "local_close" {
+			t.Errorf("EndCause = %q, want %q", res.result.EndCause, "local_close")
 		}
 	case <-time.After(3 * time.Second):
 		t.Fatal("bridge did not terminate")
@@ -440,22 +441,22 @@ func TestBridge_Cause_ParentCanceled(t *testing.T) {
 
 	parent, parentCancel := context.WithCancelCause(context.Background())
 
-	type result struct {
-		stats BridgeStats
-		err   error
+	type outcome struct {
+		result BridgeResult
+		err    error
 	}
-	ch := make(chan result, 1)
+	ch := make(chan outcome, 1)
 	go func() {
-		s, e := Bridge(parent, ws, serverConn)
-		ch <- result{s, e}
+		r, e := Bridge(parent, ws, serverConn)
+		ch <- outcome{r, e}
 	}()
 
 	parentCancel(bridgecause.CauseUserCancel)
 
 	select {
 	case res := <-ch:
-		if res.stats.Cause != "user_cancel" {
-			t.Errorf("Cause = %q, want %q", res.stats.Cause, "user_cancel")
+		if res.result.EndCause != "user_cancel" {
+			t.Errorf("EndCause = %q, want %q", res.result.EndCause, "user_cancel")
 		}
 	case <-time.After(3 * time.Second):
 		t.Fatal("bridge did not terminate after parent cancel")
@@ -465,7 +466,7 @@ func TestBridge_Cause_ParentCanceled(t *testing.T) {
 // TestBridge_Cause_ExternalSiteCancel simulates the control loop tearing
 // the bridge down on renew failure: the caller cancels the bridge ctx
 // with CauseRenewFailure mid-flight. The Bridge sees its internal ctx
-// done with that cause and reports stats.Cause == "renew_failure".
+// done with that cause and reports EndCause == "renew_failure".
 func TestBridge_Cause_ExternalSiteCancel(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ws, err := websocket.Accept(w, r, nil)
@@ -494,24 +495,337 @@ func TestBridge_Cause_ExternalSiteCancel(t *testing.T) {
 
 	bridgeCtx, bridgeCancel := context.WithCancelCause(context.Background())
 
-	type result struct {
-		stats BridgeStats
-		err   error
+	type outcome struct {
+		result BridgeResult
+		err    error
 	}
-	ch := make(chan result, 1)
+	ch := make(chan outcome, 1)
 	go func() {
-		s, e := Bridge(bridgeCtx, ws, serverConn)
-		ch <- result{s, e}
+		r, e := Bridge(bridgeCtx, ws, serverConn)
+		ch <- outcome{r, e}
 	}()
 
 	bridgeCancel(bridgecause.CauseRenewFailure)
 
 	select {
 	case res := <-ch:
-		if res.stats.Cause != "renew_failure" {
-			t.Errorf("Cause = %q, want %q", res.stats.Cause, "renew_failure")
+		if res.result.EndCause != "renew_failure" {
+			t.Errorf("EndCause = %q, want %q", res.result.EndCause, "renew_failure")
 		}
 	case <-time.After(3 * time.Second):
 		t.Fatal("bridge did not terminate after external cancel")
 	}
 }
+
+// TestBridge_Result_BothNormal verifies the "no real per-direction
+// error" contract of BridgeResult: when neither pump returns a real
+// I/O error, both per-direction fields resolve to nil. The WS peer
+// sends StatusNormalClosure on Accept and the wsToTCP pump reads it
+// cleanly via ignoreNormalClose; the tcpToWS pump is blocked on a
+// quiet net.Pipe and exits via the bridge's induced SetReadDeadline,
+// which isInducedCancellation resolves to nil. The asymmetry between
+// the two pumps' exit paths is intentional — each pump's clean-
+// close path is independently covered by TestBridge_Cause_*.
+func TestBridge_Result_BothNormal(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ws, err := websocket.Accept(w, r, nil)
+		if err != nil {
+			return
+		}
+		_ = ws.Close(websocket.StatusNormalClosure, "bye")
+	}))
+	defer srv.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(srv.URL, "http")
+	ws, _, err := websocket.Dial(context.Background(), wsURL, nil)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer ws.CloseNow()
+
+	clientConn, serverConn := net.Pipe()
+	defer clientConn.Close()
+	defer serverConn.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	result, bridgeErr := Bridge(ctx, ws, serverConn)
+	if result.TCPToWS != nil {
+		t.Errorf("TCPToWS = %v, want nil (normal close)", result.TCPToWS)
+	}
+	if result.WSToTCP != nil {
+		t.Errorf("WSToTCP = %v, want nil (normal close)", result.WSToTCP)
+	}
+	if bridgeErr != nil {
+		t.Errorf("bridgeErr = %v, want nil (normal close)", bridgeErr)
+	}
+	if result.EndCause != "peer_close" {
+		t.Errorf("EndCause = %q, want %q", result.EndCause, "peer_close")
+	}
+}
+
+// TestBridge_Result_TCPSideErrors injects a non-EOF I/O failure on the
+// TCP side via a custom net.Conn whose Read returns a sentinel that
+// does NOT match isInducedCancellation. After Bridge returns,
+// result.TCPToWS must carry the sentinel and result.WSToTCP must be
+// nil (it was cancelled by the bridge's internal ctx).
+func TestBridge_Result_TCPSideErrors(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ws, err := websocket.Accept(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer ws.CloseNow()
+		for {
+			if _, _, err := ws.Read(r.Context()); err != nil {
+				return
+			}
+		}
+	}))
+	defer srv.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(srv.URL, "http")
+	ws, _, err := websocket.Dial(context.Background(), wsURL, nil)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer ws.CloseNow()
+
+	sentinel := errors.New("synthetic tcp read failure")
+	tcp := newScriptedConn()
+	defer tcp.Close()
+	tcp.failReadAfter(0, sentinel)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	result, bridgeErr := Bridge(ctx, ws, tcp)
+	if !errors.Is(result.TCPToWS, sentinel) {
+		t.Errorf("TCPToWS = %v, want %v", result.TCPToWS, sentinel)
+	}
+	if result.WSToTCP != nil {
+		t.Errorf("WSToTCP = %v, want nil (induced ws cancellation)", result.WSToTCP)
+	}
+	if !errors.Is(bridgeErr, sentinel) {
+		t.Errorf("bridgeErr = %v, want %v", bridgeErr, sentinel)
+	}
+}
+
+// TestBridge_Result_WSSideErrors injects a non-normal close on the WS
+// side (StatusInternalError, 1011) which the ws-layer surfaces as a
+// CloseError that is NOT filtered as a normal close. The tcpToWS pump
+// is on a blocking custom net.Conn; the bridge interrupts it via
+// SetReadDeadline. The pump's tcp.Read therefore returns the deadline
+// timeout (induced) which is filtered to nil; result.WSToTCP carries
+// the CloseError.
+func TestBridge_Result_WSSideErrors(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ws, err := websocket.Accept(w, r, nil)
+		if err != nil {
+			return
+		}
+		_ = ws.Close(websocket.StatusInternalError, "boom")
+	}))
+	defer srv.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(srv.URL, "http")
+	ws, _, err := websocket.Dial(context.Background(), wsURL, nil)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer ws.CloseNow()
+
+	tcp := newScriptedConn()
+	defer tcp.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	result, _ := Bridge(ctx, ws, tcp)
+	if result.WSToTCP == nil {
+		t.Fatalf("WSToTCP = nil, want CloseError (1011)")
+	}
+	var closeErr websocket.CloseError
+	if !errors.As(result.WSToTCP, &closeErr) || closeErr.Code != websocket.StatusInternalError {
+		t.Errorf("WSToTCP = %v, want CloseError{Code=%d}", result.WSToTCP, websocket.StatusInternalError)
+	}
+	if result.TCPToWS != nil {
+		t.Errorf("TCPToWS = %v, want nil (induced tcp deadline)", result.TCPToWS)
+	}
+}
+
+// TestBridge_Result_BothError drives BOTH pumps to surface real
+// (non-induced) errors. The WS server closes with StatusInternalError
+// (a CloseError that survives the normal-close filter); the local TCP
+// side is a scripted conn whose Read returns a sentinel and whose
+// SetReadDeadline is a no-op (so the bridge's deadline-based unblock
+// does not overwrite the sentinel with a timeout). The scripted conn
+// holds its Read until the test releases it, so the bridge has
+// finished processing the first pump exit before the second pump
+// returns its real error.
+func TestBridge_Result_BothError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ws, err := websocket.Accept(w, r, nil)
+		if err != nil {
+			return
+		}
+		_ = ws.Close(websocket.StatusInternalError, "boom")
+	}))
+	defer srv.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(srv.URL, "http")
+	ws, _, err := websocket.Dial(context.Background(), wsURL, nil)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer ws.CloseNow()
+
+	sentinel := errors.New("synthetic tcp read failure")
+	tcp := newScriptedConn()
+	tcp.ignoreDeadline = true
+	defer tcp.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	type outcome struct {
+		result BridgeResult
+		err    error
+	}
+	ch := make(chan outcome, 1)
+	go func() {
+		r, e := Bridge(ctx, ws, tcp)
+		ch <- outcome{r, e}
+	}()
+
+	// Wait for the bridge to call tcp.SetReadDeadline, which it
+	// only does AFTER the first pump exits. With wsToTCP as the
+	// only pump that can finish unprompted (the WS server already
+	// sent the CloseError; tcp.Read is parked on c.releaseCh),
+	// reaching this signal proves wsToTCP has already returned
+	// its CloseError. Releasing the sentinel after this point
+	// makes the test deterministic without timing-based sleeps.
+	<-tcp.deadlineCalled
+	tcp.releaseRead(sentinel)
+
+	select {
+	case res := <-ch:
+		if res.result.WSToTCP == nil {
+			t.Errorf("WSToTCP = nil, want CloseError")
+		}
+		if !errors.Is(res.result.TCPToWS, sentinel) {
+			t.Errorf("TCPToWS = %v, want %v", res.result.TCPToWS, sentinel)
+		}
+		if res.err == nil {
+			t.Errorf("bridgeErr = nil, want non-nil")
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("bridge did not terminate")
+	}
+}
+
+// scriptedConn is a net.Conn whose Read blocks until releaseRead /
+// failReadAfter unblocks it, whose Write succeeds silently, and
+// whose Close + deadline calls are no-ops. The dedicated harness
+// keeps TestBridge_Result_* deterministic: the bridge's
+// SetReadDeadline-based unblock can be defeated via ignoreDeadline,
+// so per-direction tests can deliver a chosen sentinel error to
+// tcp.Read at exactly the moment they want.
+//
+// deadlineCalled fires on the first non-zero SetReadDeadline call.
+// Bridge only calls SetReadDeadline after the first pump exits, so
+// the channel is a sync point tests can wait on to know wsToTCP has
+// already returned before they release the TCP Read sentinel.
+type scriptedConn struct {
+	releaseCh      chan error
+	closed         chan struct{}
+	deadlineCalled chan struct{}
+	deadlineOnce   sync.Once
+	ignoreDeadline bool
+}
+
+func newScriptedConn() *scriptedConn {
+	return &scriptedConn{
+		releaseCh:      make(chan error, 1),
+		closed:         make(chan struct{}),
+		deadlineCalled: make(chan struct{}),
+	}
+}
+
+func (c *scriptedConn) Read(p []byte) (int, error) {
+	select {
+	case err := <-c.releaseCh:
+		if err == nil {
+			return 0, io.EOF
+		}
+		return 0, err
+	case <-c.closed:
+		return 0, io.EOF
+	}
+}
+
+func (c *scriptedConn) Write(p []byte) (int, error) {
+	select {
+	case <-c.closed:
+		return 0, io.ErrClosedPipe
+	default:
+		return len(p), nil
+	}
+}
+
+func (c *scriptedConn) Close() error {
+	select {
+	case <-c.closed:
+	default:
+		close(c.closed)
+	}
+	return nil
+}
+
+func (c *scriptedConn) LocalAddr() net.Addr  { return &net.IPAddr{} }
+func (c *scriptedConn) RemoteAddr() net.Addr { return &net.IPAddr{} }
+
+func (c *scriptedConn) SetDeadline(t time.Time) error      { return nil }
+func (c *scriptedConn) SetWriteDeadline(t time.Time) error { return nil }
+func (c *scriptedConn) SetReadDeadline(t time.Time) error {
+	if t.IsZero() {
+		return nil
+	}
+	c.deadlineOnce.Do(func() { close(c.deadlineCalled) })
+	if c.ignoreDeadline {
+		return nil
+	}
+	// Default behavior: complete the parked Read with a Timeout()
+	// net.Error so the bridge's induced-cancellation filter
+	// classifies it as nil.
+	select {
+	case c.releaseCh <- &timeoutError{}:
+	default:
+	}
+	return nil
+}
+
+func (c *scriptedConn) failReadAfter(d time.Duration, err error) {
+	if d == 0 {
+		c.releaseCh <- err
+		return
+	}
+	go func() {
+		time.Sleep(d)
+		c.releaseCh <- err
+	}()
+}
+
+func (c *scriptedConn) releaseRead(err error) {
+	c.releaseCh <- err
+}
+
+// timeoutError satisfies net.Error and reports Timeout() = true so the
+// bridge classifies it as an induced cancellation via
+// isInducedCancellation.
+type timeoutError struct{}
+
+func (*timeoutError) Error() string   { return "scripted-conn: deadline exceeded" }
+func (*timeoutError) Timeout() bool   { return true }
+func (*timeoutError) Temporary() bool { return true }

--- a/internal/sender/connect.go
+++ b/internal/sender/connect.go
@@ -50,15 +50,21 @@ func Connect(ctx context.Context, cfg ConnectConfig) error {
 	logAccept(logger, cfg.Target, listenerID)
 
 	stdio := &stdioConn{in: cfg.Stdin, out: cfg.Stdout}
-	stats, bridgeErr := cfg.Metrics.TrackedBridge(ctx, ws, stdio, "sender", cfg.Target)
+	result, bridgeErr := cfg.Metrics.TrackedBridge(ctx, ws, stdio, "sender", cfg.Target)
 	attrs := []any{
 		"target", cfg.Target,
-		"cause", stats.Cause,
-		"tcp_to_ws", stats.TCPToWS,
-		"ws_to_tcp", stats.WSToTCP,
+		"cause", result.EndCause,
+		"tcp_to_ws", result.Stats.TCPToWS,
+		"ws_to_tcp", result.Stats.WSToTCP,
 	}
 	if bridgeErr != nil {
 		attrs = append(attrs, "error", bridgeErr)
+	}
+	if result.TCPToWS != nil {
+		attrs = append(attrs, "tcp_to_ws_err", result.TCPToWS)
+	}
+	if result.WSToTCP != nil {
+		attrs = append(attrs, "ws_to_tcp_err", result.WSToTCP)
 	}
 	if code, ok := relay.WSCloseCode(bridgeErr); ok {
 		attrs = append(attrs, "close_code", code)

--- a/internal/sender/portforward.go
+++ b/internal/sender/portforward.go
@@ -112,11 +112,17 @@ func forwardConnection(ctx context.Context, conn net.Conn, target string, cfg Po
 	logAccept(logger, target, listenerID)
 
 	// Bridge data.
-	stats, bridgeErr := cfg.Metrics.TrackedBridge(ctx, ws, conn, "sender", target)
+	result, bridgeErr := cfg.Metrics.TrackedBridge(ctx, ws, conn, "sender", target)
 	attrs := []any{
-		"cause", stats.Cause,
-		"tcp_to_ws", stats.TCPToWS,
-		"ws_to_tcp", stats.WSToTCP,
+		"cause", result.EndCause,
+		"tcp_to_ws", result.Stats.TCPToWS,
+		"ws_to_tcp", result.Stats.WSToTCP,
+	}
+	if result.TCPToWS != nil {
+		attrs = append(attrs, "tcp_to_ws_err", result.TCPToWS)
+	}
+	if result.WSToTCP != nil {
+		attrs = append(attrs, "ws_to_tcp_err", result.WSToTCP)
 	}
 	if code, ok := relay.WSCloseCode(bridgeErr); ok {
 		attrs = append(attrs, "close_code", code)

--- a/internal/sender/socks5proxy.go
+++ b/internal/sender/socks5proxy.go
@@ -132,11 +132,17 @@ func handleSOCKS5(ctx context.Context, conn net.Conn, cfg SOCKS5Config) error {
 	_ = socks5.SendReply(conn, socks5.RepSuccess, tcpAddr)
 
 	// Bridge data.
-	stats, bridgeErr := cfg.Metrics.TrackedBridge(ctx, ws, conn, "sender", target)
+	result, bridgeErr := cfg.Metrics.TrackedBridge(ctx, ws, conn, "sender", target)
 	attrs := []any{
-		"cause", stats.Cause,
-		"tcp_to_ws", stats.TCPToWS,
-		"ws_to_tcp", stats.WSToTCP,
+		"cause", result.EndCause,
+		"tcp_to_ws", result.Stats.TCPToWS,
+		"ws_to_tcp", result.Stats.WSToTCP,
+	}
+	if result.TCPToWS != nil {
+		attrs = append(attrs, "tcp_to_ws_err", result.TCPToWS)
+	}
+	if result.WSToTCP != nil {
+		attrs = append(attrs, "ws_to_tcp_err", result.WSToTCP)
 	}
 	if code, ok := relay.WSCloseCode(bridgeErr); ok {
 		attrs = append(attrs, "close_code", code)

--- a/internal/testharness/relayparity/observability.go
+++ b/internal/testharness/relayparity/observability.go
@@ -29,6 +29,7 @@ func RunObservabilitySuite(t *testing.T, b Backend) {
 		{"SenderLogsCode_OnConnectFailure", ScenarioSenderLogsCode_OnConnectFailure},
 		{"ListenerDialFailureLog_CarriesCode", ScenarioListenerDialFailureLog_CarriesCode},
 		{"BridgeCauseLogs", ScenarioBridgeCauseLogs},
+		{"BridgePerDirection_NormalClose", ScenarioBridgePerDirection_NormalClose},
 	}
 	for _, sc := range scenarios {
 		t.Run(sc.name, func(t *testing.T) {
@@ -469,5 +470,56 @@ func ScenarioBridgeCauseLogs(t *testing.T, b Backend) {
 		`msg="bridge ended"`, "cause=")
 	if !strings.Contains(listenerLine, "cause=peer_close") {
 		t.Fatalf("listener bridge-end cause not peer_close:\n%s", listenerLine)
+	}
+}
+
+// ScenarioBridgePerDirection_NormalClose drives one port-forward
+// bridge to a local clean close, then asserts that the sender's
+// bridge-end slog line does NOT carry the per-direction error
+// attributes tcp_to_ws_err= / ws_to_tcp_err=. These attributes are
+// conditional in the caller (emitted only when the respective
+// direction's error is non-nil after the induced-cancellation
+// filter), so their absence proves both sender pumps ended cleanly:
+// tcpToWS returned nil on TCP EOF (after conn.Close), and wsToTCP
+// was induced-cancelled by the bridge's own ctx-cancel (filtered to
+// nil).
+//
+// The listener side is intentionally not asserted: the sender's
+// post-bridge ws.CloseNow() does not exchange a normal-close frame,
+// so the listener's wsToTCP pump observes an abrupt frame-header
+// EOF — a real per-direction error that the new attribute correctly
+// surfaces.
+//
+// Cross-backend: identical on mock and Azure. The conditional
+// log-attr policy lives in the sender call site, and the per-
+// direction nil/non-nil decision lives in relay.Bridge's
+// isInducedCancellation filter — neither depends on the relay
+// service.
+func ScenarioBridgePerDirection_NormalClose(t *testing.T, b Backend) {
+	t.Helper()
+	AssertNoLeaks(t)
+
+	echo := StartPlainEcho(t)
+	tun := b.Setup(t, SetupOptions{
+		NumListeners:   1,
+		SenderMode:     ModePortForward,
+		Target:         echo.Addr(),
+		AllowedTargets: []string{echo.Addr()},
+	})
+	requireLogs(t, tun)
+
+	conn := dialWithRetry(t, tun.SenderAddr, 5*time.Second)
+	want := []byte("p11 per-direction\n")
+	writeAll(t, conn, want)
+	got := readN(t, conn, len(want), 10*time.Second)
+	if !bytes.Equal(got, want) {
+		t.Fatalf("echo mismatch: got=%q want=%q", got, want)
+	}
+	_ = conn.Close()
+
+	senderLine := waitForLogLineContaining(t, tun.Senders[0].Logs, 10*time.Second,
+		`msg="bridge ended"`, "cause=")
+	if strings.Contains(senderLine, "tcp_to_ws_err=") || strings.Contains(senderLine, "ws_to_tcp_err=") {
+		t.Fatalf("sender bridge-end carries per-direction error on normal close:\n%s", senderLine)
 	}
 }


### PR DESCRIPTION
`relay.Bridge` now returns a `BridgeResult` with per-direction errors:

```go
type BridgeResult struct {
    Stats    BridgeStats
    TCPToWS  error  // TCP → WebSocket pump error, or nil
    WSToTCP  error  // WebSocket → TCP pump error, or nil
    EndCause string // bridgecause label for the side that ended the bridge
}
```

Bridge-end log lines on every caller (listener, sender port-forward / SOCKS5 / connect, arc port-forward / connect) gain conditional `tcp_to_ws_err` and `ws_to_tcp_err` slog attributes, surfacing per-direction failures that the single-error return previously hid:

```
msg="bridge ended" cause=peer_close tcp_to_ws=512 ws_to_tcp=0 \
  tcp_to_ws_err="write tcp ...: connection reset by peer" \
  ws_to_tcp_err="failed to read frame: unexpected EOF"
```

`isInducedCancellation` filters `context.Canceled`, `context.DeadlineExceeded`, and `net.Error.Timeout()=true` off the per-direction fields so the second pump's induced cancellation does not masquerade as a real error; the primary error return is unfiltered for backward compatibility.

`bridgePingLoop` is now joined before `Bridge` returns, so the bridge owns its full goroutine lifecycle.

## Files

- `internal/relay/bridge.go` — `BridgeResult`, two-channel attribution, ping-loop join, induced-cancel filter.
- `internal/metrics/metrics.go` — `TrackedBridge` returns `BridgeResult`.
- `internal/listener/listener.go`, `internal/sender/{portforward,socks5proxy,connect}.go`, `cmd/aztunnel/arc_{port_forward,connect}.go` — conditional per-direction log attrs.
- `internal/relay/bridge_test.go` — 4 new tests covering all asymmetry quadrants, plus a `scriptedConn` harness.
- `internal/testharness/relayparity/observability.go` — `ScenarioBridgePerDirection_NormalClose` cross-backend scenario.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
