### PR TITLE
fix(bench): warm up relay connection before throughput timer

### DIFF
--- a/internal/testharness/relayparity/bench.go
+++ b/internal/testharness/relayparity/bench.go
@@ -232,6 +232,19 @@ func benchSteadyThroughput(b *testing.B, backend Backend) {
 	}
 	defer conn.Close() //nolint:errcheck // best-effort
 
+	// Force the relay rendezvous to complete before the timer starts.
+	// net.DialTimeout only establishes the local TCP connection to the
+	// sender bind; the sender dials the relay lazily on first data.
+	// Without this probe the first timed iteration pays ~1s of hidden
+	// connection setup, skewing the throughput measurement.
+	probe := []byte{0x00}
+	if err := writeFull(conn, probe); err != nil {
+		b.Fatalf("warmup write: %v", err)
+	}
+	if _, err := io.ReadFull(conn, probe); err != nil {
+		b.Fatalf("warmup read: %v", err)
+	}
+
 	const transferSize = 1024 * 1024
 	body := make([]byte, transferSize)
 	if _, err := rand.Read(body); err != nil {


### PR DESCRIPTION
SteadyThroughput measures sustained MB/s on an established connection, but the TCP dial to the sender bind returns before the relay rendezvous completes. The sender dials the relay lazily on first data, so without a pre-timer probe byte the first timed iteration includes ~1s of hidden connection setup.

This skews the average downward: 1.9 MB/s instead of the true 2.7 MB/s on Azure Relay, and 90 MB/s instead of 165 MB/s on mock.

Adds a 1-byte echo round-trip between dial and b.ResetTimer() to force the end-to-end path to be fully established before measurement begins.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>