### PR TITLE
feat(e2e): performance scenarios with per-backend connect-latency thresholds

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -22,7 +22,7 @@ jobs:
   e2e:
     runs-on: ubuntu-latest
     environment: e2e-azure
-    timeout-minutes: 17
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v6
 

--- a/e2e/azure_backend_test.go
+++ b/e2e/azure_backend_test.go
@@ -114,6 +114,20 @@ func (b *azureBackend) Cell(values map[string]string) e2escenarios.Backend {
 	return &azureBackend{authName: auth, acquireEnv: b.acquireEnv}
 }
 
+// ConnectLatencyThreshold returns the per-backend connect-latency
+// ceiling for the Performance suite. Azure pays the real Azure
+// Relay control-plane rendezvous round-trip (~950 ms typical),
+// listener-side target dial, plus the bridged echo round-trip;
+// 3 s is generous to absorb cloud variance without masking the
+// Azure-class regressions (which we expect to be on the order of
+// seconds, not hundreds of ms).
+//
+// Returns 3 s regardless of authName: both Entra and SAS hit the
+// same control-plane rendezvous path.
+func (*azureBackend) ConnectLatencyThreshold() time.Duration {
+	return 3 * time.Second
+}
+
 // Setup brings up the requested topology (NumListeners listeners and
 // max(NumSenders,1) senders), waits until every listener has logged
 // "control_started" and every sender has logged its bind

--- a/internal/testharness/e2escenarios/backend.go
+++ b/internal/testharness/e2escenarios/backend.go
@@ -82,6 +82,26 @@ type Backend interface {
 	// no testing.TB to fail on cleanly).
 	Cell(values map[string]string) Backend
 
+	// ConnectLatencyThreshold is the per-backend ceiling for a single
+	// fresh-connection round-trip (Dial → 1-byte write → 1-byte echo
+	// read → Close). The Performance suite's serial-connect scenarios
+	// assert each iteration completes inside this budget.
+	//
+	// The threshold is read on the cell-pinned backend (after Cell()),
+	// so implementations may vary it per axis value (e.g. tighter for
+	// SAS than for Entra) when data justifies the differentiation.
+	// Both backends currently return a single value regardless of cell.
+	//
+	// "Connect latency" is interpreted broadly: the budget covers
+	// every wall-clock cost the harness pays from `net.Dial` (or the
+	// SOCKS5 CONNECT handshake) through a successful `conn.Close()` of
+	// the verified 1-byte round-trip. That includes the SOCKS5
+	// handshake on the SOCKS5 variant, the listener-side rendezvous,
+	// the target dial, the echo round-trip, and the socket close. A
+	// backend that wanted to split those costs into separate budgets
+	// would need a richer interface.
+	ConnectLatencyThreshold() time.Duration
+
 	// Setup brings up a relay topology described by opts and returns a
 	// Tunnel handle the scenario can drive. All resources (goroutines,
 	// subprocesses, listeners, sockets) are registered for cleanup on

--- a/internal/testharness/e2escenarios/performance.go
+++ b/internal/testharness/e2escenarios/performance.go
@@ -1,0 +1,252 @@
+package e2escenarios
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"net"
+	"testing"
+	"time"
+)
+
+// RunPerformanceScenarios runs the timing-assertion scenarios
+// against b as sub-tests under the caller's t. These complement
+// the testing.B benchmarks in bench.go: same shape of work, but
+// expressed as testing.T so CI fails when wall time exceeds the
+// per-backend threshold.
+//
+// Two scenarios assert against ConnectLatencyThreshold; the third
+// (ShortSession_Serial) is observation-only — it logs per-
+// iteration timings but does not assert a threshold.
+//
+// Scenarios run sequentially. Each builds its own topology via
+// b.Setup so the timing measurement is dominated by the per-
+// connection cost, not by amortised setup.
+func RunPerformanceScenarios(t *testing.T, b Backend) {
+	t.Helper()
+	scenarios := []struct {
+		name string
+		run  func(*testing.T, Backend)
+	}{
+		{"ConnectLatency_Serial_PortForward", ScenarioConnectLatency_Serial_PortForward},
+		{"ConnectLatency_Serial_SOCKS5", ScenarioConnectLatency_Serial_SOCKS5},
+		{"ShortSession_Serial", ScenarioShortSession_Serial},
+	}
+	for _, sc := range scenarios {
+		t.Run(sc.name, func(t *testing.T) {
+			sc.run(t, b)
+		})
+	}
+}
+
+// ScenarioConnectLatency_Serial_PortForward opens 10 serial
+// port-forward connections, each performing one 1-byte echo
+// round-trip, and asserts every iteration completes inside
+// b.ConnectLatencyThreshold(). The scenario logs per-iteration
+// elapsed time so a failure makes the offending iteration
+// obvious.
+//
+// Iteration count is fixed at 10. Walltime bounds at the current
+// 3 s thresholds:
+//   - Happy path: 10 × ~1 s rendezvous ≈ 10 s per scenario.
+//   - Threshold-only violation (operational success, elapsed too
+//     high): bounded by 10 × (threshold + connectSlack) ≈ 80 s
+//     per scenario, since runSerialConnectLatency uses
+//     t.Errorf + continue on threshold violations and a
+//     successful iteration can use up to threshold+connectSlack
+//     of budget before the deadline fires.
+//   - Operational error (dial/echo/close failure): fails fast at
+//     ≈ threshold + connectSlack ≈ 8 s via t.Fatalf.
+//
+// All three bounds keep the scenario well inside both the
+// per-test default timeout and the e2e job's 20 m envelope.
+func ScenarioConnectLatency_Serial_PortForward(t *testing.T, b Backend) {
+	t.Helper()
+	AssertNoLeaks(t)
+	runSerialConnectLatency(t, b, ModePortForward)
+}
+
+// ScenarioConnectLatency_Serial_SOCKS5 mirrors the port-forward
+// scenario but drives traffic through a SOCKS5 proxy sender. The
+// SOCKS5 handshake adds two short round-trips per connection on
+// top of the relay rendezvous; the same threshold applies to both
+// variants because the SOCKS5 cost is in the tens of milliseconds
+// — well inside the per-backend headroom.
+func ScenarioConnectLatency_Serial_SOCKS5(t *testing.T, b Backend) {
+	t.Helper()
+	AssertNoLeaks(t)
+	runSerialConnectLatency(t, b, ModeSOCKS5)
+}
+
+// ScenarioShortSession_Serial opens 10 serial port-forward
+// connections, each carrying a 1 KB round-trip (write 1 KB → read
+// 1 KB back), and logs the per-iteration wall time. The scenario
+// publishes a CI-visible baseline; it does not assert a threshold.
+//
+// The 1 KB payload is small enough to fit in a single TCP frame
+// on every reasonable MTU and large enough to exercise the
+// bridge's read-path beyond the 1-byte echo of the connect-latency
+// scenarios.
+func ScenarioShortSession_Serial(t *testing.T, b Backend) {
+	t.Helper()
+	AssertNoLeaks(t)
+	echo := StartPlainEcho(t)
+	tun := b.Setup(t, SetupOptions{
+		NumListeners:   1,
+		SenderMode:     ModePortForward,
+		Target:         echo.Addr(),
+		AllowedTargets: []string{echo.Addr()},
+	})
+
+	const iterations = 10
+	const payloadSize = 1024
+	payload := make([]byte, payloadSize)
+	for i := range payload {
+		// Deterministic filler so a corruption shows up as a clean
+		// diff in t.Errorf output rather than as crypto/rand noise.
+		payload[i] = byte(i)
+	}
+	buf := make([]byte, payloadSize)
+
+	for i := 0; i < iterations; i++ {
+		start := time.Now()
+		conn, err := net.DialTimeout("tcp", tun.SenderAddr, 30*time.Second)
+		if err != nil {
+			t.Fatalf("iter %d: dial: %v", i, err)
+		}
+		_ = conn.SetDeadline(time.Now().Add(30 * time.Second))
+		if err := writeFull(conn, payload); err != nil {
+			_ = conn.Close()
+			t.Fatalf("iter %d: write: %v", i, err)
+		}
+		if _, err := io.ReadFull(conn, buf); err != nil {
+			_ = conn.Close()
+			t.Fatalf("iter %d: read: %v", i, err)
+		}
+		if !bytes.Equal(buf, payload) {
+			_ = conn.Close()
+			t.Fatalf("iter %d: echo mismatch", i)
+		}
+		if err := conn.Close(); err != nil {
+			t.Fatalf("iter %d: close: %v", i, err)
+		}
+		t.Logf("ShortSession_Serial iter %d: %v", i, time.Since(start))
+	}
+}
+
+// runSerialConnectLatency is the shared implementation of the two
+// ConnectLatency_Serial variants. Each iteration: dial (port-
+// forward TCP or SOCKS5 CONNECT) → write 1 byte → read 1 byte
+// echoed back → close. Asserts elapsed < threshold per iteration.
+//
+// Failure-mode handling is deliberately split:
+//
+//   - Operational errors (dial/write/read/echo-mismatch/close) →
+//     t.Fatalf. These mean the harness is fundamentally broken
+//     (no rendezvous, target unreachable, socket draining
+//     timeout, etc.). Continuing past them wastes CI walltime
+//     because every subsequent iteration is likely to hit the
+//     same (threshold + connectSlack) ~ 8 s timeout — at 10
+//     iterations × 2 scenarios × 2 Azure auth cells that's a
+//     320 s failure-path burn against the 20 m e2e workflow
+//     envelope. Fail fast.
+//   - Threshold violations (operational success, elapsed >=
+//     threshold) → t.Errorf + continue. These produce a
+//     measured elapsed time on every iteration, so continuing is
+//     cheap (each iteration completed normally inside the budget
+//     window) and lets a flaky CI run surface every offending
+//     iteration in one report. CI still fails the suite either
+//     way.
+//
+// dialWithRetry / dialSOCKS5WithRetry are intentionally not used —
+// the retry helpers exist to swallow first-dial transient races on
+// brand-new tunnels, but the Performance scenarios open exactly
+// one topology and then dial it 10 times in sequence. By
+// iteration 2 the relay is fully warm; failing on a real dial
+// error here is what we want to measure.
+func runSerialConnectLatency(t *testing.T, b Backend, mode SenderMode) {
+	t.Helper()
+	threshold := b.ConnectLatencyThreshold()
+	echo := StartPlainEcho(t)
+	opts := SetupOptions{
+		NumListeners:   1,
+		SenderMode:     mode,
+		AllowedTargets: []string{echo.Addr()},
+	}
+	if mode == ModePortForward {
+		opts.Target = echo.Addr()
+	}
+	tun := b.Setup(t, opts)
+
+	const iterations = 10
+	payload := []byte{0x42}
+	buf := make([]byte, 1)
+
+	for i := 0; i < iterations; i++ {
+		elapsed, err := timeOneConnect(tun.SenderAddr, echo.Addr(), mode, payload, buf, threshold)
+		if err != nil {
+			t.Fatalf("iter %d: %v (elapsed=%v)", i, err, elapsed)
+		}
+		if elapsed >= threshold {
+			t.Errorf("iter %d: connect latency %v >= threshold %v", i, elapsed, threshold)
+			continue
+		}
+		t.Logf("ConnectLatency_Serial_%v iter %d: %v (< %v)", mode, i, elapsed, threshold)
+	}
+}
+
+// timeOneConnect opens one connection in the given mode, writes
+// payload, reads it back into buf, verifies the echo matches the
+// payload byte-for-byte, closes the connection, and returns the
+// wall time from pre-dial to post-close.
+//
+// The contract for the measured budget is Dial → write → read →
+// verify → Close, so the elapsed time is sampled AFTER a successful
+// Close. A failing Close (e.g. timeout draining the socket) counts
+// against the budget by design.
+//
+// The dial timeout and connection deadline both use
+// threshold + connectSlack rather than threshold so a timing
+// regression surfaces as the explicit elapsed >= threshold
+// assertion in the caller rather than as an i/o timeout from
+// the deadline firing exactly at threshold. The slack only widens
+// the timeout headroom; it does not change the threshold being
+// asserted.
+//
+// The deadline is anchored to start (the pre-dial timestamp),
+// not to time.Now() after the dial returns. Anchoring to start
+// bounds the entire dial+write+read+close iteration to a single
+// threshold + connectSlack window; if dial itself burns most of
+// that window the remaining read/write inherit whatever is left.
+// Anchoring to post-dial time.Now() would let the whole
+// iteration take up to 2 × (threshold + connectSlack) in the
+// worst case (dial uses one window, deadline allows another),
+// violating the bound documented on the calling scenario.
+//
+// Returns the elapsed time even on error so the caller can log
+// timing context alongside the failure reason.
+func timeOneConnect(senderAddr, target string, mode SenderMode, payload, buf []byte, threshold time.Duration) (time.Duration, error) {
+	const connectSlack = 5 * time.Second
+	start := time.Now()
+	conn, err := benchDial(senderAddr, target, mode, threshold+connectSlack)
+	if err != nil {
+		return time.Since(start), err
+	}
+	_ = conn.SetDeadline(start.Add(threshold + connectSlack))
+	if err := writeFull(conn, payload); err != nil {
+		_ = conn.Close()
+		return time.Since(start), err
+	}
+	if _, err := io.ReadFull(conn, buf); err != nil {
+		_ = conn.Close()
+		return time.Since(start), err
+	}
+	if !bytes.Equal(buf, payload) {
+		_ = conn.Close()
+		return time.Since(start), fmt.Errorf("echo mismatch: got %x want %x", buf, payload)
+	}
+	if err := conn.Close(); err != nil {
+		return time.Since(start), err
+	}
+	return time.Since(start), nil
+}

--- a/internal/testharness/e2escenarios/scenarios.go
+++ b/internal/testharness/e2escenarios/scenarios.go
@@ -14,16 +14,16 @@ import (
 )
 
 // RunAllScenarios runs every scenario suite (Core, Topology,
-// Reliability, Observability) against b. It enumerates b.Axes()
-// exactly once and runs all four suites inside each cell, so the
+// Reliability, Observability, Performance) against b. It enumerates
+// b.Axes() exactly once and runs all suites inside each cell, so the
 // auth dimension (or any future axis) appears once in the rendered
-// sub-test path even though four suites run inside it.
+// sub-test path even though every suite runs inside it.
 //
 // Call this from test entry points (TestE2E_Azure, TestE2E_Mock)
 // rather than calling the individual Run*Scenarios in sequence —
-// independent forEachCell calls would render the axis layer four
-// times and Go would disambiguate the second-fourth instances with
-// #01/#02/#03 suffixes.
+// independent forEachCell calls would render the axis layer once per
+// suite and Go would disambiguate the second-and-later instances with
+// #01/#02/... suffixes.
 func RunAllScenarios(t *testing.T, b Backend) {
 	t.Helper()
 	forEachCell(t, b.Axes(), func(t *testing.T, cell map[string]string) {
@@ -32,6 +32,7 @@ func RunAllScenarios(t *testing.T, b Backend) {
 		RunTopologyScenarios(t, cellBackend)
 		RunReliabilityScenarios(t, cellBackend)
 		RunObservabilityScenarios(t, cellBackend)
+		RunPerformanceScenarios(t, cellBackend)
 	})
 }
 

--- a/mockrelay/testharness/mockbackend/mock_backend.go
+++ b/mockrelay/testharness/mockbackend/mock_backend.go
@@ -102,6 +102,20 @@ func (m *MockBackend) Cell(values map[string]string) e2escenarios.Backend {
 	return m
 }
 
+// ConnectLatencyThreshold returns the per-backend connect-latency
+// ceiling for the Performance suite. The mock pays a configurable
+// rendezvous delay (DefaultRendezvousDelay is 1 s) plus the in-
+// process echo round-trip (single-digit ms); 3 s leaves comfortable
+// headroom for CI scheduling noise without masking regressions of
+// the order of seconds.
+//
+// The mock returns one value regardless of cell — MockBackend has
+// no axes, and the RendezvousDelay field affects timing but is not
+// itself an axis the harness enumerates over.
+func (*MockBackend) ConnectLatencyThreshold() time.Duration {
+	return 3 * time.Second
+}
+
 // Setup brings up the in-process topology described by opts and blocks
 // until every listener's control channel is attached and every sender
 // bind is accepting TCP. All goroutines, the mock HTTP server, and


### PR DESCRIPTION
PR4 of the test-restructuring workstream. Closes the workstream
opened by PR1–PR3.

The shared e2e scenario harness gains a Performance suite that runs
as testing.T (alongside the existing testing.B benchmarks in
bench.go). Two connect-latency scenarios assert per-backend
thresholds; a third short-session scenario logs per-iteration
timings as an observation-only baseline that a follow-up will
promote to a gate once CI history establishes a realistic
ceiling.

Changes:

- `e2escenarios.Backend` gains `ConnectLatencyThreshold() time.Duration`.
  Both backend implementations (`MockBackend` and `azureBackend`)
  return 3 s — generous to absorb CI scheduling noise, tight enough
  to catch regressions on the order of seconds. Differentiating
  per-cell (e.g. SAS vs Entra) is straightforward when data
  justifies it but not done now.
- New `internal/testharness/e2escenarios/performance.go` contains
  `RunPerformanceScenarios` plus the three scenario functions
  (`ConnectLatency_Serial_PortForward`,
  `ConnectLatency_Serial_SOCKS5`, `ShortSession_Serial`) and a
  shared `timeOneConnect` helper. Reuses `benchDial`, `writeFull`,
  `StartPlainEcho`, and `AssertNoLeaks` from the existing harness.
- `RunAllScenarios` calls `RunPerformanceScenarios` last in each
  cell, so the new suite runs against every (backend, auth) cell
  in CI: `TestE2E_Mock/<scenario>` in the mockrelay test job and
  `TestE2E_Azure/<auth>/<scenario>` in the e2e workflow.
- Each ConnectLatency iteration's wall time is logged via
  `t.Logf`, so a threshold failure makes the offending iteration
  obvious in CI output without needing per-iteration metric
  scraping.

CI integration: no new workflow file. The existing `test` job
(mockrelay) and `e2e` workflow (Azure) already fail on test
failure; threshold violations now surface there as plain
sub-test failures (rendered paths `TestE2E_Mock/<scenario>` and
`TestE2E_Azure/<auth>/<scenario>`, consistent with the existing
Core/Topology/Reliability/Observability scenarios — no
`Performance/` wrapper layer).
