### PR TITLE
feat(e2e): make-only local dev UX with per-developer RG isolation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ bin/
 *.out
 coverage.txt
 coverage.html
+e2e/.local.json
 
 # IDE
 .vscode/

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ LDFLAGS  := -ldflags "-X main.version=$(VERSION)"
 CGO    := $(shell go env CGO_ENABLED)
 RACE   := $(if $(filter 1,$(CGO)),-race,)
 
-.PHONY: build test cover lint clean install docker docker-alpine docker-bookworm fmt fmt-check e2e e2e-docker e2e-infra-setup e2e-infra-ci e2e-infra-clean e2e-infra-env e2e-infra-janitor vulncheck bench bench-compare help
+.PHONY: build test cover lint clean install docker docker-alpine docker-bookworm fmt fmt-check e2e e2e-docker e2e-setup e2e-attach e2e-status e2e-clean e2e-grant e2e-ci e2e-janitor vulncheck bench bench-compare help
 
 .DEFAULT_GOAL := help
 
@@ -63,9 +63,8 @@ fmt: ## Format markdown and YAML with prettier
 fmt-check: ## Check formatting (same as CI)
 	npx --yes prettier --check .
 
-e2e: build ## Run end-to-end tests (requires Azure Relay credentials)
-	go test -tags=e2e -timeout=20m -v ./e2e/azrelay/
-	go test -tags=e2e -timeout=20m -v ./e2e/
+e2e: build ## Run end-to-end tests (configure once via `make e2e-setup`)
+	go test -tags=e2e -timeout=40m -v ./e2e/azrelay/ ./e2e/
 
 e2e-docker: ## Run container-to-container e2e tests
 	@status=0; \
@@ -73,20 +72,34 @@ e2e-docker: ## Run container-to-container e2e tests
 	docker compose -f docker-compose.e2e.yml down; \
 	exit $$status
 
-e2e-infra-setup: ## Deploy e2e Azure infra + grant yourself access
+e2e-setup: ## Provision per-developer e2e infra and write e2e/.local.json
 	cd e2e/infra && go run ./cmd/e2e-infra setup
 
-e2e-infra-ci: ## Full CI setup: infra + identity + GitHub secrets (maintainer)
-	cd e2e/infra && go run ./cmd/e2e-infra ci
+e2e-attach: ## Record an existing e2e RG/namespace in e2e/.local.json
+	@if [ -z "$(RESOURCE_GROUP)" ]; then \
+		echo "error: RESOURCE_GROUP is required (example: make e2e-attach RESOURCE_GROUP=aztunnel-e2e)" >&2; \
+		exit 2; \
+	fi
+	cd e2e/infra && RESOURCE_GROUP="$(RESOURCE_GROUP)" RELAY_NAME="$(RELAY_NAME)" go run ./cmd/e2e-infra attach
 
-e2e-infra-clean: ## Delete e2e Azure resource group (requires --yes confirmation)
-	cd e2e/infra && go run ./cmd/e2e-infra clean
+e2e-status: ## Show persisted config and Azure-side health checks
+	cd e2e/infra && go run ./cmd/e2e-infra status
 
-e2e-infra-env: ## Print E2E_* env vars for local test runs (eval $$(make e2e-infra-env))
-	@cd e2e/infra && go run ./cmd/e2e-infra env
+e2e-clean: ## Delete your e2e RG (pass CLEAN_ARGS="--yes [--force]")
+	cd e2e/infra && go run ./cmd/e2e-infra clean $(CLEAN_ARGS)
 
-e2e-infra-janitor: ## Delete orphaned per-invocation hybrid connections older than 4h
-	cd e2e/infra && go run ./cmd/e2e-infra janitor
+e2e-grant: ## Grant Azure Relay Owner to another principal
+	@if [ -z "$(ASSIGNEE)" ]; then \
+		echo "error: ASSIGNEE is required (example: make e2e-grant ASSIGNEE=alice@contoso.com)" >&2; \
+		exit 2; \
+	fi
+	cd e2e/infra && go run ./cmd/e2e-infra grant --assignee "$(ASSIGNEE)"
+
+e2e-ci: ## Configure the shared CI e2e infrastructure and secrets
+	cd e2e/infra && RESOURCE_GROUP="$(or $(RESOURCE_GROUP),aztunnel-e2e)" go run ./cmd/e2e-infra ci
+
+e2e-janitor: ## Delete orphaned per-invocation hybrid connections older than 4h
+	cd e2e/infra && RESOURCE_GROUP="$(or $(RESOURCE_GROUP),aztunnel-e2e)" go run ./cmd/e2e-infra janitor
 
 vulncheck: ## Check Go dependencies for known vulnerabilities
 	go run golang.org/x/vuln/cmd/govulncheck@latest ./...
@@ -105,5 +118,5 @@ bench-compare: ## Compare e2e benchmarks across two refs: BASE=<sha> [HEAD=<sha>
 		scripts/bench-compare.sh '$(BASE)' '$(HEAD)'
 
 help: ## Show this help
-	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | \
+	@grep -E '^[a-zA-Z0-9_-]+:.*?## .*$$' $(MAKEFILE_LIST) | \
 		awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-18s\033[0m %s\n", $$1, $$2}'

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -1,271 +1,136 @@
 # End-to-End Tests
 
-These tests verify aztunnel against a real Azure Relay. They are gated behind
-the `e2e` build tag. Each Azure-dependent test provisions its own pair of
-ephemeral hybrid connections in the configured relay namespace and tears them
-down via `t.Cleanup`, so tests run with `t.Parallel()` (concurrency capped by
-`E2E_PROVISIONER_CONCURRENCY`, default 4) and concurrent `go test` pipelines
-do not collide.
+These tests verify aztunnel against a real Azure Relay namespace. They run behind
+the `e2e` build tag, and each Azure-dependent test provisions its own ephemeral
+hyco pair (`e2e-entra-<hex>`, `e2e-sas-<hex>`) via `t.Cleanup`-scoped lifetimes,
+so parallel runs do not collide.
 
-## Quick Start
+## Quick Start (local dev)
 
 ```bash
-# Contributor: deploy Azure infra + grant yourself RBAC, then run tests
-az login                       # required: TestMain uses DefaultAzureCredential
-make e2e-infra-setup
-eval "$(make e2e-infra-env)"   # exports E2E_RELAY_NAME, E2E_RESOURCE_GROUP, AZURE_SUBSCRIPTION_ID
+az login
+make e2e-setup
 make e2e
-
-# Maintainer: above + CI identity + GitHub secrets
-make e2e-infra-ci
 ```
 
-`AZURE_SUBSCRIPTION_ID` must be set when `TestMain` constructs the relay
-`Provider`. `make e2e-infra-env` resolves it from the Azure CLI's default
-subscription (`~/.azure/azureProfile.json`) so `az login` plus
-`eval "$(make e2e-infra-env)"` is enough for most contributors. Set it
-explicitly if you have multiple subscriptions and don't want to rely on
-the CLI's default.
-
-`TestMain` constructs a process-scoped `azrelay.Provider` that hands out
-freshly-suffixed pairs (`e2e-entra-<hex>` for Entra ID auth and
-`e2e-sas-<hex>` for SAS-key auth) to each test via `requireDedicatedHyco`.
-Tests register a `t.Cleanup` that tears their pair down at the end of the
-scenario. Benchmarks instead share a single pair leased on first use and
-drained on `TestMain` exit, so benchstat runs do not pay per-sub-bench
-provisioning. The orphan janitor workflow (`.github/workflows/e2e-janitor.yml`)
-reaps anything left behind by killed runners.
-
-## Environment Variables
-
-| Variable                      | Required | Description                                                            |
-| ----------------------------- | -------- | ---------------------------------------------------------------------- |
-| `E2E_RELAY_NAME`              | Yes      | Azure Relay namespace name                                             |
-| `E2E_RESOURCE_GROUP`          | Yes      | Resource group containing the relay namespace                          |
-| `AZURE_SUBSCRIPTION_ID`       | Yes      | Subscription used to provision per-test hycos                          |
-| `E2E_AUTH`                    | No       | `entra`, `sas`, or both (default)                                      |
-| `E2E_PROVISIONER_CONCURRENCY` | No       | Cap on in-flight hyco provisions across `t.Parallel` tests (default 4) |
-| `E2E_LARGE_TRANSFER`          | No       | Set to `1` to enable 100MB bulk transfer                               |
-| `E2E_LONG_LIVED`              | No       | Set to `1` to enable >2 min keepalive test                             |
-
-Authentication is via `DefaultAzureCredential`: `az login` for local
-development, OIDC federated workload identity for GitHub Actions. No SAS
-listener/sender keys need to be configured by hand — the namespace
-holds two **permanent** namespace-scoped authorization rules,
-`e2e-listener` (Listen-only) and `e2e-sender` (Send-only), provisioned
-once by `e2e-infra setup` (or `e2e-infra ci`). `TestMain` reads their
-keys via `azrelay.AcquireRunRules` (a `Microsoft.Relay/...ListKeys`
-call against each permanent rule — no create / no delete) and reuses
-them across every per-test SAS hyco. The rules outlive every test
-invocation; the orphan janitor sweeps only hybrid connections, not
-authorization rules.
-
-## Test Scenarios
-
-### Functional
-
-- **TestPortForwardBasic** — echo round-trip through port-forward mode
-- **TestSOCKS5Basic** — echo round-trip through SOCKS5 proxy mode
-- **TestConnectStdio** — raw TCP through connect (stdin/stdout) mode
-- **TestSSHProxyCommand** — real SSH session through the tunnel
-- **TestSASKeyAuth** — port-forward with SAS key authentication
-- **TestAllowlistAllow** — CIDR allowlist permits connection
-- **TestAllowlistDeny** — connection rejected by allowlist
-- **TestMaxConnections** — `--max-connections` limit enforced
-
-### Data Integrity
-
-- **TestSmallPayload** — 256 individual 1-byte writes
-- **TestLargePayload** — 1MB payload with SHA256 verification
-- **TestBulkTransfer** — 100MB streaming transfer (opt-in)
-- **TestLongLivedConnection** — survives >2 min idle period (opt-in)
-
-### Concurrency
-
-- **TestConcurrentSameTarget** — 50 simultaneous port-forward connections
-- **TestConcurrentDistinctTargets** — 50 SOCKS5 connections to distinct targets
-
-### Metrics
-
-- **TestMetricsEndpoint** — `/metrics` returns valid Prometheus data
-- **TestMetricsConnectionCount** — connection counters accurate after traffic
-- **TestMetricsErrorReason** — allowlist rejection recorded with correct reason
-- **TestMetricsDialDuration** — dial duration histogram populated
-
-### Multi-Instance
-
-- **TestMultiListenerPortForwardSmoke** — two listeners on the same hyco serve
-  a single port-forward sender; asserts all flows round-trip and neither
-  listener emits an error-level log line. Per-listener distribution is logged,
-  not asserted, because Azure Relay's listener-selection is not specified as
-  round-robin.
-
-## Test Harness Conventions
-
-The Phase 1 harness pass (see `helpers_test.go` + `multi_test.go`) introduces
-a small set of helpers that new tests should prefer over ad-hoc sleeps and
-manual process management:
-
-- `(*aztunnelProcess).Stop(t)` — idempotent kill + wait. Safe to call from a
-  test that also has the implicit `t.Cleanup` Stop registered.
-- `(*aztunnelProcess).MetricsAddr(t, timeout)` — block until the subprocess
-  logs `metrics server listening`, return the bound `host:port`. Use with
-  `--metrics-addr 127.0.0.1:0`.
-- `waitForMetric(t, addr, name, predicate, timeout)` — poll `/metrics` until
-  `predicate(sumMetric(name))` is true. Prefer over `time.Sleep` before
-  scraping counters.
-- `waitForMetricsContains(t, addr, substr, timeout)` — same shape but for
-  label-keyed assertions (e.g., `reason="dial_failed"`).
-- `scrapeMetricsBest(addr)` — non-fatal scrape returning `""` on error;
-  intended for use inside polling loops where transient failures are
-  expected.
-
-## Running Specific Tests
+Maintainers who need CI identity + GitHub secret setup run:
 
 ```bash
-# Run only metrics tests.
-go test -tags=e2e -timeout=10m -v -run TestMetrics ./e2e/...
-
-# Run with opt-in tests.
-E2E_LARGE_TRANSFER=1 E2E_LONG_LIVED=1 make e2e
+make e2e-ci
 ```
 
-## Infrastructure Setup
+## Per-developer isolation
 
-The maintainer-facing tool is `./e2e/infra/cmd/e2e-infra`, exposed via
-`make e2e-infra-*` targets. It replaces the prior shell scripts and shells
-out to no external tooling (no `az`, no `gh`, no `jq`).
+`make e2e-setup` defaults to `aztunnel-e2e-<alias>`, where `<alias>` is derived
+from your signed-in Azure user. This keeps local test infra isolated from CI and
+from other developers.
 
-### CLI Subcommands
+- Override alias: `ALIAS=foo make e2e-setup`
+- Override RG directly: `RESOURCE_GROUP=my-rg make e2e-setup`
 
-| Make target         | CLI subcommand                                 | Purpose                                                                           |
-| ------------------- | ---------------------------------------------- | --------------------------------------------------------------------------------- |
-| `e2e-infra-setup`   | `e2e-infra setup`                              | Create RG + namespace + permanent SAS rules + grant yourself `Azure Relay Owner`. |
-| `e2e-infra-ci`      | `e2e-infra ci`                                 | Above + Entra app + federated credential + GitHub secrets.                        |
-| `e2e-infra-clean`   | `e2e-infra clean --yes`                        | Delete the resource group (and everything in it).                                 |
-| `e2e-infra-env`     | `e2e-infra env`                                | Print `export` statements for `E2E_*` and `AZURE_*` vars.                         |
-| `e2e-infra-janitor` | `e2e-infra janitor [--max-age 4h] [--dry-run]` | Delete orphan `e2e-{entra,sas}-<hex>` hycos older than max-age.                   |
-| (none)              | `e2e-infra grant --self\|--user\|--sp …`       | Grant `Azure Relay Owner` to a principal.                                         |
+The setup command writes `e2e/.local.json`, which `make e2e` reads automatically.
+No `eval` flow and no shell-level env export are required.
 
-### Environment Variable Overrides
+## Join an existing setup
 
-| Variable         | Default                          | Notes                                   |
-| ---------------- | -------------------------------- | --------------------------------------- |
-| `RESOURCE_GROUP` | `aztunnel-e2e`                   | Resource group name                     |
-| `LOCATION`       | `westus2`                        | Azure region for created resources      |
-| `RELAY_NAME`     | `aztunnel-<short hash>`          | Auto-generated from sub + RG when unset |
-| `ENTRA_APP`      | `aztunnel-e2e-ci`                | CI app registration display name        |
-| `GITHUB_REPO`    | auto-detected from `.git/config` | `owner/name` of the GitHub repo         |
-| `GITHUB_ENV`     | `e2e-azure`                      | GitHub environment name                 |
-
-### Migrating From the Old Shell Scripts
-
-If you previously ran `create-relay.sh` / `uniquestring.sh` to deploy a
-namespace, the new `e2e-infra setup` is not bit-compatible with the
-historic Bash `uniqueString` helper — different hash function, different
-length — so it does **not** synthesize the same name from a given
-(subscription, resource group) pair.
-
-Two options to migrate without rebuilding:
-
-- **Implicit discovery (recommended for single-namespace RGs):** if your
-  resource group contains exactly one relay namespace,
-  `e2e-infra setup` / `ci` / `env` / `janitor` all auto-discover it and
-  reuse it. Just run `make e2e-infra-setup` (or `make e2e-infra-ci`) and
-  the CLI prints `(reusing existing namespace …)` instead of generating
-  a new name.
-- **Explicit:** pass the existing namespace name on the command line or
-  via `RELAY_NAME=…`. For example:
-  `RELAY_NAME=aztunnel-e2e-relay make e2e-infra-setup`.
-
-If the RG contains more than one relay namespace, every subcommand
-errors out asking for `--relay-name` (or `RELAY_NAME=…`); pick one
-explicitly.
-
-### RBAC
-
-The CI service principal (and your developer account) need the built-in
-**Azure Relay Owner** role at the relay namespace scope. This single role
-covers control-plane operations (create/delete hybrid connections, manage
-SAS auth rules, ListKeys) and data-plane operations (Listen, Send). The
-`e2e-infra setup` and `e2e-infra ci` subcommands grant it automatically.
-
-To grant access to another user or SP:
+If you already have access to an existing namespace (for example a teammate's or
+the shared CI RG), record it locally without provisioning:
 
 ```bash
-# Yourself (idempotent)
-cd e2e/infra && go run ./cmd/e2e-infra grant --self
-
-# Another user by UPN
-cd e2e/infra && go run ./cmd/e2e-infra grant --user alice@contoso.com
-
-# A service principal by app display name
-cd e2e/infra && go run ./cmd/e2e-infra grant --sp aztunnel-e2e-ci
+make e2e-attach RESOURCE_GROUP=aztunnel-e2e
 ```
 
-### Configuring GitHub
+`RELAY_NAME=<ns>` is optional when the RG has exactly one namespace.
 
-The `ci` subcommand needs a GitHub token in `GITHUB_TOKEN` with `repo` +
-`admin:org_environment` scopes (or equivalents).
+## Running tests
+
+`make e2e` resolves config in this order:
+
+1. `AZURE_SUBSCRIPTION_ID` + `E2E_RESOURCE_GROUP` env vars (CI / explicit override)
+2. `e2e/.local.json` (local setup/attach flow)
+3. Fail with a directive error
+
+Optional toggles:
+
+| Variable                      | Description                                 |
+| ----------------------------- | ------------------------------------------- |
+| `E2E_AUTH`                    | `entra`, `sas`, or unset (both)             |
+| `E2E_PROVISIONER_CONCURRENCY` | In-flight provisioning cap (default 4)      |
+| `E2E_LARGE_TRANSFER`          | Set `1` to run the 100MB transfer test      |
+| `E2E_LONG_LIVED`              | Set `1` to run the >2 minute keepalive test |
+
+## Contributor-only fallback (`sasOnly`)
+
+If setup can provision infra but cannot create role assignments
+(`AuthorizationFailed` on `Microsoft.Authorization/roleAssignments/write`), setup
+completes and records `sasOnly: true` in `e2e/.local.json`.
+
+When `sasOnly` is set and `E2E_AUTH` is not explicitly set, `TestMain` forces
+`E2E_AUTH=sas`, so Entra subtests skip cleanly instead of timing out.
+
+After an owner grants access, re-record the local config without
+re-attempting the role assignment so `sasOnly` flips back to false:
 
 ```bash
-# Environment secrets only (maintainer)
-cd e2e/infra && GITHUB_TOKEN=$(gh auth token) go run ./cmd/e2e-infra ci
-
-# Environment + Dependabot repo secrets
-cd e2e/infra && GITHUB_TOKEN=$(gh auth token) go run ./cmd/e2e-infra ci --dependabot
+make e2e-grant RESOURCE_GROUP=<their-rg> RELAY_NAME=<their-namespace> ASSIGNEE=<your-upn>
+make e2e-attach RESOURCE_GROUP=<their-rg> RELAY_NAME=<their-namespace>
 ```
 
-### Costs
+## Status / troubleshooting
 
-- **Idle**: $0 (no listeners connected)
-- **During tests**: fractions of a penny (pro-rated per listener-hour, ~$0.014/hr)
-- **Monthly**: $0 if only used for CI runs
-
-Healthy `make e2e` invocations clean up their hybrid connections via
-`t.Cleanup` registered by `requireDedicatedHyco`. A daily `E2E Janitor`
-workflow (`make e2e-infra-janitor`) reaps orphans left behind by killed
-runners or panicking tests, so the namespace does not accumulate billable
-resources over time.
-
-### Tear Down
+Run this first when local e2e runs look wrong:
 
 ```bash
-# Delete the resource group (relay, SAS rules, RBAC assignments)
-make e2e-infra-clean
-
-# To also remove the Entra app registration (maintainer only):
-APP_ID=$(az ad app list --filter "displayName eq 'aztunnel-e2e-ci'" -o json | jq -r '.[0].appId')
-az ad app delete --id "$APP_ID"
+make e2e-status
 ```
 
-## Concurrency Model
+It prints the resolved source/subscription/resource-group/namespace/sas-only mode
+and verifies permanent SAS-rule readability.
 
-PR pipelines no longer use a workflow `concurrency` group, because
-collisions between concurrent invocations are eliminated at the hyco level:
+## Cleanup
 
-- `TestMain` constructs the shared `azrelay.Provider` once. Each test
-  (and the shared benchmark lease) calls `Provider.Provision`, which
-  generates a fresh suffix and creates `e2e-entra-<suffix>` +
-  `e2e-sas-<suffix>`. `t.Parallel()` tests run with their hyco
-  lifetime scoped to a single `t.Cleanup`.
-- Static hyco names from prior versions (`e2e-entra`, `e2e-sas`) are no
-  longer required and are intentionally not provisioned by the new setup.
-- Hyco names are matched against `^e2e-(entra|sas)-[0-9a-f]{12}$` for the
-  janitor, so any unrelated hycos in the namespace are not touched.
-- SAS authorization rules live at **namespace scope**, not per hyco,
-  and are permanent fixtures of the namespace: two rules
-  (`e2e-listener` with Listen-only, `e2e-sender` with Send-only) are
-  provisioned once by `e2e-infra setup` and reused across every
-  `go test` invocation. `TestMain` calls `azrelay.AcquireRunRules` to
-  read their primary keys via `ListKeys` — no create, no delete, no
-  per-test rule churn. Every per-test hyco signs SAS tokens with these
-  shared permanent keys. The two-rule split preserves the contract
-  that a listener key cannot send and vice versa
-  (asserted by `TestWrongSASClaim`).
-- Permanent SAS rules keep the e2e-owned authorization-rule count
-  fixed at two (`e2e-listener` + `e2e-sender`), well below the
-  Azure Relay 12-rules-per-namespace cap, regardless of how many
-  `go test` invocations are running concurrently.
-- The relay namespace itself is shared across pipelines; only hybrid
-  connections are per-test (authorization rules are permanent).
+`make e2e-clean` only deletes RGs that were created by `make e2e-setup`
+(validated via ownership tags). It will not delete unrelated or attached RGs.
+
+To forget an attached or stale local config without deleting infra:
+
+```bash
+rm e2e/.local.json
+```
+
+## CI environment overrides
+
+CI continues to inject config via workflow `env` blocks. The default shared RG
+stays `aztunnel-e2e`.
+
+| Variable                | Purpose                               |
+| ----------------------- | ------------------------------------- |
+| `AZURE_SUBSCRIPTION_ID` | Subscription for ARM calls            |
+| `E2E_RESOURCE_GROUP`    | Shared CI RG (default `aztunnel-e2e`) |
+| `E2E_RELAY_NAME`        | Relay namespace to target             |
+
+## Test matrix highlights
+
+- Functional: port-forward, SOCKS5, connect, SSH, allowlist, max-connections
+- Data integrity: small/large payloads, opt-in bulk + long-lived
+- Concurrency: same-target and distinct-target fanout
+- Metrics: endpoint, counters, error reasons, dial histograms
+- Multi-instance smoke: two listeners on one hyco with flow distribution logging
+
+<details>
+<summary>Implementation notes</summary>
+
+The implementation lives under `e2e/infra/cmd/e2e-infra`; Make targets are the
+stable user-facing surface.
+
+| Make target   | CLI subcommand                   |
+| ------------- | -------------------------------- |
+| `e2e-setup`   | `e2e-infra setup`                |
+| `e2e-attach`  | `e2e-infra attach`               |
+| `e2e-status`  | `e2e-infra status`               |
+| `e2e-clean`   | `e2e-infra clean`                |
+| `e2e-grant`   | `e2e-infra grant --assignee ...` |
+| `e2e-ci`      | `e2e-infra ci`                   |
+| `e2e-janitor` | `e2e-infra janitor`              |
+
+</details>

--- a/e2e/azrelay/provider.go
+++ b/e2e/azrelay/provider.go
@@ -125,7 +125,7 @@ func DefaultClientOptions() *arm.ClientOptions {
 // key info from p.cfg.RunRules. Teardown deletes both hycos; the
 // permanent run-scoped rules live on past every PairToken and are
 // not torn down by tests at all (they are provisioned once by
-// `e2e-infra setup` and outlive every test invocation).
+// `make e2e-setup` and outlive every test invocation).
 //
 // Provision blocks if the concurrency semaphore is full. The block
 // honours ctx.Done so callers (typically t.Cleanup-registered)

--- a/e2e/azrelay/runrules.go
+++ b/e2e/azrelay/runrules.go
@@ -14,7 +14,7 @@ import (
 // PermanentListenerRuleName is the well-known name of the Listen-only
 // namespace SAS authorization rule that every e2e test invocation reads
 // (never creates) at startup. Provisioned once per namespace by
-// e2e/infra/azure.Provisioner.EnsureRunRules (via `e2e-infra setup`).
+// e2e/infra/azure.Provisioner.EnsureRunRules (via `make e2e-setup`).
 const PermanentListenerRuleName = "e2e-listener"
 
 // PermanentSenderRuleName is the well-known name of the Send-only
@@ -35,7 +35,7 @@ const readKeyMaxWait = 30 * time.Second
 // creates.
 //
 // The rules are permanent fixtures of the namespace (provisioned by
-// `e2e-infra setup` once, never deleted by tests). AcquireRunRules
+// `make e2e-setup` once, never deleted by tests). AcquireRunRules
 // reads their primary keys via ListKeys; it does NOT create or delete
 // rules. This keeps the e2e-owned authorization-rule count constant
 // at two regardless of how many parallel CI jobs target the
@@ -60,9 +60,9 @@ type RunRules struct {
 // PermanentSenderRuleName) and returns a populated *RunRules.
 //
 // The rules must already exist in cfg.Namespace — provision them once
-// with `e2e-infra setup`. If either rule is missing, AcquireRunRules
+// with `make e2e-setup`. If either rule is missing, AcquireRunRules
 // returns an error whose message names the missing rule and points to
-// `e2e-infra setup`.
+// `make e2e-setup`.
 //
 // cfg.RunRules is ignored by this function (the returned *RunRules is
 // what the caller would set on cfg.RunRules before constructing a
@@ -105,14 +105,14 @@ func AcquireRunRules(ctx context.Context, cfg Config) (*RunRules, error) {
 }
 
 // Teardown is a no-op: RunRules is read-only and the permanent rules
-// are owned by `e2e-infra setup`, surviving past every test invocation.
+// are owned by `make e2e-setup`, surviving past every test invocation.
 // The method exists so callers can `defer rr.Teardown()` symmetrically
 // with other resource handles.
 func (r *RunRules) Teardown(ctx context.Context) error { return nil }
 
 // readPermanentKey fetches the primary key for the named permanent
 // rule, retrying briefly on transient ARM errors. A 404 is surfaced
-// with a hint pointing at `e2e-infra setup` — the most common cause is
+// with a hint pointing at `make e2e-setup` — the most common cause is
 // running tests against a namespace that has not been provisioned yet.
 func readPermanentKey(ctx context.Context, ns *armrelay.NamespacesClient, cfg Config, name string) (string, error) {
 	deadline := time.Now().Add(readKeyMaxWait)
@@ -127,7 +127,7 @@ func readPermanentKey(ctx context.Context, ns *armrelay.NamespacesClient, cfg Co
 		}
 		lastErr = err
 		if isNotFound(err) {
-			return "", fmt.Errorf("permanent SAS rule %q (or its parent namespace %s/%s) not found — run `e2e-infra setup` to provision (or `e2e-infra ci` for CI setup): %w",
+			return "", fmt.Errorf("permanent SAS rule %q (or its parent namespace %s/%s) not found — run `make e2e-setup` to provision (or `make e2e-ci` for CI setup): %w",
 				name, cfg.ResourceGroup, cfg.Namespace, err)
 		}
 		if !isTransient(err) {

--- a/e2e/azrelay/runrules_test.go
+++ b/e2e/azrelay/runrules_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestPermanentRuleNamesAreStable(t *testing.T) {
 	// Pin the permanent rule names against accidental rename. The
-	// names are baked into operational tooling (`e2e-infra setup`
+	// names are baked into operational tooling (`make e2e-setup`
 	// provisions them; `az relay namespace authorization-rule …`
 	// is how maintainers manage them out-of-band), so changing
 	// them silently would orphan the existing rules and break
@@ -94,7 +94,7 @@ func TestValidateForRunRules_MirrorsValidate(t *testing.T) {
 
 func TestTeardownIsNoOp(t *testing.T) {
 	// RunRules.Teardown is a no-op because the permanent rules are
-	// owned by `e2e-infra setup`. Pin that contract so a future
+	// owned by `make e2e-setup`. Pin that contract so a future
 	// refactor doesn't silently reintroduce delete-on-teardown —
 	// which would race every other in-flight CI run sharing the
 	// namespace.

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -3,15 +3,12 @@
 // Package e2e contains end-to-end tests for aztunnel that run against a real
 // Azure Relay. Tests are gated behind the "e2e" build tag and require:
 //
-//   - E2E_RELAY_NAME: Azure Relay namespace name
-//   - E2E_RESOURCE_GROUP: resource group containing the namespace
-//   - AZURE_SUBSCRIPTION_ID: subscription ID for ARM API calls
+//   - E2E_RELAY_NAME, E2E_RESOURCE_GROUP, AZURE_SUBSCRIPTION_ID:
+//     supplied either by CI env vars or by e2e/.local.json from
+//     `make e2e-setup` / `make e2e-attach`
 //   - Valid Azure credentials (az login, managed identity, OIDC, etc.)
 //
-// Run `eval "$(make e2e-infra-env)"` to export all three from the
-// resource group provisioned by `make e2e-infra-setup`; the
-// `e2e-infra env` tool resolves AZURE_SUBSCRIPTION_ID from the
-// Azure CLI default if not already exported.
+// Local setup flow: `az login`, `make e2e-setup`, then `make e2e`.
 //
 // Each test provisions its own pair of ephemeral hybrid connections —
 // e2e-entra-<hex> for Entra ID auth and e2e-sas-<hex> for SAS key auth —

--- a/e2e/infra/azure/alias.go
+++ b/e2e/infra/azure/alias.go
@@ -1,0 +1,150 @@
+package azure
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+
+	"github.com/philsphicas/aztunnel/e2e/infra/internal/msgraph"
+)
+
+// DefaultResourceGroupPrefix is the prefix prepended to the slugged
+// alias to form the per-developer default RG name. CI uses the bare
+// CIResourceGroup ("aztunnel-e2e"); developers default to
+// "aztunnel-e2e-<alias>" so they never collide with CI or each other.
+const DefaultResourceGroupPrefix = "aztunnel-e2e-"
+
+// CIResourceGroup is the fixed RG name that CI provisions and the
+// `make e2e-ci` target falls back to when no override is provided.
+const CIResourceGroup = "aztunnel-e2e"
+
+// maxAliasLen caps the slugged alias length. Azure RGs allow 90 chars
+// but the relay namespace name is derived from sub + RG and lives in
+// a 50-char DNS label, so we leave headroom.
+const maxAliasLen = 30
+
+// SlugAlias returns a conservative slug suitable for embedding in
+// an Azure RG name. The output:
+//   - is lowercase ASCII letters, digits, or '-';
+//   - has no consecutive '-';
+//   - has no leading or trailing '-' or '.';
+//   - is at most maxAliasLen characters;
+//   - is empty when no slug can be produced.
+//
+// Unicode letters / digits are folded to their lowercase ASCII
+// equivalents by a small map of common cases (accented Latin
+// letters); anything else outside [a-z0-9-] becomes a '-' separator.
+// The fold is intentionally minimal — when in doubt we let the
+// caller fall back to the object-id-prefix path.
+func SlugAlias(in string) string {
+	in = strings.ToLower(in)
+	var b strings.Builder
+	b.Grow(len(in))
+	prevDash := true
+	for _, r := range in {
+		if folded, ok := asciiFold[r]; ok {
+			r = folded
+		}
+		switch {
+		case r >= 'a' && r <= 'z', r >= '0' && r <= '9':
+			b.WriteRune(r)
+			prevDash = false
+		default:
+			if !prevDash {
+				b.WriteByte('-')
+				prevDash = true
+			}
+		}
+	}
+	out := strings.Trim(b.String(), "-.")
+	if len(out) > maxAliasLen {
+		out = strings.TrimRight(out[:maxAliasLen], "-.")
+	}
+	return out
+}
+
+// asciiFold maps a small set of accented Latin runes to their ASCII
+// equivalent. Anything not in this map is treated as a separator.
+var asciiFold = map[rune]rune{
+	'à': 'a', 'á': 'a', 'â': 'a', 'ã': 'a', 'ä': 'a', 'å': 'a',
+	'è': 'e', 'é': 'e', 'ê': 'e', 'ë': 'e',
+	'ì': 'i', 'í': 'i', 'î': 'i', 'ï': 'i',
+	'ò': 'o', 'ó': 'o', 'ô': 'o', 'õ': 'o', 'ö': 'o',
+	'ù': 'u', 'ú': 'u', 'û': 'u', 'ü': 'u',
+	'ñ': 'n', 'ç': 'c', 'ß': 's',
+}
+
+// AliasFromUPN returns a slug derived from the local-part of an UPN
+// (the part before '@'). Returns "" when slugging yields nothing
+// usable; callers should fall back to AliasFromObjectID in that case.
+func AliasFromUPN(upn string) string {
+	local := upn
+	if at := strings.IndexByte(local, '@'); at >= 0 {
+		local = local[:at]
+	}
+	return SlugAlias(local)
+}
+
+// AliasFromObjectID returns the first 12 hex characters of an AAD
+// object id, stripping hyphens. The 48-bit prefix is enough to make
+// collisions across developers in one subscription statistically
+// negligible while keeping the RG name short.
+func AliasFromObjectID(oid string) string {
+	clean := strings.ToLower(strings.ReplaceAll(oid, "-", ""))
+	if len(clean) > 12 {
+		clean = clean[:12]
+	}
+	return clean
+}
+
+// DeriveAlias picks the alias from the signed-in user. UPN local-part
+// is preferred; falls back to the first 12 hex of the object id if
+// slugging produces nothing usable.
+func DeriveAlias(oid, upn string) string {
+	if a := AliasFromUPN(upn); a != "" {
+		return a
+	}
+	return AliasFromObjectID(oid)
+}
+
+// ResolveResourceGroup applies the documented precedence for picking
+// the e2e RG name. Called before Provisioner construction because
+// NewProvisioner requires the resolved RG up-front.
+//
+//  1. Explicit `--resource-group` / RESOURCE_GROUP wins.
+//  2. Explicit `--alias` / ALIAS → DefaultResourceGroupPrefix + slug.
+//  3. ciFallback (CICmd path) → CIResourceGroup.
+//  4. Otherwise → derive from signed-in user (msgraph /me).
+//
+// The msgraph lookup happens only on the fallback path so commands
+// invoked with an explicit RG name never pay for it.
+func ResolveResourceGroup(ctx context.Context, cred azcore.TokenCredential, explicitRG, explicitAlias string, ciFallback bool) (string, error) {
+	if explicitRG != "" {
+		return explicitRG, nil
+	}
+	if explicitAlias != "" {
+		slug := SlugAlias(explicitAlias)
+		if slug == "" {
+			return "", fmt.Errorf("--alias %q produces an empty slug; pass --resource-group explicitly", explicitAlias)
+		}
+		return DefaultResourceGroupPrefix + slug, nil
+	}
+	if ciFallback {
+		return CIResourceGroup, nil
+	}
+	gc, err := msgraph.New(cred)
+	if err != nil {
+		return "", err
+	}
+	oid, upn, err := gc.SignedInUserObjectID(ctx)
+	if err != nil {
+		return "", fmt.Errorf("derive alias from signed-in user (run `az login`): %w", err)
+	}
+	alias := DeriveAlias(oid, upn)
+	if alias == "" {
+		return "", fmt.Errorf("could not derive a non-empty alias from oid=%s upn=%q; pass --alias or --resource-group", oid, upn)
+	}
+	return DefaultResourceGroupPrefix + alias, nil
+}

--- a/e2e/infra/azure/alias_test.go
+++ b/e2e/infra/azure/alias_test.go
@@ -1,0 +1,103 @@
+package azure
+
+import "testing"
+
+func TestSlugAlias(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"alice", "alice"},
+		{"Alice.Smith", "alice-smith"},
+		{"firstname.lastname", "firstname-lastname"},
+		{"weird+plus", "weird-plus"},
+		{"a_b_c", "a-b-c"},
+		{"héllo", "hello"},
+		{"François", "francois"},
+		{"--double--dash--", "double-dash"},
+		{"trailing.", "trailing"},
+		{".leading", "leading"},
+		{"...---...", ""},
+		{"", ""},
+		{"a", "a"},
+		{"a@b", "a-b"},
+		{"Alice O'Brien", "alice-o-brien"},
+		{"日本語user", "user"},
+		{"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}, // capped at 30
+		{"alias-with-many-chars-then-end---", "alias-with-many-chars-then-end"},
+	}
+	for _, c := range cases {
+		got := SlugAlias(c.in)
+		if got != c.want {
+			t.Errorf("SlugAlias(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestSlugAliasLengthCap(t *testing.T) {
+	long := ""
+	for i := 0; i < 200; i++ {
+		long += "x"
+	}
+	got := SlugAlias(long)
+	if len(got) > maxAliasLen {
+		t.Errorf("SlugAlias did not cap length: got %d chars", len(got))
+	}
+}
+
+func TestAliasFromUPN(t *testing.T) {
+	cases := []struct {
+		upn, want string
+	}{
+		{"alice@example.com", "alice"},
+		{"firstname.lastname@contoso.com", "firstname-lastname"},
+		{"weird+plus@x.com", "weird-plus"},
+		{"héllo@x.com", "hello"},
+		{"no-at-sign", "no-at-sign"},
+		{"", ""},
+		{"@onlyat", ""},
+	}
+	for _, c := range cases {
+		got := AliasFromUPN(c.upn)
+		if got != c.want {
+			t.Errorf("AliasFromUPN(%q) = %q, want %q", c.upn, got, c.want)
+		}
+	}
+}
+
+func TestAliasFromObjectID(t *testing.T) {
+	cases := []struct {
+		oid, want string
+	}{
+		{"00000000-0000-0000-0000-000000000000", "000000000000"},
+		{"AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA", "aaaaaaaaaaaa"},
+		{"abcd", "abcd"},
+		{"", ""},
+	}
+	for _, c := range cases {
+		got := AliasFromObjectID(c.oid)
+		if got != c.want {
+			t.Errorf("AliasFromObjectID(%q) = %q, want %q", c.oid, got, c.want)
+		}
+	}
+}
+
+func TestDeriveAlias_PrefersUPN(t *testing.T) {
+	got := DeriveAlias("00000000-0000-0000-0000-000000000000", "alice@example.com")
+	if got != "alice" {
+		t.Errorf("DeriveAlias = %q, want \"alice\"", got)
+	}
+}
+
+func TestDeriveAlias_FallsBackToOID(t *testing.T) {
+	got := DeriveAlias("00000000-0000-0000-0000-000000000000", "@")
+	if got != "000000000000" {
+		t.Errorf("DeriveAlias = %q, want \"000000000000\"", got)
+	}
+}
+
+func TestDeriveAlias_EmptyOnBothEmpty(t *testing.T) {
+	got := DeriveAlias("", "")
+	if got != "" {
+		t.Errorf("DeriveAlias = %q, want \"\"", got)
+	}
+}

--- a/e2e/infra/azure/namespace.go
+++ b/e2e/infra/azure/namespace.go
@@ -43,8 +43,9 @@ type Provisioner struct {
 
 // NewProvisioner constructs a Provisioner using DefaultAzureCredential.
 // It does not call Azure other than to resolve the subscription ID, which
-// is read from AZURE_SUBSCRIPTION_ID env var (set by `azure/login` in CI
-// and by `az account set` locally).
+// is read from AZURE_SUBSCRIPTION_ID env var (set by `azure/login` in CI)
+// and otherwise falls back to ~/.azure/azureProfile.json (`az account
+// show`'s default subscription) so a contributor only needs `az login`.
 func NewProvisioner(ctx context.Context, cfg Config) (*Provisioner, error) {
 	if cfg.ResourceGroup == "" {
 		return nil, errors.New("ResourceGroup is required")
@@ -53,9 +54,6 @@ func NewProvisioner(ctx context.Context, cfg Config) (*Provisioner, error) {
 		cfg.SubscriptionID = os.Getenv("AZURE_SUBSCRIPTION_ID")
 	}
 	if cfg.SubscriptionID == "" {
-		// Fall back to the Azure CLI's default subscription so contributors
-		// who have only run `az login` get a working `e2e-infra env` /
-		// `make e2e-infra-env` without an extra pre-export step.
 		if id, err := defaultSubscriptionFromAzureCLIProfile(); err == nil {
 			cfg.SubscriptionID = id
 		}
@@ -100,8 +98,9 @@ func (p *Provisioner) ResolvedNamespace() string { return p.resolvedRelay }
 //
 //  1. Config.RelayName, if non-empty.
 //  2. Any single existing namespace already present in the resource
-//     group (so migrating users do not silently end up with a second
-//     namespace alongside the one their previous tooling created).
+//     group (so attaching to an existing setup does not silently end
+//     up with a second namespace alongside the one another tool
+//     created).
 //  3. A deterministic hash derived from subscription + RG (see
 //     generateRelayName).
 //
@@ -199,7 +198,7 @@ func (p *Provisioner) DiscoverNamespace(ctx context.Context) (string, error) {
 	}
 	switch len(names) {
 	case 0:
-		return "", fmt.Errorf("no relay namespace found in %s — run `e2e-infra setup` first", p.cfg.ResourceGroup)
+		return "", fmt.Errorf("no relay namespace found in %s — run `make e2e-setup` first", p.cfg.ResourceGroup)
 	case 1:
 		p.resolvedRelay = names[0]
 		return names[0], nil
@@ -242,30 +241,51 @@ func generateRelayName(subID, rg string) string {
 // contributors who have authenticated via `az login` but have not
 // exported AZURE_SUBSCRIPTION_ID into their shell environment.
 func defaultSubscriptionFromAzureCLIProfile() (string, error) {
-	home, err := os.UserHomeDir()
+	p, err := ReadAzureCLIProfileDefault()
 	if err != nil {
 		return "", err
+	}
+	return p.Subscription, nil
+}
+
+// AzureCLIDefaults is the resolved default subscription + tenant from
+// the Azure CLI's local profile. Either field may be empty when the
+// profile is absent or unparseable.
+type AzureCLIDefaults struct {
+	Subscription string
+	Tenant       string
+}
+
+// ReadAzureCLIProfileDefault parses ~/.azure/azureProfile.json and
+// returns the subscription id + tenant id flagged as the current
+// default. Used by `make e2e-status` to detect identity-context drift
+// without making any network calls.
+func ReadAzureCLIProfileDefault() (AzureCLIDefaults, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return AzureCLIDefaults{}, err
 	}
 	path := filepath.Join(home, ".azure", "azureProfile.json")
 	data, err := os.ReadFile(path) //nolint:gosec // path is under user's home dir
 	if err != nil {
-		return "", err
+		return AzureCLIDefaults{}, err
 	}
 	// Azure CLI on Windows writes a UTF-8 BOM.
 	trimmed := strings.TrimPrefix(string(data), "\ufeff")
 	var profile struct {
 		Subscriptions []struct {
 			ID        string `json:"id"`
+			TenantID  string `json:"tenantId"`
 			IsDefault bool   `json:"isDefault"`
 		} `json:"subscriptions"`
 	}
 	if err := json.Unmarshal([]byte(trimmed), &profile); err != nil {
-		return "", fmt.Errorf("parse %s: %w", path, err)
+		return AzureCLIDefaults{}, fmt.Errorf("parse %s: %w", path, err)
 	}
 	for _, s := range profile.Subscriptions {
 		if s.IsDefault {
-			return s.ID, nil
+			return AzureCLIDefaults{Subscription: s.ID, Tenant: s.TenantID}, nil
 		}
 	}
-	return "", errors.New("no default subscription in azureProfile.json")
+	return AzureCLIDefaults{}, errors.New("no default subscription in azureProfile.json")
 }

--- a/e2e/infra/azure/rbac.go
+++ b/e2e/infra/azure/rbac.go
@@ -20,6 +20,14 @@ import (
 // hyco create/delete, auth-rule create, ListKeys, Listen, and Send.
 const azureRelayOwnerRoleDefID = "2787bf04-f1f5-4bfe-8383-c8a24483ee38"
 
+// ErrAuthorizationFailed is returned by GrantOwnerSelf (and the
+// underlying grantOwner) when the caller lacks
+// Microsoft.Authorization/roleAssignments/write at the scope. SetupCmd
+// downgrades this to the documented SAS-only fallback path; other
+// callers (`make e2e-grant ASSIGNEE=…`, the CI subcommand) propagate
+// it as a hard failure.
+var ErrAuthorizationFailed = errors.New("caller lacks role-assignment write permission")
+
 // GrantOwnerSelf grants Azure Relay Owner to the signed-in user at
 // namespace scope.
 func (p *Provisioner) GrantOwnerSelf(ctx context.Context) error {
@@ -106,10 +114,25 @@ func (p *Provisioner) grantOwner(ctx context.Context, oid string, pt armauthoriz
 			fmt.Fprintln(os.Stderr, "    ✓ already assigned")
 			return nil
 		}
+		if isAuthorizationFailed(err) {
+			return fmt.Errorf("%w: %v", ErrAuthorizationFailed, err)
+		}
 		return fmt.Errorf("create role assignment: %w", err)
 	}
 	fmt.Fprintln(os.Stderr, "    ✓ granted")
 	return nil
+}
+
+// isAuthorizationFailed reports whether err is the well-known
+// "caller is missing Microsoft.Authorization/roleAssignments/write"
+// ARM response. Returned to allow `make e2e-setup` to fall back to
+// SAS-only mode without failing.
+func isAuthorizationFailed(err error) bool {
+	var respErr *azcore.ResponseError
+	if !errors.As(err, &respErr) {
+		return false
+	}
+	return respErr.ErrorCode == "AuthorizationFailed"
 }
 
 // isRoleAlreadyAssigned returns true if the error from a role-assignment

--- a/e2e/infra/azure/rbac_test.go
+++ b/e2e/infra/azure/rbac_test.go
@@ -1,0 +1,58 @@
+package azure
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+)
+
+func TestIsAuthorizationFailed(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"plain error", errors.New("boom"), false},
+		{"auth failed code", &azcore.ResponseError{ErrorCode: "AuthorizationFailed"}, true},
+		{"wrapped auth failed code", fmtWrap{inner: &azcore.ResponseError{ErrorCode: "AuthorizationFailed"}}, true},
+		{"other code", &azcore.ResponseError{ErrorCode: "NoSuchThing"}, false},
+		{"status only", &azcore.ResponseError{StatusCode: http.StatusForbidden}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isAuthorizationFailed(tc.err); got != tc.want {
+				t.Errorf("isAuthorizationFailed(%v) = %v, want %v", tc.err, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestIsRoleAlreadyAssigned(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"plain error", errors.New("boom"), false},
+		{"RoleAssignmentExists", &azcore.ResponseError{ErrorCode: "RoleAssignmentExists"}, true},
+		{"RoleAssignmentAlreadyExists", &azcore.ResponseError{ErrorCode: "RoleAssignmentAlreadyExists"}, true},
+		{"wrapped RoleAssignmentExists", fmtWrap{inner: &azcore.ResponseError{ErrorCode: "RoleAssignmentExists"}}, true},
+		{"other code", &azcore.ResponseError{ErrorCode: "NoSuchThing"}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isRoleAlreadyAssigned(tc.err); got != tc.want {
+				t.Errorf("isRoleAlreadyAssigned(%v) = %v, want %v", tc.err, got, tc.want)
+			}
+		})
+	}
+}
+
+type fmtWrap struct{ inner error }
+
+func (w fmtWrap) Error() string { return "wrapped: " + w.inner.Error() }
+func (w fmtWrap) Unwrap() error { return w.inner }

--- a/e2e/infra/azure/runrules.go
+++ b/e2e/infra/azure/runrules.go
@@ -54,7 +54,7 @@ func (p *Provisioner) EnsureRunRules(ctx context.Context) error {
 // not-found from the GET is treated as "create"; any other error is
 // returned. The upsert path is wrapped in RetryOnAuthRuleConflict
 // to absorb Azure Relay's per-scope 40901 throttle, which can fire
-// when two parallel `e2e-infra setup` invocations race against each
+// when two parallel `make e2e-setup` invocations race against each
 // other or when listener and sender upserts land back-to-back on a
 // fresh namespace.
 func (p *Provisioner) ensureOneRunRule(ctx context.Context, namespace, name string, right armrelay.AccessRights) error {

--- a/e2e/infra/azure/tags.go
+++ b/e2e/infra/azure/tags.go
@@ -1,0 +1,82 @@
+package azure
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources"
+)
+
+// Tag keys stamped on RGs that `make e2e-setup` creates. `make e2e-clean`
+// uses TagKeyTool to refuse deleting RGs it doesn't own (CI's RG,
+// a colleague's RG, anything pre-existing the developer attached to).
+const (
+	TagKeyOwner = "aztunnel-e2e-owner"
+	TagKeyTool  = "aztunnel-e2e-tool"
+	TagValTool  = "e2e-infra"
+)
+
+// ErrNotOwned is returned by CleanCmd's tag check when the RG either
+// has no `aztunnel-e2e-tool` tag or carries a different value. Callers
+// surface a directive error pointing at `az group delete` for the
+// "really wipe it" escape hatch and `--force` for the in-tool override.
+var ErrNotOwned = errors.New("resource group is not tagged as owned by e2e-infra")
+
+// ownerTags returns the tag map stamped onto an RG at setup time.
+// Values are pointers because armresources.ResourceGroup.Tags is
+// map[string]*string.
+func ownerTags(ownerOID string) map[string]*string {
+	owner := ownerOID
+	tool := TagValTool
+	return map[string]*string{
+		TagKeyOwner: &owner,
+		TagKeyTool:  &tool,
+	}
+}
+
+// AssertOwnedForDelete checks whether the RG's existing tags include
+// the e2e-infra ownership marker and match the current caller's
+// object ID. Returns nil when the RG is safe to delete via
+// `make e2e-clean`; ErrNotOwned when not.
+func AssertOwnedForDelete(tags map[string]*string, callerOID string) error {
+	tool, ok := tags[TagKeyTool]
+	if !ok || tool == nil || *tool != TagValTool {
+		return fmt.Errorf("%w: tag %s=%q is required", ErrNotOwned, TagKeyTool, TagValTool)
+	}
+	owner, ok := tags[TagKeyOwner]
+	if !ok || owner == nil || !strings.EqualFold(*owner, callerOID) {
+		return fmt.Errorf("%w: tag %s must match the current user object id", ErrNotOwned, TagKeyOwner)
+	}
+	return nil
+}
+
+// GetResourceGroupTags fetches the current tag map of the RG. Used by
+// CleanCmd before deletion. Returns the tags as-is from ARM (may be
+// nil when the RG carries no tags).
+func (p *Provisioner) GetResourceGroupTags(ctx context.Context) (map[string]*string, error) {
+	resp, err := p.rgClient.Get(ctx, p.cfg.ResourceGroup, nil)
+	if err != nil {
+		return nil, fmt.Errorf("get resource group: %w", err)
+	}
+	if resp.Tags == nil {
+		return nil, nil
+	}
+	return resp.Tags, nil
+}
+
+// TagResourceGroup writes (or overwrites) the ownership tags on the
+// RG. Idempotent: the patch preserves other tags. Setup only calls
+// this when the RG is untagged or already owned by the current user;
+// the caller is responsible for not overwriting another owner's tags.
+func (p *Provisioner) TagResourceGroup(ctx context.Context, ownerOID string) error {
+	tags := ownerTags(ownerOID)
+	_, err := p.rgClient.Update(ctx, p.cfg.ResourceGroup, armresources.ResourceGroupPatchable{
+		Tags: tags,
+	}, nil)
+	if err != nil {
+		return fmt.Errorf("tag resource group: %w", err)
+	}
+	return nil
+}

--- a/e2e/infra/azure/tags_test.go
+++ b/e2e/infra/azure/tags_test.go
@@ -1,0 +1,46 @@
+package azure
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestAssertOwnedForDelete(t *testing.T) {
+	ours := TagValTool
+	other := "manual"
+	callerOID := "11111111-1111-1111-1111-111111111111"
+	otherOID := "00000000-0000-0000-0000-000000000000"
+	cases := []struct {
+		name string
+		tags map[string]*string
+		want error
+	}{
+		{"nil tags", nil, ErrNotOwned},
+		{"no tool tag", map[string]*string{"unrelated": ptr("x")}, ErrNotOwned},
+		{"other tool", map[string]*string{TagKeyTool: &other}, ErrNotOwned},
+		{"nil value", map[string]*string{TagKeyTool: nil}, ErrNotOwned},
+		{"missing owner", map[string]*string{TagKeyTool: &ours}, ErrNotOwned},
+		{"owner mismatch", map[string]*string{TagKeyTool: &ours, TagKeyOwner: &otherOID}, ErrNotOwned},
+		{"e2e-infra owned by caller", map[string]*string{TagKeyTool: &ours, TagKeyOwner: &callerOID}, nil},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := AssertOwnedForDelete(c.tags, callerOID)
+			if !errors.Is(got, c.want) {
+				t.Errorf("got %v, want %v", got, c.want)
+			}
+		})
+	}
+}
+
+func TestOwnerTags(t *testing.T) {
+	tags := ownerTags("11111111-1111-1111-1111-111111111111")
+	if tags[TagKeyTool] == nil || *tags[TagKeyTool] != TagValTool {
+		t.Errorf("tool tag missing or wrong: %v", tags[TagKeyTool])
+	}
+	if tags[TagKeyOwner] == nil || *tags[TagKeyOwner] != "11111111-1111-1111-1111-111111111111" {
+		t.Errorf("owner tag missing or wrong: %v", tags[TagKeyOwner])
+	}
+}
+
+func ptr(s string) *string { return &s }

--- a/e2e/infra/cmd/e2e-infra/attach.go
+++ b/e2e/infra/cmd/e2e-infra/attach.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/philsphicas/aztunnel/e2e/azrelay"
+	"github.com/philsphicas/aztunnel/e2e/infra/azure"
+	"github.com/philsphicas/aztunnel/e2e/infra/internal/msgraph"
+)
+
+// AttachCmd records an attachment to a pre-existing RG + namespace in
+// e2e/.local.json. It performs verification only — no create, no grant,
+// no delete. Use case: joining a colleague's or CI's setup without
+// re-provisioning.
+type AttachCmd struct{}
+
+func (c *AttachCmd) Run(ctx context.Context) error {
+	if CLI.ResourceGroup == "" {
+		return errors.New("attach requires --resource-group (or RESOURCE_GROUP env)")
+	}
+	prov, err := azure.NewProvisioner(ctx, azure.Config{
+		ResourceGroup: CLI.ResourceGroup,
+		RelayName:     CLI.RelayName,
+	})
+	if err != nil {
+		return err
+	}
+
+	fmt.Fprintf(os.Stderr, "==> attaching to resource group %s\n", CLI.ResourceGroup)
+	tags, err := prov.GetResourceGroupTags(ctx)
+	if err != nil {
+		return fmt.Errorf("verify resource group access: %w", err)
+	}
+	_ = tags // tags are informational only on attach; clean's owner-check is what matters.
+
+	relay, err := prov.DiscoverNamespace(ctx)
+	if err != nil {
+		return err
+	}
+	fmt.Fprintf(os.Stderr, "==> discovered relay namespace %s\n", relay)
+
+	// Confirm the permanent SAS rules exist + we can ListKeys at
+	// least one. ListKeys is the data-plane gate that decides whether
+	// tests can run at all.
+	if _, err := azrelay.AcquireRunRules(ctx, azrelay.Config{
+		SubscriptionID: prov.SubscriptionID(),
+		ResourceGroup:  CLI.ResourceGroup,
+		Namespace:      relay,
+		Cred:           prov.Credential(),
+	}); err != nil {
+		return fmt.Errorf("verify SAS rules readable: %w\n"+
+			"    the namespace exists but `make e2e-attach` cannot read the permanent\n"+
+			"    SAS rules; ask whoever ran `make e2e-setup` on it to grant you the\n"+
+			"    `Azure Relay Owner` role at namespace scope (or run\n"+
+			"    `make e2e-grant RESOURCE_GROUP=%s RELAY_NAME=%s ASSIGNEE=<your-upn>`)",
+			err, CLI.ResourceGroup, relay)
+	}
+	fmt.Fprintln(os.Stderr, "    ✓ permanent SAS rules readable")
+
+	gc, err := msgraph.New(prov.Credential())
+	if err != nil {
+		return err
+	}
+	oid, _, err := gc.SignedInUserObjectID(ctx)
+	if err != nil {
+		return fmt.Errorf("resolve signed-in user: %w", err)
+	}
+	tenant, err := gc.TenantID(ctx)
+	if err != nil {
+		return fmt.Errorf("resolve tenant id: %w", err)
+	}
+
+	cfg := LocalConfig{
+		Subscription:  prov.SubscriptionID(),
+		Tenant:        tenant,
+		UserObjectID:  oid,
+		ResourceGroup: CLI.ResourceGroup,
+		RelayName:     relay,
+		// Attach leaves sasOnly false; `make e2e-status` re-probes
+		// data-plane access on demand. If the caller cannot Listen /
+		// Send the entra subtests will fail, which is the same
+		// outcome as running tests against an under-permissioned
+		// namespace today — just with a clearer error.
+		SASOnly:   false,
+		CreatedAt: nowRFC3339(),
+	}
+	path, err := writeLocalConfig(cfg)
+	if err != nil {
+		return err
+	}
+	printLocalConfigWritten(path)
+	fmt.Fprintln(os.Stderr, "==> ready to run `make e2e`")
+	return nil
+}

--- a/e2e/infra/cmd/e2e-infra/localconfig.go
+++ b/e2e/infra/cmd/e2e-infra/localconfig.go
@@ -1,0 +1,126 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// LocalConfig is the on-disk shape of e2e/.local.json. Mirrors the
+// struct in e2e/testmain_helpers.go; duplicated here so the two
+// modules stay decoupled. Field tags and ordering MUST match.
+type LocalConfig struct {
+	Subscription  string `json:"subscription"`
+	Tenant        string `json:"tenant"`
+	UserObjectID  string `json:"userObjectId"`
+	ResourceGroup string `json:"resourceGroup"`
+	RelayName     string `json:"relayName"`
+	SASOnly       bool   `json:"sasOnly"`
+	CreatedAt     string `json:"createdAt"`
+}
+
+// localConfigFilename is the basename written under e2e/.
+const localConfigFilename = ".local.json"
+
+// localConfigPath returns the absolute filesystem path of
+// e2e/.local.json relative to the repository root. The CLI runs under
+// e2e/infra (its module root) so the path is "../" + ".local.json".
+//
+// All subcommands resolve the path the same way; this is the single
+// source of truth.
+func localConfigPath() (string, error) {
+	wd, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	candidate := filepath.Join(wd, "..", localConfigFilename)
+	abs, err := filepath.Abs(candidate)
+	if err != nil {
+		return "", err
+	}
+	// Defence-in-depth: the path's parent directory must be named
+	// "e2e" — fail loudly if someone invokes us from an unexpected cwd
+	// rather than silently writing the file in the wrong place.
+	parent := filepath.Base(filepath.Dir(abs))
+	if parent != "e2e" {
+		return "", fmt.Errorf("expected to be invoked from e2e/infra (so cwd/../%s lives in e2e/), got parent=%q (cwd=%s)",
+			localConfigFilename, parent, wd)
+	}
+	return abs, nil
+}
+
+// writeLocalConfig serialises cfg to e2e/.local.json with mode 0600.
+// Overwrites any existing file.
+func writeLocalConfig(cfg LocalConfig) (string, error) {
+	path, err := localConfigPath()
+	if err != nil {
+		return "", err
+	}
+	data, err := json.MarshalIndent(cfg, "", "  ")
+	if err != nil {
+		return "", err
+	}
+	// Trailing newline so editors don't fight the file on save.
+	data = append(data, '\n')
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		return "", fmt.Errorf("write %s: %w", path, err)
+	}
+	return path, nil
+}
+
+// readLocalConfig parses e2e/.local.json. Wraps os.ErrNotExist when
+// the file is missing so callers can distinguish "no config yet" from
+// "config is corrupt".
+func readLocalConfig() (*LocalConfig, string, error) {
+	path, err := localConfigPath()
+	if err != nil {
+		return nil, "", err
+	}
+	data, err := os.ReadFile(path) //nolint:gosec // path is constructed from a fixed basename + cwd.
+	if err != nil {
+		return nil, path, err
+	}
+	var cfg LocalConfig
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		return nil, path, fmt.Errorf("parse %s: %w", path, err)
+	}
+	return &cfg, path, nil
+}
+
+// nowRFC3339 returns the current UTC instant as an RFC 3339 string.
+// Indirected so tests can pin time.
+var nowRFC3339 = func() string {
+	return time.Now().UTC().Format(time.RFC3339)
+}
+
+// printLocalConfigWritten prints the standard "config persisted" line
+// shown after setup or attach. The path is rendered relative to the
+// repo root for readability.
+func printLocalConfigWritten(path string) {
+	rel, err := filepath.Rel(filepath.Dir(filepath.Dir(path)), path)
+	if err != nil {
+		rel = path
+	}
+	fmt.Fprintf(os.Stderr, "==> wrote %s\n", rel)
+}
+
+// printAuthorizationFallbackNote writes the SAS-only fallback
+// paragraph to stderr with an explicit grant command scoped to the
+// requester's RG/namespace.
+func printAuthorizationFallbackNote(sub, rg, relay string) {
+	fmt.Fprintf(os.Stderr, "==> note: your Azure account does not have Microsoft.Authorization/roleAssignments/write\n"+
+		"    on subscription %s, so I cannot grant you the Azure Relay data-plane role\n"+
+		"    needed for Entra-authenticated tests. SAS-only mode will be used.\n"+
+		"\n"+
+		"    To enable Entra tests later, ask a subscription Owner (or anyone with User\n"+
+		"    Access Administrator on the namespace) to run:\n"+
+		"\n"+
+		"        make e2e-grant RESOURCE_GROUP=%s RELAY_NAME=%s ASSIGNEE=<your-upn>\n"+
+		"\n"+
+		"    Then refresh your local config without retrying the role assignment:\n"+
+		"\n"+
+		"        make e2e-attach RESOURCE_GROUP=%s RELAY_NAME=%s\n",
+		sub, rg, relay, rg, relay)
+}

--- a/e2e/infra/cmd/e2e-infra/main.go
+++ b/e2e/infra/cmd/e2e-infra/main.go
@@ -1,81 +1,224 @@
-// Command e2e-infra is the maintainer-facing setup tool for the aztunnel
-// E2E test infrastructure. It replaces the historic shell scripts in
-// this directory with a single Go binary that uses the Azure SDK + GitHub
-// API directly — no `az`, `gh`, or `jq` shell-outs.
+// Command e2e-infra is the implementation behind the `make e2e-*` Make
+// targets that provision and operate the aztunnel E2E test
+// infrastructure. Use the Make targets directly — they are the stable
+// user surface. `make help` lists them with one-line summaries.
 //
 // Subcommands:
 //
-//	setup      — Create namespace + permanent SAS rules + grant self Azure Relay Owner
-//	ci         — setup + create Entra app + federated credential + GitHub secrets
-//	clean      — Delete the resource group (and everything in it)
-//	grant      — Grant Azure Relay Owner to a principal
-//	env        — Print the env vars required to run e2e tests locally
-//	janitor    — Delete orphan e2e-{entra,sas}-<hex> hycos older than --max-age
+//	setup      — Create per-developer RG + namespace + permanent SAS rules + grant self. Writes e2e/.local.json.
+//	attach     — Record an existing RG + namespace in e2e/.local.json (no create / grant).
+//	status     — Print resolved config and probe Azure-side health.
+//	ci         — Maintainer-only: setup + Entra app + GitHub secrets.
+//	clean      — Delete the resource group (owner-tag-protected; --force overrides).
+//	grant      — Grant Azure Relay Owner to a principal.
+//	janitor    — Delete orphan e2e-{entra,sas}-<hex> hycos older than --max-age.
 package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/signal"
+	"strings"
 	"syscall"
 	"time"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/alecthomas/kong"
 
+	"github.com/philsphicas/aztunnel/e2e/azrelay"
 	"github.com/philsphicas/aztunnel/e2e/infra/azure"
 	"github.com/philsphicas/aztunnel/e2e/infra/entra"
 	"github.com/philsphicas/aztunnel/e2e/infra/githubcfg"
+	"github.com/philsphicas/aztunnel/e2e/infra/internal/msgraph"
 	"github.com/philsphicas/aztunnel/e2e/infra/janitor"
 )
 
 // CLI is the top-level kong-parsed command structure.
+//
+// ResourceGroup intentionally has no default — each subcommand calls
+// azure.ResolveResourceGroup with the appropriate ciFallback flag so
+// the per-developer derivation happens consistently. `make e2e-ci`
+// is the only target that defaults to azure.CIResourceGroup.
 var CLI struct {
-	ResourceGroup string `name:"resource-group" env:"RESOURCE_GROUP" default:"aztunnel-e2e" help:"Resource group containing the relay namespace."`
+	ResourceGroup string `name:"resource-group" env:"RESOURCE_GROUP" help:"Resource group (default: aztunnel-e2e-<alias-from-signed-in-user>; CI: aztunnel-e2e)."`
 	RelayName     string `name:"relay-name" env:"RELAY_NAME" help:"Relay namespace name (auto-generated from subscription + RG if empty)."`
+	Alias         string `name:"alias" env:"ALIAS" help:"Slug used to form aztunnel-e2e-<alias>; default derives from the signed-in user (Microsoft Graph /me)."`
 
-	Setup   SetupCmd   `cmd:"" help:"Create namespace + permanent SAS rules + grant self Azure Relay Owner."`
-	CI      CICmd      `cmd:"" help:"Full CI setup: namespace + permanent SAS rules + Entra app + GitHub secrets."`
-	Clean   CleanCmd   `cmd:"" help:"Delete the resource group."`
+	Setup   SetupCmd   `cmd:"" help:"Provision per-developer RG + namespace + permanent SAS rules + grant self. Writes e2e/.local.json."`
+	Attach  AttachCmd  `cmd:"" help:"Record an existing RG + namespace in e2e/.local.json without provisioning."`
+	Status  StatusCmd  `cmd:"" help:"Print resolved config and probe Azure-side health."`
+	CI      CICmd      `cmd:"" help:"Maintainer-only: setup + Entra app + GitHub secrets."`
+	Clean   CleanCmd   `cmd:"" help:"Delete this developer's RG (owner-tag-protected)."`
 	Grant   GrantCmd   `cmd:"" help:"Grant Azure Relay Owner to a principal."`
-	Env     EnvCmd     `cmd:"" help:"Print E2E_* env vars for local test runs."`
 	Janitor JanitorCmd `cmd:"" help:"Delete orphan e2e-{entra,sas}-<hex> hycos."`
 }
 
-// SetupCmd creates the resource group + relay namespace and grants the
-// signed-in user Azure Relay Owner at namespace scope.
-type SetupCmd struct {
-	Location string `name:"location" env:"LOCATION" default:"westus2" help:"Azure region for created resources."`
-	SkipRBAC bool   `name:"skip-rbac" help:"Do not grant RBAC roles (useful when running without role-assignment permissions)."`
-}
-
-func (c *SetupCmd) Run(ctx context.Context) error {
+// bootstrap is the common pre-amble: construct a credential (via a
+// throwaway placeholder Provisioner), resolve the RG name, then
+// construct the real Provisioner against that RG.
+//
+// ciFallback=true uses azure.CIResourceGroup when no RG / alias is
+// specified; false derives one from the signed-in user.
+func bootstrap(ctx context.Context, location string, ciFallback bool) (*azure.Provisioner, string, error) {
+	cred, err := bootstrapCredential(ctx)
+	if err != nil {
+		return nil, "", err
+	}
+	rg, err := azure.ResolveResourceGroup(ctx, cred, CLI.ResourceGroup, CLI.Alias, ciFallback)
+	if err != nil {
+		return nil, "", err
+	}
 	prov, err := azure.NewProvisioner(ctx, azure.Config{
-		ResourceGroup: CLI.ResourceGroup,
-		Location:      c.Location,
+		ResourceGroup: rg,
+		Location:      location,
 		RelayName:     CLI.RelayName,
 	})
 	if err != nil {
+		return nil, rg, err
+	}
+	return prov, rg, nil
+}
+
+// bootstrapCredential returns a TokenCredential without needing an
+// already-resolved RG. We construct a placeholder Provisioner whose
+// only job is to materialise the same DefaultAzureCredential each
+// subcommand would otherwise build itself.
+func bootstrapCredential(ctx context.Context) (azcore.TokenCredential, error) {
+	prov, err := azure.NewProvisioner(ctx, azure.Config{ResourceGroup: "_bootstrap"})
+	if err != nil {
+		return nil, err
+	}
+	return prov.Credential(), nil
+}
+
+// SetupCmd creates the RG + relay namespace + permanent SAS rules,
+// tags the RG with the signed-in user's OID, grants Azure Relay Owner
+// on the namespace, and writes e2e/.local.json. On Contributor-only
+// callers the grant gracefully falls back to SAS-only mode.
+type SetupCmd struct {
+	Location string `name:"location" env:"LOCATION" default:"westus2" help:"Azure region for created resources."`
+	SkipRBAC bool   `name:"skip-rbac" help:"Do not attempt the RBAC grant (forces SAS-only)."`
+}
+
+const rbacPropagationMaxWait = 30 * time.Second
+
+func (c *SetupCmd) Run(ctx context.Context) error {
+	prov, rg, err := bootstrap(ctx, c.Location, false)
+	if err != nil {
 		return err
 	}
+	fmt.Fprintf(os.Stderr, "==> using resource group %s\n", rg)
+
+	gc, err := msgraph.New(prov.Credential())
+	if err != nil {
+		return err
+	}
+	oid, upn, err := gc.SignedInUserObjectID(ctx)
+	if err != nil {
+		return fmt.Errorf("resolve signed-in user (run `az login`): %w", err)
+	}
+	tenant, err := gc.TenantID(ctx)
+	if err != nil {
+		return fmt.Errorf("resolve tenant id: %w", err)
+	}
+
 	if _, err := prov.EnsureNamespace(ctx); err != nil {
 		return fmt.Errorf("ensure namespace: %w", err)
 	}
 	if err := prov.EnsureRunRules(ctx); err != nil {
 		return fmt.Errorf("ensure run rules: %w", err)
 	}
+
+	existingTags, err := prov.GetResourceGroupTags(ctx)
+	if err != nil {
+		return fmt.Errorf("read resource group tags: %w", err)
+	}
+	switch {
+	case azure.AssertOwnedForDelete(existingTags, oid) == nil:
+		if err := prov.TagResourceGroup(ctx, oid); err != nil {
+			fmt.Fprintf(os.Stderr, "    WARNING: could not refresh ownership tags: %v\n", err)
+		}
+	case existingTags[azure.TagKeyTool] == nil:
+		if err := prov.TagResourceGroup(ctx, oid); err != nil {
+			fmt.Fprintf(os.Stderr, "    WARNING: could not tag resource group: %v\n", err)
+			fmt.Fprintln(os.Stderr, "    WARNING: `make e2e-clean` will refuse this RG until the tag is applied")
+		}
+	default:
+		fmt.Fprintln(os.Stderr, "==> resource group is tagged by a different owner; leaving ownership tags unchanged")
+	}
+
+	sasOnly := c.SkipRBAC
 	if c.SkipRBAC {
-		fmt.Fprintln(os.Stderr, "    (skipping RBAC per --skip-rbac)")
-		return nil
+		fmt.Fprintln(os.Stderr, "==> skipping RBAC grant per --skip-rbac; SAS-only mode")
+	} else {
+		err := prov.GrantOwnerSelf(ctx)
+		switch {
+		case err == nil:
+			waitForRBACPropagation(ctx, prov, rg)
+		case errors.Is(err, azure.ErrAuthorizationFailed):
+			printAuthorizationFallbackNote(prov.SubscriptionID(), rg, prov.ResolvedNamespace())
+			sasOnly = true
+		default:
+			return fmt.Errorf("grant self: %w", err)
+		}
 	}
-	if err := prov.GrantOwnerSelf(ctx); err != nil {
-		return fmt.Errorf("grant self: %w", err)
+
+	cfg := LocalConfig{
+		Subscription:  prov.SubscriptionID(),
+		Tenant:        tenant,
+		UserObjectID:  oid,
+		ResourceGroup: rg,
+		RelayName:     prov.ResolvedNamespace(),
+		SASOnly:       sasOnly,
+		CreatedAt:     nowRFC3339(),
 	}
+	path, err := writeLocalConfig(cfg)
+	if err != nil {
+		return err
+	}
+	printLocalConfigWritten(path)
+	fmt.Fprintf(os.Stderr, "==> setup complete for %s\n", upn)
+	fmt.Fprintln(os.Stderr, "    next: `make e2e` to run the test suite")
 	return nil
 }
 
+// waitForRBACPropagation gives newly created role assignments a short
+// window to propagate before the first Entra-backed test run.
+func waitForRBACPropagation(ctx context.Context, prov *azure.Provisioner, rg string) {
+	cfg := azrelay.Config{
+		SubscriptionID: prov.SubscriptionID(),
+		ResourceGroup:  rg,
+		Namespace:      prov.ResolvedNamespace(),
+		Cred:           prov.Credential(),
+	}
+	deadline := time.Now().Add(rbacPropagationMaxWait)
+	var lastErr error
+	for {
+		probeCtx, cancel := context.WithTimeout(ctx, 3*time.Second)
+		_, err := azrelay.AcquireRunRules(probeCtx, cfg)
+		cancel()
+		if err == nil {
+			return
+		}
+		lastErr = err
+		if time.Now().After(deadline) {
+			fmt.Fprintf(os.Stderr, "    WARNING: Azure Relay RBAC may still be propagating; first Entra test run may fail briefly: %v\n", lastErr)
+			return
+		}
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(2 * time.Second):
+		}
+	}
+}
+
 // CICmd performs the full maintainer setup: namespace + Entra app +
-// federated credential + GitHub secrets/variables.
+// federated credential + GitHub secrets/variables. Targets the
+// CI-fixed RG name (azure.CIResourceGroup) by default; explicit
+// --resource-group / RESOURCE_GROUP / --alias still wins.
 type CICmd struct {
 	Location   string `name:"location" env:"LOCATION" default:"westus2" help:"Azure region for created resources."`
 	EntraApp   string `name:"entra-app" env:"ENTRA_APP" default:"aztunnel-e2e-ci" help:"Entra app registration display name."`
@@ -86,14 +229,15 @@ type CICmd struct {
 }
 
 func (c *CICmd) Run(ctx context.Context) error {
-	prov, err := azure.NewProvisioner(ctx, azure.Config{
-		ResourceGroup: CLI.ResourceGroup,
-		Location:      c.Location,
-		RelayName:     CLI.RelayName,
-	})
+	prov, rg, err := bootstrap(ctx, c.Location, true)
 	if err != nil {
 		return err
 	}
+	fmt.Fprintf(os.Stderr, "==> using resource group %s\n", rg)
+
+	// CI's RG is shared across maintainers and predates per-developer
+	// tagging; do not stamp owner tags so `make e2e-clean` continues
+	// to require --force against it.
 	if _, err := prov.EnsureNamespace(ctx); err != nil {
 		return fmt.Errorf("ensure namespace: %w", err)
 	}
@@ -122,7 +266,7 @@ func (c *CICmd) Run(ctx context.Context) error {
 		Repo:           repo,
 		Environment:    c.GitHubEnv,
 		RelayName:      prov.ResolvedNamespace(),
-		ResourceGroup:  CLI.ResourceGroup,
+		ResourceGroup:  rg,
 		ClientID:       app.ApplicationID,
 		TenantID:       app.TenantID,
 		SubscriptionID: prov.SubscriptionID(),
@@ -134,41 +278,74 @@ func (c *CICmd) Run(ctx context.Context) error {
 	return nil
 }
 
-// CleanCmd deletes the resource group (and all resources in it).
+// CleanCmd deletes the resource group. Refuses unless the RG carries
+// the `aztunnel-e2e-tool=e2e-infra` owner tag (or --force is set).
 type CleanCmd struct {
 	Confirm bool `name:"yes" help:"Skip the y/N confirmation prompt."`
+	Force   bool `name:"force" help:"Bypass the owner-tag check (use with care)."`
 }
 
 func (c *CleanCmd) Run(ctx context.Context) error {
-	if !c.Confirm {
-		fmt.Fprintf(os.Stderr, "About to delete resource group %q. Pass --yes to confirm.\n", CLI.ResourceGroup)
-		return fmt.Errorf("not confirmed")
-	}
-	prov, err := azure.NewProvisioner(ctx, azure.Config{
-		ResourceGroup: CLI.ResourceGroup,
-		RelayName:     CLI.RelayName,
-	})
+	prov, rg, err := bootstrap(ctx, "", false)
 	if err != nil {
 		return err
 	}
-	return prov.DeleteResourceGroup(ctx)
+	if !c.Force {
+		gc, err := msgraph.New(prov.Credential())
+		if err != nil {
+			return fmt.Errorf("resolve current user: %w", err)
+		}
+		callerOID, _, err := gc.SignedInUserObjectID(ctx)
+		if err != nil {
+			return fmt.Errorf("resolve current user: %w", err)
+		}
+		tags, err := prov.GetResourceGroupTags(ctx)
+		if err != nil {
+			return fmt.Errorf("verify RG ownership: %w", err)
+		}
+		if err := azure.AssertOwnedForDelete(tags, callerOID); err != nil {
+			msg := fmt.Sprintf("refusing to delete resource group %s: %v\n"+
+				"    `make e2e-clean` only deletes RGs created by `make e2e-setup` (verified\n"+
+				"    via the `%s` and `%s` tags). To delete anyway, pass --force, or use\n"+
+				"    `az group delete --name %s` for a manually-managed RG",
+				rg, err, azure.TagKeyTool, azure.TagKeyOwner, rg)
+			return errors.New(msg)
+		}
+	}
+	if !c.Confirm {
+		fmt.Fprintf(os.Stderr, "About to delete resource group %q. Pass --yes to confirm.\n", rg)
+		return errors.New("not confirmed")
+	}
+	if err := prov.DeleteResourceGroup(ctx); err != nil {
+		return err
+	}
+	// Best-effort: drop e2e/.local.json if it pointed at the RG we
+	// just deleted. Non-fatal — the deletion already happened.
+	if local, path, lerr := readLocalConfig(); lerr == nil && strings.EqualFold(local.ResourceGroup, rg) {
+		if rerr := os.Remove(path); rerr != nil {
+			fmt.Fprintf(os.Stderr, "    note: could not remove %s: %v\n", path, rerr)
+		} else {
+			fmt.Fprintf(os.Stderr, "==> removed e2e/%s (it pointed at the deleted RG)\n", localConfigFilename)
+		}
+	}
+	return nil
 }
 
 // GrantCmd grants Azure Relay Owner to a principal at namespace scope.
+// --assignee is the Make-target-friendly entry point; --self / --user /
+// --sp remain for explicit cases.
 type GrantCmd struct {
-	Self bool   `name:"self" xor:"target" help:"Grant to the signed-in user."`
-	User string `name:"user" xor:"target" help:"Grant to a user by UPN/email."`
-	SP   string `name:"sp" xor:"target" help:"Grant to a service principal by app display name."`
+	Self     bool   `name:"self" xor:"target" help:"Grant to the signed-in user."`
+	User     string `name:"user" xor:"target" help:"Grant to a user by UPN/email."`
+	SP       string `name:"sp" xor:"target" help:"Grant to a service principal by app display name."`
+	Assignee string `name:"assignee" xor:"target" help:"Grant to UPN (contains @) or app display name (auto-detected)."`
 }
 
 func (c *GrantCmd) Run(ctx context.Context) error {
-	if !c.Self && c.User == "" && c.SP == "" {
-		return fmt.Errorf("exactly one of --self, --user, --sp is required")
+	if !c.Self && c.User == "" && c.SP == "" && c.Assignee == "" {
+		return errors.New("exactly one of --self, --user, --sp, --assignee is required")
 	}
-	prov, err := azure.NewProvisioner(ctx, azure.Config{
-		ResourceGroup: CLI.ResourceGroup,
-		RelayName:     CLI.RelayName,
-	})
+	prov, _, err := bootstrap(ctx, "", false)
 	if err != nil {
 		return err
 	}
@@ -177,44 +354,26 @@ func (c *GrantCmd) Run(ctx context.Context) error {
 		return prov.GrantOwnerSelf(ctx)
 	case c.User != "":
 		return prov.GrantOwnerUser(ctx, c.User)
-	default:
+	case c.SP != "":
 		return prov.GrantOwnerSPByAppName(ctx, c.SP)
+	default:
+		if strings.Contains(c.Assignee, "@") {
+			return prov.GrantOwnerUser(ctx, c.Assignee)
+		}
+		return prov.GrantOwnerSPByAppName(ctx, c.Assignee)
 	}
-}
-
-// EnvCmd prints the env vars needed for local `make e2e` runs (replacement
-// for the historic env.sh).
-type EnvCmd struct{}
-
-func (c *EnvCmd) Run(ctx context.Context) error {
-	prov, err := azure.NewProvisioner(ctx, azure.Config{
-		ResourceGroup: CLI.ResourceGroup,
-		RelayName:     CLI.RelayName,
-	})
-	if err != nil {
-		return err
-	}
-	relay, err := prov.DiscoverNamespace(ctx)
-	if err != nil {
-		return err
-	}
-	fmt.Printf("export E2E_RELAY_NAME=%s\n", relay)
-	fmt.Printf("export E2E_RESOURCE_GROUP=%s\n", CLI.ResourceGroup)
-	fmt.Printf("export AZURE_SUBSCRIPTION_ID=%s\n", prov.SubscriptionID())
-	return nil
 }
 
 // JanitorCmd deletes orphan per-invocation hycos older than --max-age.
+// Falls back to the CI RG (azure.CIResourceGroup) when no explicit
+// override is set; matches the cron job's expectation.
 type JanitorCmd struct {
 	MaxAge time.Duration `name:"max-age" default:"4h" help:"Delete e2e-{entra,sas}-<hex> hycos older than this."`
 	DryRun bool          `name:"dry-run" help:"Print what would be deleted without deleting."`
 }
 
 func (c *JanitorCmd) Run(ctx context.Context) error {
-	prov, err := azure.NewProvisioner(ctx, azure.Config{
-		ResourceGroup: CLI.ResourceGroup,
-		RelayName:     CLI.RelayName,
-	})
+	prov, rg, err := bootstrap(ctx, "", true)
 	if err != nil {
 		return err
 	}
@@ -224,7 +383,7 @@ func (c *JanitorCmd) Run(ctx context.Context) error {
 	}
 	return janitor.Run(ctx, janitor.Config{
 		SubscriptionID: prov.SubscriptionID(),
-		ResourceGroup:  CLI.ResourceGroup,
+		ResourceGroup:  rg,
 		Namespace:      relay,
 		MaxAge:         c.MaxAge,
 		DryRun:         c.DryRun,
@@ -242,7 +401,7 @@ func run() int {
 
 	cliCtx := kong.Parse(&CLI,
 		kong.Name("e2e-infra"),
-		kong.Description("Maintainer-facing setup CLI for aztunnel E2E test infrastructure."),
+		kong.Description("Implementation behind the `make e2e-*` Make targets — use those directly."),
 		kong.UsageOnError(),
 		kong.ConfigureHelp(kong.HelpOptions{Compact: true}),
 		// BindTo (not Bind/Run-arg) is required for interface types: kong's

--- a/e2e/infra/cmd/e2e-infra/status.go
+++ b/e2e/infra/cmd/e2e-infra/status.go
@@ -1,0 +1,107 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/philsphicas/aztunnel/e2e/azrelay"
+	"github.com/philsphicas/aztunnel/e2e/infra/azure"
+	"github.com/philsphicas/aztunnel/e2e/infra/internal/msgraph"
+)
+
+// StatusCmd prints the resolved e2e config and probes Azure-side
+// health. Exits 0 when everything looks good; non-zero otherwise so
+// `make e2e-status && make e2e` is composable.
+type StatusCmd struct{}
+
+func (c *StatusCmd) Run(ctx context.Context) error {
+	local, path, err := readLocalConfig()
+	if errors.Is(err, os.ErrNotExist) {
+		msg := fmt.Sprintf("no %s found\n"+
+			"    Run `make e2e-setup` to provision a per-developer Azure Relay namespace,\n"+
+			"    or `make e2e-attach RESOURCE_GROUP=<rg>` to record a pre-existing one",
+			path)
+		return errors.New(msg)
+	}
+	if err != nil {
+		return err
+	}
+
+	// Header / one-line summary first. Subsequent checks may append
+	// WARN / ERROR lines.
+	fmt.Printf("config source     : e2e/%s\n", localConfigFilename)
+	fmt.Printf("subscription      : %s\n", local.Subscription)
+	fmt.Printf("tenant            : %s\n", local.Tenant)
+	fmt.Printf("resource group    : %s\n", local.ResourceGroup)
+	fmt.Printf("relay namespace   : %s\n", local.RelayName)
+	fmt.Printf("sas-only mode     : %t\n", local.SASOnly)
+
+	var problems []string
+
+	// Subscription / tenant drift check against the Azure CLI default.
+	// Skipped silently when the CLI profile is absent — managed-identity
+	// and OIDC environments don't have ~/.azure/azureProfile.json.
+	azureProfile, err := azure.ReadAzureCLIProfileDefault()
+	switch {
+	case errors.Is(err, os.ErrNotExist):
+		// nothing to compare against; skip
+	case err != nil:
+		problems = append(problems, fmt.Sprintf("could not read ~/.azure/azureProfile.json: %v", err))
+	case azureProfile.Subscription != "" && !strings.EqualFold(azureProfile.Subscription, local.Subscription):
+		problems = append(problems, fmt.Sprintf("subscription mismatch: Azure CLI default is %s but persisted is %s — run `az account set --subscription %s` or re-run `make e2e-setup`",
+			azureProfile.Subscription, local.Subscription, local.Subscription))
+	case azureProfile.Tenant != "" && local.Tenant != "" && !strings.EqualFold(azureProfile.Tenant, local.Tenant):
+		problems = append(problems, fmt.Sprintf("tenant mismatch: Azure CLI default tenant is %s but persisted is %s — `az login --tenant %s`",
+			azureProfile.Tenant, local.Tenant, local.Tenant))
+	}
+
+	prov, err := azure.NewProvisioner(ctx, azure.Config{
+		SubscriptionID: local.Subscription,
+		ResourceGroup:  local.ResourceGroup,
+		RelayName:      local.RelayName,
+	})
+	if err != nil {
+		problems = append(problems, fmt.Sprintf("construct provisioner: %v", err))
+	} else {
+		if _, err := prov.GetResourceGroupTags(ctx); err != nil {
+			problems = append(problems, fmt.Sprintf("resource group GET failed: %v", err))
+		}
+		if _, err := azrelay.AcquireRunRules(ctx, azrelay.Config{
+			SubscriptionID: local.Subscription,
+			ResourceGroup:  local.ResourceGroup,
+			Namespace:      local.RelayName,
+			Cred:           prov.Credential(),
+		}); err != nil {
+			problems = append(problems, fmt.Sprintf("permanent SAS rules ListKeys failed: %v", err))
+		} else {
+			fmt.Printf("perm SAS rules    : readable\n")
+		}
+
+		gc, err := msgraph.New(prov.Credential())
+		if err != nil {
+			problems = append(problems, fmt.Sprintf("graph client: %v", err))
+		} else {
+			oid, _, err := gc.SignedInUserObjectID(ctx)
+			switch {
+			case err != nil:
+				problems = append(problems, fmt.Sprintf("resolve current user: %v", err))
+			case local.UserObjectID != "" && !strings.EqualFold(oid, local.UserObjectID):
+				problems = append(problems, fmt.Sprintf("identity drift: persisted user %s, current %s — `az login` or re-run `make e2e-setup`",
+					local.UserObjectID, oid))
+			}
+		}
+	}
+
+	if len(problems) == 0 {
+		fmt.Printf("status            : OK\n")
+		return nil
+	}
+	fmt.Printf("status            : ATTENTION\n")
+	for _, p := range problems {
+		fmt.Fprintf(os.Stderr, "    !! %s\n", p)
+	}
+	return fmt.Errorf("%d issue(s) need attention; see above", len(problems))
+}

--- a/e2e/testmain_helpers.go
+++ b/e2e/testmain_helpers.go
@@ -1,0 +1,187 @@
+// Package e2e — config-resolution helpers used by TestMain.
+//
+// This file is intentionally untagged so the pure-Go helpers can be
+// unit-tested without the e2e build tag (which would otherwise drag in
+// every Azure-dependent test fixture). Anything that actually calls
+// Azure SDKs lives in testmain_test.go (//go:build e2e).
+package e2e
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// LocalConfigFilename is the basename of the per-developer config file
+// produced by `make e2e-setup` / `make e2e-attach` and consumed by
+// TestMain. Lives at e2e/.local.json relative to the repo root.
+const LocalConfigFilename = ".local.json"
+
+// LocalConfig is the on-disk shape of e2e/.local.json. Field tags use
+// camelCase; missing/zero fields are tolerated by load but checked by
+// the consumers that need them.
+type LocalConfig struct {
+	Subscription  string `json:"subscription"`
+	Tenant        string `json:"tenant"`
+	UserObjectID  string `json:"userObjectId"`
+	ResourceGroup string `json:"resourceGroup"`
+	RelayName     string `json:"relayName"`
+	SASOnly       bool   `json:"sasOnly"`
+	CreatedAt     string `json:"createdAt"`
+}
+
+// loadLocalConfig reads <dir>/.local.json. Returns the wrapped
+// os.ErrNotExist when the file is absent (the env-vars-only path);
+// returns a parse error otherwise.
+func loadLocalConfig(dir string) (*LocalConfig, error) {
+	path := filepath.Join(dir, LocalConfigFilename)
+	data, err := os.ReadFile(path) //nolint:gosec // path is composed from a test-controlled dir + a fixed basename.
+	if err != nil {
+		return nil, err
+	}
+	var cfg LocalConfig
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		return nil, fmt.Errorf("parse %s: %w", path, err)
+	}
+	return &cfg, nil
+}
+
+// resolvedConfig is the union of fields TestMain needs regardless of
+// where it found them.
+type resolvedConfig struct {
+	Subscription  string
+	ResourceGroup string
+	RelayName     string
+	// Source describes where the values came from. Values: "env"
+	// (CI / explicit override) or "local-config" (developer flow).
+	Source string
+	// Local is the parsed .local.json when Source == "local-config".
+	// nil otherwise.
+	Local *LocalConfig
+}
+
+// envLookup mirrors os.LookupEnv so resolveTestConfig is unit-testable
+// without process-wide env mutation.
+type envLookup func(key string) (string, bool)
+
+// errNoConfig is the sentinel returned when neither env vars nor a
+// local config file are present. Its Error() text is the message
+// TestMain prints to stderr before exiting.
+var errNoConfig = errors.New("e2e configuration not found")
+
+// resolveTestConfig applies the precedence:
+//
+//  1. AZURE_SUBSCRIPTION_ID + E2E_RESOURCE_GROUP both set → env path
+//     (CI / explicit override). E2E_RELAY_NAME also read from env.
+//  2. <dir>/.local.json present → file path (developer flow).
+//  3. Otherwise → errNoConfig.
+//
+// The env path takes precedence even when a local config file is
+// present, which is what lets CI shadow a developer's persisted
+// config and what lets a developer override the file ad-hoc.
+func resolveTestConfig(env envLookup, dir string) (*resolvedConfig, error) {
+	subEnv, _ := env("AZURE_SUBSCRIPTION_ID")
+	rgEnv, _ := env("E2E_RESOURCE_GROUP")
+	if subEnv != "" && rgEnv != "" {
+		nsEnv, _ := env("E2E_RELAY_NAME")
+		return &resolvedConfig{
+			Subscription:  subEnv,
+			ResourceGroup: rgEnv,
+			RelayName:     nsEnv,
+			Source:        "env",
+		}, nil
+	}
+	cfg, err := loadLocalConfig(dir)
+	if err == nil {
+		if cfg.Subscription == "" || cfg.ResourceGroup == "" || cfg.RelayName == "" {
+			return nil, fmt.Errorf("e2e: %s/%s is missing required fields (subscription/resourceGroup/relayName); re-run `make e2e-setup`",
+				dir, LocalConfigFilename)
+		}
+		return &resolvedConfig{
+			Subscription:  cfg.Subscription,
+			ResourceGroup: cfg.ResourceGroup,
+			RelayName:     cfg.RelayName,
+			Source:        "local-config",
+			Local:         cfg,
+		}, nil
+	}
+	if !errors.Is(err, os.ErrNotExist) {
+		return nil, err
+	}
+	return nil, errNoConfig
+}
+
+// currentUserOIDFn returns the AAD object ID of the current credential.
+// Injected as a function so checkIdentityDrift is testable without an
+// Azure dependency.
+type currentUserOIDFn func(ctx context.Context) (string, error)
+
+// checkIdentityDrift returns nil if local is nil, has no
+// UserObjectID, or the live OID matches the persisted one. Otherwise
+// returns a formatted error matching the message documented in the
+// spec.
+func checkIdentityDrift(ctx context.Context, local *LocalConfig, current currentUserOIDFn) error {
+	if local == nil || local.UserObjectID == "" {
+		return nil
+	}
+	got, err := current(ctx)
+	if err != nil {
+		return fmt.Errorf("resolve current Azure identity: %w", err)
+	}
+	if !strings.EqualFold(got, local.UserObjectID) {
+		return &identityDriftError{
+			expectedOID: local.UserObjectID,
+			currentOID:  got,
+		}
+	}
+	return nil
+}
+
+type identityDriftError struct {
+	expectedOID string
+	currentOID  string
+}
+
+func (e *identityDriftError) Error() string {
+	return fmt.Sprintf("==> e2e: persisted e2e/%s is for user %s, but the current Azure\n"+
+		"    credential resolves to %s. Either:\n"+
+		"      - `az login` with the original user, OR\n"+
+		"      - `rm e2e/%s && make e2e-setup` to re-provision under your\n"+
+		"        current identity (your new RG will be aztunnel-e2e-<your-alias>).",
+		LocalConfigFilename, e.expectedOID, e.currentOID, LocalConfigFilename)
+}
+
+// parseOIDFromJWT extracts the "oid" claim from a JWT access token.
+// Used by the e2e-tagged TestMain to derive the current AAD object id
+// from a token issued by DefaultAzureCredential. The token's signature
+// is not validated — the credential is trusted and we only inspect a
+// claim to compare against persisted config; no authorization decision
+// is being made.
+func parseOIDFromJWT(token string) (string, error) {
+	parts := strings.Split(token, ".")
+	if len(parts) < 2 {
+		return "", errors.New("invalid JWT: fewer than 2 segments")
+	}
+	// JWT payloads are spec'd as base64url without padding, but some
+	// issuers pad anyway; tolerate both by stripping trailing '=' and
+	// using RawURLEncoding (which handles the -/_ alphabet).
+	payload, err := base64.RawURLEncoding.DecodeString(strings.TrimRight(parts[1], "="))
+	if err != nil {
+		return "", fmt.Errorf("decode JWT payload: %w", err)
+	}
+	var claims struct {
+		OID string `json:"oid"`
+	}
+	if err := json.Unmarshal(payload, &claims); err != nil {
+		return "", err
+	}
+	if claims.OID == "" {
+		return "", errors.New("JWT did not include an oid claim")
+	}
+	return claims.OID, nil
+}

--- a/e2e/testmain_helpers_test.go
+++ b/e2e/testmain_helpers_test.go
@@ -1,0 +1,233 @@
+package e2e
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestResolveTestConfig_EnvWins(t *testing.T) {
+	dir := t.TempDir()
+	writeLocalConfigJSON(t, dir, LocalConfig{
+		Subscription:  "file-sub",
+		ResourceGroup: "file-rg",
+		RelayName:     "file-ns",
+	})
+	env := mapEnv(map[string]string{
+		"AZURE_SUBSCRIPTION_ID": "env-sub",
+		"E2E_RESOURCE_GROUP":    "env-rg",
+		"E2E_RELAY_NAME":        "env-ns",
+	})
+	got, err := resolveTestConfig(env, dir)
+	if err != nil {
+		t.Fatalf("resolveTestConfig: %v", err)
+	}
+	if got.Source != "env" {
+		t.Errorf("Source = %q, want \"env\"", got.Source)
+	}
+	if got.Subscription != "env-sub" || got.ResourceGroup != "env-rg" || got.RelayName != "env-ns" {
+		t.Errorf("env values not used: %+v", got)
+	}
+	if got.Local != nil {
+		t.Errorf("Local should be nil on env path, got %+v", got.Local)
+	}
+}
+
+func TestResolveTestConfig_EnvMissingFallsBackToFile(t *testing.T) {
+	dir := t.TempDir()
+	writeLocalConfigJSON(t, dir, LocalConfig{
+		Subscription:  "file-sub",
+		Tenant:        "file-tenant",
+		UserObjectID:  "file-oid",
+		ResourceGroup: "file-rg",
+		RelayName:     "file-ns",
+		SASOnly:       true,
+		CreatedAt:     "2026-05-20T00:00:00Z",
+	})
+	// Only E2E_RELAY_NAME is set (a single env var should not be
+	// enough to short-circuit the file path).
+	env := mapEnv(map[string]string{"E2E_RELAY_NAME": "env-ns"})
+	got, err := resolveTestConfig(env, dir)
+	if err != nil {
+		t.Fatalf("resolveTestConfig: %v", err)
+	}
+	if got.Source != "local-config" {
+		t.Errorf("Source = %q, want \"local-config\"", got.Source)
+	}
+	if got.RelayName != "file-ns" {
+		t.Errorf("RelayName = %q, want \"file-ns\" (file should win when env path incomplete)", got.RelayName)
+	}
+	if got.Local == nil || !got.Local.SASOnly || got.Local.UserObjectID != "file-oid" {
+		t.Errorf("Local fields not populated: %+v", got.Local)
+	}
+}
+
+func TestResolveTestConfig_NoConfig(t *testing.T) {
+	dir := t.TempDir()
+	env := mapEnv(nil)
+	_, err := resolveTestConfig(env, dir)
+	if !errors.Is(err, errNoConfig) {
+		t.Fatalf("err = %v, want errNoConfig", err)
+	}
+}
+
+func TestResolveTestConfig_FileMalformed(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, LocalConfigFilename), []byte("{not json"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	env := mapEnv(nil)
+	_, err := resolveTestConfig(env, dir)
+	if err == nil || errors.Is(err, errNoConfig) {
+		t.Fatalf("expected parse error, got %v", err)
+	}
+}
+
+func TestResolveTestConfig_FileMissingRequiredField(t *testing.T) {
+	dir := t.TempDir()
+	writeLocalConfigJSON(t, dir, LocalConfig{
+		Subscription:  "file-sub",
+		ResourceGroup: "file-rg",
+		// RelayName intentionally omitted.
+	})
+	_, err := resolveTestConfig(mapEnv(nil), dir)
+	if err == nil {
+		t.Fatal("expected error for missing relayName")
+	}
+	if !strings.Contains(err.Error(), "make e2e-setup") {
+		t.Errorf("error should point at `make e2e-setup`: %v", err)
+	}
+}
+
+func TestCheckIdentityDrift_NilLocal(t *testing.T) {
+	if err := checkIdentityDrift(context.Background(), nil, func(context.Context) (string, error) {
+		t.Fatal("currentUserOIDFn must not be called when local is nil")
+		return "", nil
+	}); err != nil {
+		t.Errorf("nil local should be a no-op, got %v", err)
+	}
+}
+
+func TestCheckIdentityDrift_EmptyPersistedOID(t *testing.T) {
+	local := &LocalConfig{Subscription: "x"}
+	if err := checkIdentityDrift(context.Background(), local, func(context.Context) (string, error) {
+		t.Fatal("currentUserOIDFn must not be called when persisted OID is empty")
+		return "", nil
+	}); err != nil {
+		t.Errorf("empty persisted OID should be a no-op, got %v", err)
+	}
+}
+
+func TestCheckIdentityDrift_Match(t *testing.T) {
+	local := &LocalConfig{UserObjectID: "11111111-1111-1111-1111-111111111111"}
+	live := func(context.Context) (string, error) {
+		return "11111111-1111-1111-1111-111111111111", nil
+	}
+	if err := checkIdentityDrift(context.Background(), local, live); err != nil {
+		t.Errorf("match should be no-op, got %v", err)
+	}
+}
+
+func TestCheckIdentityDrift_MatchCaseInsensitive(t *testing.T) {
+	local := &LocalConfig{UserObjectID: "AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA"}
+	live := func(context.Context) (string, error) {
+		return "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", nil
+	}
+	if err := checkIdentityDrift(context.Background(), local, live); err != nil {
+		t.Errorf("case-insensitive UUID compare should match, got %v", err)
+	}
+}
+
+func TestCheckIdentityDrift_Mismatch(t *testing.T) {
+	local := &LocalConfig{UserObjectID: "11111111-1111-1111-1111-111111111111"}
+	live := func(context.Context) (string, error) {
+		return "00000000-0000-0000-0000-000000000000", nil
+	}
+	err := checkIdentityDrift(context.Background(), local, live)
+	if err == nil {
+		t.Fatal("expected mismatch error")
+	}
+	msg := err.Error()
+	for _, want := range []string{"persisted", "11111111-1111-1111-1111-111111111111", "00000000-0000-0000-0000-000000000000", "make e2e-setup"} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("error missing %q: %s", want, msg)
+		}
+	}
+}
+
+func TestCheckIdentityDrift_FetchError(t *testing.T) {
+	local := &LocalConfig{UserObjectID: "x"}
+	live := func(context.Context) (string, error) {
+		return "", errors.New("boom")
+	}
+	err := checkIdentityDrift(context.Background(), local, live)
+	if err == nil || !strings.Contains(err.Error(), "boom") {
+		t.Fatalf("error should wrap fetch failure, got %v", err)
+	}
+}
+
+func TestParseOIDFromJWT(t *testing.T) {
+	want := "11111111-1111-1111-1111-111111111111"
+	b, _ := json.Marshal(map[string]string{"oid": want})
+	token := "header." + base64.RawURLEncoding.EncodeToString(b) + ".sig"
+	got, err := parseOIDFromJWT(token)
+	if err != nil {
+		t.Fatalf("parseOIDFromJWT: %v", err)
+	}
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestParseOIDFromJWT_PaddedBase64(t *testing.T) {
+	want := "00000000-0000-0000-0000-000000000000"
+	b, _ := json.Marshal(map[string]string{"oid": want})
+	// Standard base64url with padding (URLEncoding emits = padding;
+	// the parser strips it).
+	encoded := base64.URLEncoding.EncodeToString(b)
+	token := "h." + encoded + ".s"
+	got, err := parseOIDFromJWT(token)
+	if err != nil {
+		t.Fatalf("parseOIDFromJWT: %v", err)
+	}
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestParseOIDFromJWT_NoOID(t *testing.T) {
+	b, _ := json.Marshal(map[string]string{"sub": "x"})
+	token := "h." + base64.RawURLEncoding.EncodeToString(b) + ".s"
+	if _, err := parseOIDFromJWT(token); err == nil {
+		t.Fatal("expected error for missing oid claim")
+	}
+}
+
+func TestParseOIDFromJWT_Malformed(t *testing.T) {
+	if _, err := parseOIDFromJWT("not-a-jwt"); err == nil {
+		t.Fatal("expected error for malformed JWT")
+	}
+}
+
+func mapEnv(m map[string]string) envLookup {
+	return func(key string) (string, bool) {
+		v, ok := m[key]
+		return v, ok
+	}
+}
+
+func writeLocalConfigJSON(t *testing.T, dir string, cfg LocalConfig) {
+	t.Helper()
+	data, err := json.MarshalIndent(cfg, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, LocalConfigFilename), data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/e2e/testmain_test.go
+++ b/e2e/testmain_test.go
@@ -4,19 +4,23 @@ package e2e
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"strconv"
 	"testing"
 	"time"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
+
 	"github.com/philsphicas/aztunnel/e2e/azrelay"
 )
 
 // relayProvider is the process-scoped factory used by
-// requireDedicatedHyco to hand out fresh per-test hyco pairs. nil
-// when E2E_RELAY_NAME is unset, in which case every helper that
-// requires Azure routes to t.Skip via requireProvider.
+// requireDedicatedHyco to hand out fresh per-test hyco pairs.
+// requireProvider handles the nil case defensively, but TestMain
+// exits non-zero before tests run if config cannot be resolved.
 //
 // Lifecycle: constructed once at TestMain entry, no explicit
 // teardown. The Provider holds only an *armrelay.HybridConnectionsClient
@@ -28,7 +32,7 @@ var relayProvider *azrelay.Provider
 
 // runRules holds the two permanent namespace-scoped SAS authorization
 // rules (Listen-only + Send-only) provisioned out-of-band by
-// `e2e-infra setup`. The keys are read once at TestMain startup and
+// `make e2e-setup`. The keys are read once at TestMain startup and
 // shared by every PairToken's Result. There is no per-run teardown —
 // the rules outlive every test invocation.
 var runRules *azrelay.RunRules
@@ -39,17 +43,24 @@ var runRules *azrelay.RunRules
 // stuck control plane hang the suite.
 const runRuleAcquireTimeout = 90 * time.Second
 
+const noConfigMessage = "==> e2e: no configuration found.\n" +
+	"    Run `make e2e-setup` to provision a per-developer Azure Relay namespace,\n" +
+	"    or `make e2e-attach RESOURCE_GROUP=<rg>` to record a pre-existing one."
+
 // TestMain constructs the process-scoped relay Provider so every
 // test can call requireDedicatedHyco to provision its own private
 // hyco pair. There is no shared pre-provisioned pair — each test
 // owns its hyco lifetime end-to-end, which lets the suite run with
 // t.Parallel().
 //
-// Required env vars:
+// Config resolution order:
 //
-//   - E2E_RELAY_NAME            Azure Relay namespace name
-//   - E2E_RESOURCE_GROUP        Resource group containing the namespace
-//   - AZURE_SUBSCRIPTION_ID     Subscription ID for ARM API calls
+//  1. AZURE_SUBSCRIPTION_ID + E2E_RESOURCE_GROUP env vars are both set:
+//     use env vars (CI / explicit override), with E2E_RELAY_NAME read
+//     from env as well.
+//  2. Else read e2e/.local.json from the package cwd (`./.local.json`).
+//  3. Else fail with a directive error that points to `make e2e-setup`
+//     or `make e2e-attach`.
 //
 // Optional env var:
 //
@@ -57,11 +68,6 @@ const runRuleAcquireTimeout = 90 * time.Second
 //     across all t.Parallel test goroutines (default 4). Raise only
 //     when CI data shows headroom under the namespace-level 429
 //     envelope.
-//
-// If E2E_RELAY_NAME is unset, the Provider is not constructed and
-// every test falls through to t.Skip via requireProvider. This
-// preserves the historic ergonomics for contributors running
-// `go test` without an Azure account.
 func TestMain(m *testing.M) {
 	os.Exit(testMain(m))
 }
@@ -80,34 +86,64 @@ func testMain(m *testing.M) int {
 		fatal("pre-build aztunnel: %v", err)
 	}
 
-	if os.Getenv("E2E_RELAY_NAME") == "" {
-		fmt.Fprintln(os.Stderr, "==> e2e: E2E_RELAY_NAME is unset — TestMain will not construct a Provider")
-		fmt.Fprintln(os.Stderr, "==> e2e: every Azure-dependent test will be SKIPPED (CLI-only tests still run). Run `eval \"$(make e2e-infra-env)\"` first, or set E2E_RELAY_NAME explicitly.")
-		// drainBenchLease is a no-op when no benchmark could lease;
-		// no Provider was constructed so leaseSharedHyco cannot have
-		// run. No need to defer it on this skip path.
-		return m.Run()
+	resolved, err := resolveTestConfig(os.LookupEnv, ".")
+	if err != nil {
+		if errors.Is(err, errNoConfig) {
+			fatal("%s", noConfigMessage)
+		}
+		fatal("%v", err)
+	}
+	if resolved.RelayName == "" {
+		fatal("e2e config is missing relayName; set E2E_RELAY_NAME for env-based config or re-run `make e2e-setup`")
 	}
 
-	sub := os.Getenv("AZURE_SUBSCRIPTION_ID")
-	rg := os.Getenv("E2E_RESOURCE_GROUP")
-	if sub == "" || rg == "" {
-		fatal("E2E_RELAY_NAME is set but AZURE_SUBSCRIPTION_ID and/or E2E_RESOURCE_GROUP are missing\n" +
-			"  set AZURE_SUBSCRIPTION_ID and E2E_RESOURCE_GROUP, or unset E2E_RELAY_NAME to skip e2e tests")
+	if resolved.Source == "local-config" {
+		currentOID := func(ctx context.Context) (string, error) {
+			cred, err := azidentity.NewDefaultAzureCredential(nil)
+			if err != nil {
+				return "", fmt.Errorf("default azure credential: %w", err)
+			}
+			tk, err := cred.GetToken(ctx, policy.TokenRequestOptions{
+				Scopes: []string{"https://management.azure.com/.default"},
+			})
+			if err != nil {
+				return "", fmt.Errorf("acquire ARM token: %w", err)
+			}
+			oid, err := parseOIDFromJWT(tk.Token)
+			if err != nil {
+				return "", fmt.Errorf("parse oid from ARM token: %w", err)
+			}
+			return oid, nil
+		}
+		identityCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		err = checkIdentityDrift(identityCtx, resolved.Local, currentOID)
+		cancel()
+		if err != nil {
+			fatal("%v", err)
+		}
+		if resolved.Local != nil && resolved.Local.SASOnly {
+			if _, isSet := os.LookupEnv("E2E_AUTH"); !isSet {
+				if err := os.Setenv("E2E_AUTH", "sas"); err != nil {
+					fatal("set E2E_AUTH=sas: %v", err)
+				}
+				fmt.Fprintln(os.Stderr, "==> e2e: SAS-only mode per e2e/.local.json. Entra subtests will skip.")
+				fmt.Fprintln(os.Stderr, "    After someone grants you the Azure Relay role, run `make e2e-attach RESOURCE_GROUP=… RELAY_NAME=…` to refresh.")
+			}
+		}
 	}
 
 	conc := readConcurrencyEnv()
 
 	cfg := azrelay.Config{
-		SubscriptionID: sub,
-		ResourceGroup:  rg,
-		Namespace:      os.Getenv("E2E_RELAY_NAME"),
+		SubscriptionID: resolved.Subscription,
+		ResourceGroup:  resolved.ResourceGroup,
+		Namespace:      resolved.RelayName,
 		Concurrency:    conc,
 	}
 
 	// Acquire the namespace SAS rule keys. The rules
 	// (e2e-listener with Listen, e2e-sender with Send) are permanent
-	// fixtures of the namespace provisioned once by `e2e-infra setup`;
+	// fixtures of the namespace provisioned once by `make e2e-setup`;
 	// AcquireRunRules only reads their ListKeys output and never
 	// creates or deletes rules. Hyco provisioning never mutates
 	// authorization rules either. Failures here are fatal — without
@@ -140,7 +176,7 @@ func testMain(m *testing.M) int {
 	}
 	relayProvider = p
 	fmt.Fprintf(os.Stderr, "==> e2e: relay Provider ready (namespace=%s/%s, concurrency=%d)\n",
-		rg, os.Getenv("E2E_RELAY_NAME"), conc)
+		resolved.ResourceGroup, resolved.RelayName, conc)
 
 	return m.Run()
 }

--- a/scripts/bench-compare.sh
+++ b/scripts/bench-compare.sh
@@ -24,7 +24,7 @@
 #   COUNT      -count= passed to `go test -bench` (default: 5).
 #   BENCH      -bench= regex passed to `go test` (default: .).
 #   BACKEND    "mock" (default) or "azure". Azure benchmarks require
-#              `make e2e-infra-setup` + `eval "$(make e2e-infra-env)"`
+#              `make e2e-setup`
 #              first; pin E2E_AUTH for benchstat name stability.
 #   BENCHTIME  -benchtime= passed to `go test` (default: 1s for mock,
 #              10x for azure — each azure iteration is a real relay
@@ -95,6 +95,15 @@ echo "==> adding worktree base@$BASE_SHORT"
 git worktree add --detach --quiet "$base_wt" "$BASE_SHA"
 echo "==> adding worktree head@$HEAD_SHORT"
 git worktree add --detach --quiet "$head_wt" "$HEAD_SHA"
+
+if [ "$BACKEND" = "azure" ]; then
+  if [ ! -f "$repo_root/e2e/.local.json" ]; then
+    echo "error: BACKEND=azure requires $repo_root/e2e/.local.json (run \`make e2e-setup\` first)" >&2
+    exit 1
+  fi
+  cp "$repo_root/e2e/.local.json" "$base_wt/e2e/.local.json"
+  cp "$repo_root/e2e/.local.json" "$head_wt/e2e/.local.json"
+fi
 
 run_bench() {
   local wt=$1


### PR DESCRIPTION
## Summary

This adds a make-first local e2e developer UX with per-developer Azure resource
group isolation and persisted local config in `e2e/.local.json`.

### What this adds

- New public make targets for local setup/attach/status/clean/grant/ci/janitor
  (`e2e-setup`, `e2e-attach`, `e2e-status`, `e2e-clean`, `e2e-grant`,
  `e2e-ci`, `e2e-janitor`), with old `e2e-infra-*` targets removed.
- Test runtime config resolution in `TestMain`: env override first, then
  `e2e/.local.json`; identity drift check for local-config path; automatic
  `E2E_AUTH=sas` when `sasOnly` is persisted and `E2E_AUTH` is unset.
- Infra CLI additions:
  - default per-dev RG derivation (`aztunnel-e2e-<alias>`)
  - `attach` and `status` subcommands
  - `setup` `AuthorizationFailed` fallback to SAS-only mode
  - owner-tag-protected clean + `--force` bypass
  - persisted local config write/read helpers.
- README rewrite to document the new 3-command local quick start and the
  make-target-only public surface.

## Local validation

Validated on a personal sandbox Azure subscription:

1. **Clean-state setup + status + full suite**
   - Start from: no `e2e/.local.json`, `AZURE_SUBSCRIPTION_ID` unset
   - `make e2e-setup` succeeds and writes expected `e2e/.local.json`
   - `make e2e-status` returns `status : OK`
   - `make e2e` passes full suite with both `entra` and `sas` subtests
2. **Attach flow against existing CI RG**
   - `rm e2e/.local.json`
   - `make e2e-attach RESOURCE_GROUP=aztunnel-e2e` succeeds
   - `make e2e-status` returns `status : OK`
   - `make e2e` passes full suite with both `entra` and `sas` subtests
3. **sasOnly fallback path**
   - setup run without role-assignment permission yielded fallback note and
     persisted `sasOnly: true`
   - `make e2e` in that state ran SAS path and passed
   - also added unit tests for `AuthorizationFailed` detection in
     `e2e/infra/azure/rbac_test.go`
4. **`make e2e-clean` guard + force bypass**
   - `make e2e-clean RESOURCE_GROUP=aztunnel-e2e CLEAN_ARGS="--yes"` refused
     deletion due ownership-tag guard
   - `make e2e-clean RESOURCE_GROUP=aztunnel-e2e CLEAN_ARGS="--force"` bypassed
     guard and reached confirmation gate (`not confirmed`) without deleting

## Acceptance criteria

- [x] `make help` shows the new target set; old `e2e-infra-*` targets are gone.
- [x] `make e2e-setup` on a fresh sub produces an RG named
      `aztunnel-e2e-<alias>` with owner tagging on created RGs.
- [x] `make e2e` reads `e2e/.local.json` and runs tests without setting shell env vars.
- [x] `e2e/.local.json` is gitignored and not staged.
- [x] `eval "$(...)"` pattern no longer appears in `e2e/README.md`.
- [x] `AZURE_SUBSCRIPTION_ID` is removed from the primary README quick start
      (kept only in CI overrides section).
- [x] README quick start is exactly 3 commands.
- [x] Build + non-e2e tests pass (`make build && go vet ./... && go test ./...`).
- [x] Lint path is clean (`make lint`).
- [x] Added comments describe current behavior only.
- [x] Single commit on branch.
- [x] Dual-model local review run (GPT-5.5 + Opus 4.7) before push; findings addressed.

