### PR TITLE
refactor(e2e): replace ad-hoc auth loop with declarative Backend.Axes()

### DIFF
--- a/e2e/azure_backend_test.go
+++ b/e2e/azure_backend_test.go
@@ -16,10 +16,17 @@ import (
 // the in-process MockBackend (mockrelay/testharness/mockbackend) is a
 // behavioural gap in the mock that we have to either fix or document.
 //
-// Each instance is bound to a single auth method ("entra" or "sas")
-// so the caller can run the same scenario suite once per available
-// auth. All listeners and senders are real aztunnel subprocesses
-// driven by the existing helpers (startListener, startPortForwardSender,
+// An azureBackend exists in one of two modes:
+//
+//   - Factory: axis is non-nil, authName is empty. Returned from
+//     newAzureBackendFactory. Axes() reports the auth dimension; the
+//     harness enumerates it via Cell() to produce pinned backends.
+//   - Pinned: axis is nil, authName is "entra" or "sas". Returned
+//     from Cell(). Setup reads authName to pick the auth method.
+//     Pinned backends have no further axes.
+//
+// All listeners and senders are real aztunnel subprocesses driven by
+// the existing helpers (startListener, startPortForwardSender,
 // startSOCKS5Sender), so they exercise the same code paths that
 // production users hit. Each subprocess exposes its own Prometheus
 // /metrics endpoint via --metrics-addr 127.0.0.1:0, which the
@@ -38,13 +45,74 @@ import (
 //     drained at TestMain exit. Used by BenchmarkE2E_Azure so
 //     benchstat runs do not pay per-sub-bench provisioning.
 type azureBackend struct {
+	axis       *authAxis
 	authName   string
 	acquireEnv func(testing.TB) *relayEnv
 }
 
-// Name returns the backend identifier used in test sub-paths, e.g.
-// "azure-entra" or "azure-sas".
-func (b *azureBackend) Name() string { return "azure-" + b.authName }
+// authAxis is the e2escenarios.Axis the Azure backend varies over.
+// Values is the set of auth methods discovered at factory-construction
+// time via availableAuthNames; the harness enumerates them in order
+// and emits one t.Run per value.
+type authAxis struct {
+	values []string
+}
+
+func (*authAxis) Name() string       { return "auth" }
+func (a *authAxis) Values() []string { return a.values }
+
+// newAzureBackendFactory returns an *azureBackend whose Axes() lists
+// the auth methods available in this process — discovered once via
+// availableAuthNames(t) — and whose Cell(values) returns a fresh
+// *azureBackend pinned to values["auth"]. Cell-pinned backends have
+// no further axes (Axes() returns nil), so the harness only loops
+// over the auth axis once.
+//
+// acquireEnv is fixed by the caller (requireDedicatedHyco for
+// scenario runs, leaseSharedHyco for benchmarks).
+func newAzureBackendFactory(t testing.TB, acquireEnv func(testing.TB) *relayEnv) *azureBackend {
+	return &azureBackend{
+		axis:       &authAxis{values: availableAuthNames(t)},
+		acquireEnv: acquireEnv,
+	}
+}
+
+// Name returns the backend identifier (always "azure"). The harness
+// does not embed it in sub-test paths — the auth dimension appears
+// via the axis t.Run wrapping — but scenarios and external callers
+// may surface it in debug output.
+func (*azureBackend) Name() string { return "azure" }
+
+// Axes returns the matrix dimensions this backend varies over.
+// Factory backends (constructed via newAzureBackendFactory) return
+// the auth axis; pinned backends (returned from Cell) return nil.
+func (b *azureBackend) Axes() []e2escenarios.Axis {
+	if b.axis == nil {
+		return nil
+	}
+	return []e2escenarios.Axis{b.axis}
+}
+
+// Cell returns a fresh *azureBackend pinned to the cell described by
+// values. Factory backends require values["auth"]; pinned backends
+// (axis == nil) accept only an empty values map and return a clone
+// of the receiver.
+func (b *azureBackend) Cell(values map[string]string) e2escenarios.Backend {
+	if b.axis == nil {
+		if len(values) != 0 {
+			panic("azureBackend.Cell: pinned backend accepts no axis values")
+		}
+		return &azureBackend{authName: b.authName, acquireEnv: b.acquireEnv}
+	}
+	auth, ok := values["auth"]
+	if !ok {
+		panic("azureBackend.Cell: missing required axis key \"auth\"")
+	}
+	if len(values) != 1 {
+		panic("azureBackend.Cell: expected exactly one axis value (auth)")
+	}
+	return &azureBackend{authName: auth, acquireEnv: b.acquireEnv}
+}
 
 // Setup brings up the requested topology (NumListeners listeners and
 // max(NumSenders,1) senders), waits until every listener has logged

--- a/e2e/e2e_bench_test.go
+++ b/e2e/e2e_bench_test.go
@@ -38,8 +38,9 @@ import (
 func BenchmarkE2E_Azure(b *testing.B) {
 	requireProvider(b)
 	name := availableAuthNames(b)[0]
-	b.Run(name, func(b *testing.B) {
-		backend := &azureBackend{authName: name, acquireEnv: leaseSharedHyco}
-		e2escenarios.RunBenchmarks(b, backend)
-	})
+	f := &azureBackend{
+		axis:       &authAxis{values: []string{name}},
+		acquireEnv: leaseSharedHyco,
+	}
+	e2escenarios.RunAllBenchmarks(b, f)
 }

--- a/e2e/e2e_scenarios_test.go
+++ b/e2e/e2e_scenarios_test.go
@@ -9,10 +9,16 @@ import (
 )
 
 // TestE2E_Azure runs the shared core e2e scenario suite against a real
-// Azure Relay namespace, once per configured auth method (Entra,
-// SAS). The same scenarios run against the in-process MockBackend in
+// Azure Relay namespace, once per available auth method (Entra, SAS).
+// The same scenarios run against the in-process MockBackend in
 // mockrelay/testharness/mockbackend — any divergence between this
 // test and that one is a behavioural gap to fix in the mock.
+//
+// The auth dimension is declared on the backend as an axis
+// (newAzureBackendFactory discovers it once via availableAuthNames at
+// TestE2E_Azure entry); e2escenarios.RunAllScenarios enumerates it,
+// wrapping each value in t.Run so the rendered sub-test paths read
+// as TestE2E_Azure/<auth>/<scenario>.
 //
 // TestE2E_Azure does NOT call t.Parallel() because AssertNoLeaks
 // (registered at the top of every scenario) samples process-wide
@@ -23,14 +29,6 @@ import (
 // concurrency cap is not the bottleneck here.
 func TestE2E_Azure(t *testing.T) {
 	requireProvider(t)
-	for _, name := range availableAuthNames(t) {
-		name := name
-		t.Run(name, func(t *testing.T) {
-			b := &azureBackend{authName: name, acquireEnv: requireDedicatedHyco}
-			e2escenarios.RunCoreScenarios(t, b)
-			e2escenarios.RunTopologyScenarios(t, b)
-			e2escenarios.RunReliabilityScenarios(t, b)
-			e2escenarios.RunObservabilityScenarios(t, b)
-		})
-	}
+	f := newAzureBackendFactory(t, requireDedicatedHyco)
+	e2escenarios.RunAllScenarios(t, f)
 }

--- a/internal/testharness/e2escenarios/backend.go
+++ b/internal/testharness/e2escenarios/backend.go
@@ -30,6 +30,19 @@ func (m SenderMode) String() string {
 	}
 }
 
+// Axis is one matrix dimension a Backend can vary over. The harness
+// enumerates Values in order, wrapping each in t.Run(value, ...) so
+// the rendered sub-test path reads as `<entry>/<value>/<scenario>`
+// (or with deeper axis nesting, `<entry>/<value1>/<value2>/<scenario>`).
+//
+// Axis Names are purely informational (used by error messages and
+// the Cell() contract — see Backend.Cell). They do not appear in
+// sub-test paths; only Values do.
+type Axis interface {
+	Name() string
+	Values() []string
+}
+
 // Backend is the abstraction e2e scenarios run against. Each
 // implementation knows how to bring up a topology that satisfies
 // SetupOptions and to tear it down cleanly via t.Cleanup.
@@ -40,10 +53,34 @@ func (m SenderMode) String() string {
 // methods used are Helper / Fatalf / Logf / Cleanup, all on the
 // shared interface.
 type Backend interface {
-	// Name identifies the backend in test output (e.g. "mock",
-	// "azure-entra", "azure-sas"). Used to make sub-test paths
-	// readable.
+	// Name identifies the backend (e.g. "mock", "azure"). The harness
+	// does not embed it in sub-test paths — axis values fill that
+	// role via t.Run wrapping — but scenarios and external callers
+	// may surface it in debug output.
 	Name() string
+
+	// Axes returns the matrix dimensions this backend varies over.
+	// Order is significant: the harness nests t.Run calls in the
+	// returned order, so Axes()[0] becomes the outermost sub-test
+	// layer. Returning nil (or an empty slice) means the backend has
+	// no axes and the harness jumps straight to scenarios.
+	Axes() []Axis
+
+	// Cell returns a Backend pinned to the cell described by values.
+	// values is keyed by Axis.Name and contains exactly one entry per
+	// axis returned by Axes(); the harness builds it as it descends
+	// the t.Run nesting. When the backend has axes, Cell must return
+	// a fresh Backend instance — never the receiver — because
+	// subsequent cells would otherwise overwrite the pinned state on
+	// the same receiver. A no-axis backend has no per-cell state to
+	// clobber, so Cell({}) on such a backend may return the receiver
+	// unchanged.
+	//
+	// Cell implementations should validate that values contains every
+	// axis key they expect; a missing or misspelled key is a harness
+	// contract bug and should panic with a precise message (Cell has
+	// no testing.TB to fail on cleanly).
+	Cell(values map[string]string) Backend
 
 	// Setup brings up a relay topology described by opts and returns a
 	// Tunnel handle the scenario can drive. All resources (goroutines,

--- a/internal/testharness/e2escenarios/cells.go
+++ b/internal/testharness/e2escenarios/cells.go
@@ -1,0 +1,121 @@
+package e2escenarios
+
+import (
+	"fmt"
+	"testing"
+)
+
+// forEachCell enumerates the Cartesian product of axes and invokes
+// body once per cell, each call nested under t.Run for every axis
+// value in turn. The cell map passed to body is keyed by Axis.Name
+// and contains exactly one entry per axis.
+//
+// When axes is empty, body is called once on t directly with an
+// empty cell — no t.Run wrapping. This keeps simple no-axis
+// backends (the mock) from gaining a redundant sub-test layer.
+//
+// forEachCell fatals if any axis has an empty Values() slice (that
+// would otherwise silently skip the whole suite) or if two axes
+// share a Name (the cell map indexes by name, so duplicates would
+// silently collapse dimensions).
+func forEachCell(t *testing.T, axes []Axis, body func(*testing.T, map[string]string)) {
+	t.Helper()
+	if len(axes) == 0 {
+		body(t, map[string]string{})
+		return
+	}
+	if err := validateAxisNames(axes); err != nil {
+		t.Fatalf("forEachCell: %v", err)
+	}
+	enumerate(t, axes, map[string]string{}, body)
+}
+
+func enumerate(t *testing.T, axes []Axis, acc map[string]string, body func(*testing.T, map[string]string)) {
+	t.Helper()
+	if len(axes) == 0 {
+		// Defensive copy: the caller is about to start scenario
+		// sub-tests and may stash the cell; reusing the working map
+		// across sibling cells would mutate prior cells' stored
+		// state.
+		cell := make(map[string]string, len(acc))
+		for k, v := range acc {
+			cell[k] = v
+		}
+		body(t, cell)
+		return
+	}
+	axis := axes[0]
+	values := axis.Values()
+	if len(values) == 0 {
+		t.Fatalf("axis %q has no values", axis.Name())
+	}
+	for _, v := range values {
+		v := v
+		t.Run(v, func(t *testing.T) {
+			acc[axis.Name()] = v
+			enumerate(t, axes[1:], acc, body)
+			delete(acc, axis.Name())
+		})
+	}
+}
+
+// forEachBenchCell mirrors forEachCell for *testing.B. It exists as
+// its own function because *testing.B's Run signature is incompatible
+// with *testing.T's at compile time; the body structure is otherwise
+// identical.
+func forEachBenchCell(b *testing.B, axes []Axis, body func(*testing.B, map[string]string)) {
+	b.Helper()
+	if len(axes) == 0 {
+		body(b, map[string]string{})
+		return
+	}
+	if err := validateAxisNames(axes); err != nil {
+		b.Fatalf("forEachBenchCell: %v", err)
+	}
+	enumerateBench(b, axes, map[string]string{}, body)
+}
+
+func enumerateBench(b *testing.B, axes []Axis, acc map[string]string, body func(*testing.B, map[string]string)) {
+	b.Helper()
+	if len(axes) == 0 {
+		cell := make(map[string]string, len(acc))
+		for k, v := range acc {
+			cell[k] = v
+		}
+		body(b, cell)
+		return
+	}
+	axis := axes[0]
+	values := axis.Values()
+	if len(values) == 0 {
+		b.Fatalf("axis %q has no values", axis.Name())
+	}
+	for _, v := range values {
+		v := v
+		b.Run(v, func(b *testing.B) {
+			acc[axis.Name()] = v
+			enumerateBench(b, axes[1:], acc, body)
+			delete(acc, axis.Name())
+		})
+	}
+}
+
+// validateAxisNames returns an error if any Axis.Name is empty or if
+// two axes share a name. The cell maps used by forEachCell /
+// forEachBenchCell are keyed by Axis.Name, so duplicates would
+// silently overwrite each other and collapse dimensions; empty names
+// produce unreadable cell maps and ambiguous Cell() contracts.
+func validateAxisNames(axes []Axis) error {
+	seen := make(map[string]struct{}, len(axes))
+	for _, a := range axes {
+		name := a.Name()
+		if name == "" {
+			return fmt.Errorf("axis with empty Name()")
+		}
+		if _, dup := seen[name]; dup {
+			return fmt.Errorf("duplicate axis Name() %q", name)
+		}
+		seen[name] = struct{}{}
+	}
+	return nil
+}

--- a/internal/testharness/e2escenarios/scenarios.go
+++ b/internal/testharness/e2escenarios/scenarios.go
@@ -13,6 +13,38 @@ import (
 	"time"
 )
 
+// RunAllScenarios runs every scenario suite (Core, Topology,
+// Reliability, Observability) against b. It enumerates b.Axes()
+// exactly once and runs all four suites inside each cell, so the
+// auth dimension (or any future axis) appears once in the rendered
+// sub-test path even though four suites run inside it.
+//
+// Call this from test entry points (TestE2E_Azure, TestE2E_Mock)
+// rather than calling the individual Run*Scenarios in sequence —
+// independent forEachCell calls would render the axis layer four
+// times and Go would disambiguate the second-fourth instances with
+// #01/#02/#03 suffixes.
+func RunAllScenarios(t *testing.T, b Backend) {
+	t.Helper()
+	forEachCell(t, b.Axes(), func(t *testing.T, cell map[string]string) {
+		cellBackend := b.Cell(cell)
+		RunCoreScenarios(t, cellBackend)
+		RunTopologyScenarios(t, cellBackend)
+		RunReliabilityScenarios(t, cellBackend)
+		RunObservabilityScenarios(t, cellBackend)
+	})
+}
+
+// RunAllBenchmarks is the *testing.B mirror of RunAllScenarios:
+// enumerates backend.Axes() once and calls RunBenchmarks inside
+// each cell.
+func RunAllBenchmarks(b *testing.B, backend Backend) {
+	b.Helper()
+	forEachBenchCell(b, backend.Axes(), func(b *testing.B, cell map[string]string) {
+		RunBenchmarks(b, backend.Cell(cell))
+	})
+}
+
 // RunCoreScenarios runs every single-flow e2e scenario against b as a
 // set of sub-tests under the caller's t. New scenarios get added here.
 //

--- a/mockrelay/testharness/mockbackend/bench_test.go
+++ b/mockrelay/testharness/mockbackend/bench_test.go
@@ -20,5 +20,5 @@ import (
 //	    ./testharness/mockbackend/...
 func BenchmarkE2E_Mock(b *testing.B) {
 	var backend mockbackend.MockBackend
-	e2escenarios.RunBenchmarks(b, &backend)
+	e2escenarios.RunAllBenchmarks(b, &backend)
 }

--- a/mockrelay/testharness/mockbackend/mock_backend.go
+++ b/mockrelay/testharness/mockbackend/mock_backend.go
@@ -41,8 +41,27 @@ import (
 // `go test ./mockrelay/...` job.
 type MockBackend struct{}
 
-// Name returns the backend identifier used in test sub-paths.
+// Name returns the backend identifier (always "mock"). The harness
+// does not embed it in sub-test paths — MockBackend has no axes,
+// so scenarios run directly under the test entry point — but
+// scenarios and external callers may surface it in debug output.
 func (*MockBackend) Name() string { return "mock" }
+
+// Axes returns the matrix dimensions this backend varies over. The
+// mock has none — it only speaks SAS against an in-process server,
+// so the harness runs scenarios directly under the test entry point
+// with no axis sub-path layer.
+func (*MockBackend) Axes() []e2escenarios.Axis { return nil }
+
+// Cell returns the backend pinned to the cell described by values.
+// MockBackend has no axes so values must be empty; Cell returns the
+// receiver unchanged.
+func (m *MockBackend) Cell(values map[string]string) e2escenarios.Backend {
+	if len(values) != 0 {
+		panic("MockBackend.Cell: no axes, expected empty values")
+	}
+	return m
+}
 
 // Setup brings up the in-process topology described by opts and blocks
 // until every listener's control channel is attached and every sender

--- a/mockrelay/testharness/mockbackend/scenarios_test.go
+++ b/mockrelay/testharness/mockbackend/scenarios_test.go
@@ -13,10 +13,5 @@ import (
 // the CI `test` job enforces.
 func TestE2E_Mock(t *testing.T) {
 	var b mockbackend.MockBackend
-	t.Run(b.Name(), func(t *testing.T) {
-		e2escenarios.RunCoreScenarios(t, &b)
-		e2escenarios.RunTopologyScenarios(t, &b)
-		e2escenarios.RunReliabilityScenarios(t, &b)
-		e2escenarios.RunObservabilityScenarios(t, &b)
-	})
+	e2escenarios.RunAllScenarios(t, &b)
 }


### PR DESCRIPTION
PR2 of the test-restructuring workstream.

Generalize the e2e harness from "Backend + ad-hoc subtest loops" to
a declarative N-axis matrix the harness enumerates itself.

Backend gains:
- `Axes() []Axis` — declarative matrix dimensions
- `Cell(map[string]string) Backend` — per-cell factory

The harness gains:
- `RunAllScenarios(t, b)` — enumerates b.Axes() once and runs Core +
  Topology + Reliability + Observability suites inside each cell.
- `RunAllBenchmarks(b, backend)` — same for benchmarks.

The four scenario-suite dispatchers (RunCoreScenarios etc.) and
RunBenchmarks are unchanged; they continue to take a pre-pinned
Backend. Only the new aggregates wrap forEachCell around them, so
the axis layer appears exactly once in the rendered sub-test path
even though four suites run inside it.

The existing auth dimension is ported through this abstraction.
Pure refactor: scenario count and bodies are unchanged. Rendered
sub-test paths under TestE2E_Azure and BenchmarkE2E_Azure are
byte-identical. TestE2E_Mock loses one redundant subtest layer
(`mock/` — the function name already encodes it).

Future backend dimensions and configuration (mock rendezvous delay
in PR3, mux axis in PR5 post-#47) plug in without further harness
changes — PR3 as a backend config knob, PR5 as one more Axis
implementation per backend.
