### PR TITLE
feat(mockrelay): default per-accept rendezvous delay matches Azure-class latency

### DIFF
--- a/mockrelay/testharness/mockbackend/mock_backend.go
+++ b/mockrelay/testharness/mockbackend/mock_backend.go
@@ -34,12 +34,51 @@ import (
 	dto "github.com/prometheus/client_model/go"
 )
 
+// DefaultRendezvousDelay is the per-accept delay the mock adds when
+// MockBackend.RendezvousDelay is zero. ~1 s approximates the
+// production Azure Relay control-plane rendezvous round-trip and
+// keeps Layer-1 timing thresholds aligned between the mock and
+// Azure backends.
+const DefaultRendezvousDelay = 1 * time.Second
+
+// NoRendezvousDelay is the sentinel callers assign to
+// MockBackend.RendezvousDelay to disable the per-accept delay
+// (in-process ~6 ms baseline). Any negative duration would work
+// because server.WithAcceptDelay clamps negatives to zero; this
+// constant gives the intent a name and keeps call sites readable:
+//
+//	b := mockbackend.MockBackend{RendezvousDelay: mockbackend.NoRendezvousDelay}
+const NoRendezvousDelay time.Duration = -1
+
 // MockBackend implements e2escenarios.Backend by standing up a mock
 // relay server + aztunnel listener(s) + aztunnel sender(s) all in the
 // same process. It is the fast, deterministic side of the mock-vs-
 // Azure conformance matrix and runs in the default
 // `go test ./mockrelay/...` job.
-type MockBackend struct{}
+type MockBackend struct {
+	// RendezvousDelay selects the per-accept delay the mock adds
+	// to approximate Azure Relay's ~950 ms control-plane rendezvous
+	// latency. The value is applied via server.WithAcceptDelay,
+	// which sleeps before completing the WebSocket upgrade on every
+	// accept (listener-rendezvous) dial for the lifetime of the
+	// test's Server.
+	//
+	//	0 (the zero value) → DefaultRendezvousDelay (~1 s). This is
+	//	                     the production-shaped default and what
+	//	                     MockBackend{} produces with no other
+	//	                     configuration.
+	//	negative           → no delay (the in-process ~6 ms baseline).
+	//	                     Use the exported NoRendezvousDelay
+	//	                     sentinel at call sites for readability.
+	//	positive           → that value, used directly.
+	//
+	// The default is on so e2e timing thresholds calibrated against
+	// Azure also fire against the mock. The negative-as-disabled
+	// convention mirrors server.WithAcceptDelay, which already
+	// clamps negative durations to zero — there is no ambiguity at
+	// the wire level.
+	RendezvousDelay time.Duration
+}
 
 // Name returns the backend identifier (always "mock"). The harness
 // does not embed it in sub-test paths — MockBackend has no axes,
@@ -67,7 +106,7 @@ func (m *MockBackend) Cell(values map[string]string) e2escenarios.Backend {
 // until every listener's control channel is attached and every sender
 // bind is accepting TCP. All goroutines, the mock HTTP server, and
 // the sender binds are released via t.Cleanup.
-func (*MockBackend) Setup(t testing.TB, opts e2escenarios.SetupOptions) *e2escenarios.Tunnel {
+func (b *MockBackend) Setup(t testing.TB, opts e2escenarios.SetupOptions) *e2escenarios.Tunnel {
 	t.Helper()
 	if opts.NumListeners < 1 {
 		t.Fatalf("NumListeners must be >= 1, got %d", opts.NumListeners)
@@ -82,7 +121,11 @@ func (*MockBackend) Setup(t testing.TB, opts e2escenarios.SetupOptions) *e2escen
 		numSenders = 1
 	}
 
-	host, clientOpts := startMockRelay(t)
+	delay := b.RendezvousDelay
+	if delay == 0 {
+		delay = DefaultRendezvousDelay
+	}
+	host, clientOpts := startMockRelay(t, delay)
 	// Cleanup ordering: startMockRelay's own t.Cleanup registers
 	// srv.Close. Register cancel+wg.Wait AFTER it so LIFO teardown
 	// runs cancel first → drains the listener / sender goroutines
@@ -274,17 +317,32 @@ func (*MockBackend) Setup(t testing.TB, opts e2escenarios.SetupOptions) *e2escen
 // plus a ClientOptions whose TLSConfig skips verification of the test
 // certificate.
 //
-// RendezvousTimeout is deliberately short so MaxConn back-pressure
-// scenarios — which intentionally provoke listeners to drop accept
-// messages and rely on the rendezvous timing out — fail-fast on each
-// retry instead of waiting the default. 1s is plenty for in-process
-// rendezvous round-trips.
-func startMockRelay(t testing.TB) (host string, opts relay.ClientOptions) {
+// rendezvousDelay is applied via server.WithAcceptDelay; it sleeps
+// before completing the WebSocket upgrade on every accept-side dial
+// for the lifetime of the Server. Pass DefaultRendezvousDelay (or
+// the value resolved from MockBackend.RendezvousDelay) for normal
+// e2e runs; pass NoRendezvousDelay for benchmark paths that need
+// synchronous rendezvous. Negative values are clamped to zero by
+// server.WithAcceptDelay.
+//
+// RendezvousTimeout is sized to the configured delay plus a 1 s
+// in-process round-trip margin. The margin alone is enough for the
+// opt-out path (the WebSocket upgrade completes in single-digit
+// milliseconds); adding the delay keeps the timeout above the
+// minimum walltime a successful accept can take. MaxConn back-
+// pressure scenarios still fail-fast on dropped accepts: each retry
+// pays one timeout, which scales linearly with the delay but stays
+// well under the scenarios' overall convergence windows.
+func startMockRelay(t testing.TB, rendezvousDelay time.Duration) (host string, opts relay.ClientOptions) {
 	t.Helper()
-	rs, err := server.NewServer(server.Config{
+	timeoutDelay := rendezvousDelay
+	if timeoutDelay < 0 {
+		timeoutDelay = 0
+	}
+	rs, err := server.NewServerForTesting(server.Config{
 		Logger:            slog.New(slog.NewTextHandler(io.Discard, nil)),
-		RendezvousTimeout: 1 * time.Second,
-	})
+		RendezvousTimeout: timeoutDelay + 1*time.Second,
+	}, server.WithAcceptDelay(rendezvousDelay))
 	if err != nil {
 		t.Fatalf("new mock relay: %v", err)
 	}

--- a/mockrelay/testharness/mockbackend/rendezvous_delay_test.go
+++ b/mockrelay/testharness/mockbackend/rendezvous_delay_test.go
@@ -1,0 +1,96 @@
+package mockbackend_test
+
+import (
+	"bytes"
+	"io"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/philsphicas/aztunnel/internal/testharness/e2escenarios"
+	"github.com/philsphicas/aztunnel/mockrelay/testharness/mockbackend"
+)
+
+// TestMockBackend_DefaultRendezvousDelay verifies that a zero-value
+// MockBackend applies DefaultRendezvousDelay (~1 s) to each accept,
+// observable as a lower bound on the elapsed time for a single
+// sender→listener→target round-trip.
+//
+// The assertion is a lower-bound only: scheduling noise on a loaded
+// CI runner can only make the measured elapsed time longer, never
+// shorter, so a >= comparison against (DefaultRendezvousDelay - slack)
+// is robust.
+func TestMockBackend_DefaultRendezvousDelay(t *testing.T) {
+	var b mockbackend.MockBackend
+	elapsed := timeOneRoundTrip(t, &b)
+	// 50 ms of slack absorbs timer-resolution differences between
+	// the t.Now() observation and the server's first sleep
+	// observation. Tune up if you see flakes; never down.
+	wantAtLeast := mockbackend.DefaultRendezvousDelay - 50*time.Millisecond
+	if elapsed < wantAtLeast {
+		t.Fatalf("round-trip took %v with default delay; want >= %v (DefaultRendezvousDelay - 50ms slack)", elapsed, wantAtLeast)
+	}
+}
+
+// TestMockBackend_NoRendezvousDelay verifies that the
+// NoRendezvousDelay sentinel drops the per-accept delay back to
+// the in-process baseline (~6 ms), bounded by an upper threshold
+// well below DefaultRendezvousDelay so any accidental fall-through
+// to the default trips the test.
+func TestMockBackend_NoRendezvousDelay(t *testing.T) {
+	b := mockbackend.MockBackend{RendezvousDelay: mockbackend.NoRendezvousDelay}
+	elapsed := timeOneRoundTrip(t, &b)
+	// 500 ms is exactly half of DefaultRendezvousDelay and well
+	// above the in-process baseline (~6 ms + tens of ms of TCP/
+	// accept/echo overhead) plus any reasonable CI scheduling noise.
+	// Any value under 500 ms confirms the opt-out is live.
+	upperBound := mockbackend.DefaultRendezvousDelay / 2
+	if elapsed > upperBound {
+		t.Fatalf("round-trip took %v with NoRendezvousDelay; want < %v (DefaultRendezvousDelay/2). Wiring of the negative-sentinel opt-out is likely broken.", elapsed, upperBound)
+	}
+}
+
+// timeOneRoundTrip brings up a 1-listener, 1-sender port-forward
+// topology against an in-process echo target, performs one TCP
+// dial + one echo round-trip, and returns the wall time from the
+// pre-dial timestamp to the post-read timestamp. All resources are
+// torn down via t.Cleanup registered by Setup and StartPlainEcho.
+//
+// The helper drives Setup + one Dial directly rather than reusing a
+// Core scenario so the elapsed time isolates a single accept-side
+// rendezvous round-trip. Core scenarios open multiple connections
+// and apply leak / sampler instrumentation, both of which would
+// dilute the timing signal the assertions in this file rely on.
+func timeOneRoundTrip(t *testing.T, b e2escenarios.Backend) time.Duration {
+	t.Helper()
+	echo := e2escenarios.StartPlainEcho(t)
+	tun := b.Setup(t, e2escenarios.SetupOptions{
+		NumListeners:   1,
+		NumSenders:     1,
+		SenderMode:     e2escenarios.ModePortForward,
+		Target:         echo.Addr(),
+		AllowedTargets: []string{echo.Addr()},
+	})
+
+	start := time.Now()
+	conn, err := net.DialTimeout("tcp", tun.SenderAddr, 5*time.Second)
+	if err != nil {
+		t.Fatalf("dial sender bind: %v", err)
+	}
+	defer conn.Close() //nolint:errcheck // best-effort cleanup
+
+	payload := []byte("ping")
+	_ = conn.SetDeadline(time.Now().Add(5 * time.Second))
+	if _, err := conn.Write(payload); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	got := make([]byte, len(payload))
+	if _, err := io.ReadFull(conn, got); err != nil {
+		t.Fatalf("read echo: %v", err)
+	}
+	elapsed := time.Since(start)
+	if !bytes.Equal(got, payload) {
+		t.Fatalf("echo mismatch: got %q want %q", got, payload)
+	}
+	return elapsed
+}

--- a/mockrelay/testharness/mockbackend/token_fetch_metric_test.go
+++ b/mockrelay/testharness/mockbackend/token_fetch_metric_test.go
@@ -55,7 +55,7 @@ func (e *erroringTokenProvider) GetToken(context.Context, string) (string, error
 // (e2e/token_fetch_metric_test.go) covers the result=ok path against
 // real Entra/SAS providers.
 func TestTokenFetchMetric_MockRelay(t *testing.T) {
-	host, clientOpts := startMockRelay(t)
+	host, clientOpts := startMockRelay(t, DefaultRendezvousDelay)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	var wg sync.WaitGroup


### PR DESCRIPTION
PR3 of the test-restructuring workstream.

MockBackend now applies a ~1 s per-accept rendezvous delay by default,
approximating the Azure Relay control-plane rendezvous round-trip
(~950 ms). Layer-1 e2e timing thresholds calibrated against Azure now
also fire against the mock instead of passing trivially.

Changes:

- New `MockBackend.RendezvousDelay time.Duration` field selects the
  delay applied to the Server brought up by Setup. The zero value
  (unset) resolves to the new `DefaultRendezvousDelay` package
  constant (`1 * time.Second`). A positive value is used directly;
  a negative value (canonically the new `NoRendezvousDelay = -1`
  sentinel) is clamped to zero by `server.WithAcceptDelay`,
  letting callers opt out of the delay without colliding with the
  "field unset" zero case.
- `startMockRelay` switches from `server.NewServer` to
  `server.NewServerForTesting` and applies the resolved delay via
  `server.WithAcceptDelay`. The two constructors return the same
  `*server.Server`; only `NewServerForTesting` admits Options.
  `RendezvousTimeout` is sized to `max(delay, 0) + 1 * time.Second`
  so the in-process rendezvous round-trip always has enough headroom
  while the MaxConn back-pressure path still fail-fasts on dropped
  accepts.
- `TestTokenFetchMetric_MockRelay` picks up the new default and
  takes roughly one second longer per connection. Its assertion
  (token-fetch counters increment) is timing-independent.
- New `rendezvous_delay_test.go` is a focused wiring test covering
  the default-on path (lower-bound timing assertion) and the
  `NoRendezvousDelay` opt-out (upper-bound timing assertion).

Fault tests (`control_events_test.go`, `ws_close_code_test.go`)
construct their Server independently via `startFaultyMockRelay` /
`startMockRelayWithCloseCode` and continue to run with zero
rendezvous delay automatically — no edits needed there.

PR4 will calibrate `Backend.ConnectLatencyThreshold` against this
new mock baseline so the Performance scenarios it introduces fire
the same threshold against both backends.