### PR TITLE
fix(e2e): restore make e2e streaming output and skip entra hyco in SAS-only mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,8 +63,24 @@ fmt: ## Format markdown and YAML with prettier
 fmt-check: ## Check formatting (same as CI)
 	npx --yes prettier --check .
 
+# `go test` buffers each test binary's combined stdout+stderr until
+# that binary exits when multiple packages share one invocation,
+# so `-v` does NOT stream output across packages. The `./e2e/` run
+# is the slow one (~14-17 min on Azure); keep these as separate
+# invocations so each binary's output streams live. Both
+# invocations run unconditionally and the recipe exits with the
+# combined non-zero status if either fails — mirroring the
+# multi-package `go test` semantics so a failure in azrelay does
+# not mask one in ./e2e/ (see also the e2e-docker target's
+# status-capture pattern). The 20 m per-invocation timeout is
+# generous against the ~14-17 min Azure run and is independent of
+# the GHA job-level `timeout-minutes` (which is the binding
+# constraint on CI). See golang/go#24929.
 e2e: build ## Run end-to-end tests (configure once via `make e2e-setup`)
-	go test -tags=e2e -timeout=40m -v ./e2e/azrelay/ ./e2e/
+	@status=0; \
+	go test -tags=e2e -timeout=20m -v ./e2e/azrelay/ || status=$$?; \
+	go test -tags=e2e -timeout=20m -v ./e2e/ || status=$$?; \
+	exit $$status
 
 e2e-docker: ## Run container-to-container e2e tests
 	@status=0; \

--- a/e2e/azrelay/provider.go
+++ b/e2e/azrelay/provider.go
@@ -119,13 +119,15 @@ func DefaultClientOptions() *arm.ClientOptions {
 	}
 }
 
-// Provision creates a fresh (entra, sas) hybrid-connection pair via
-// Provisioner: create entra hyco, create sas hyco. The returned
-// PairToken's Result is stamped with the namespace-scoped SAS rule
-// key info from p.cfg.RunRules. Teardown deletes both hycos; the
-// permanent run-scoped rules live on past every PairToken and are
-// not torn down by tests at all (they are provisioned once by
-// `make e2e-setup` and outlive every test invocation).
+// Provision creates a fresh hybrid-connection pair via Provisioner:
+// the SAS hyco unconditionally, and the entra hyco unless
+// Config.SkipEntra is true (in which case Result.EntraHycoName is
+// left empty). The returned PairToken's Result is stamped with the
+// namespace-scoped SAS rule key info from p.cfg.RunRules. Teardown
+// deletes whichever hycos were created; the permanent run-scoped
+// rules live on past every PairToken and are not torn down by
+// tests at all (they are provisioned once by `make e2e-setup` and
+// outlive every test invocation).
 //
 // Provision blocks if the concurrency semaphore is full. The block
 // honours ctx.Done so callers (typically t.Cleanup-registered)
@@ -203,15 +205,23 @@ func (t *PairToken) Result() *Result {
 	return t.result
 }
 
-// HycoNames returns the (entra, sas) names this token holds. Useful
-// for log messages.
+// HycoNames returns the (entra, sas) names this token holds. After a
+// successful Provision the names come from the recorded Result, so a
+// SkipEntra-mode token returns ("", "e2e-sas-<suffix>"). When no
+// Result is set (tests that construct a PairToken with only a
+// suffix), HycoNames synthesises both names from the suffix.
 func (t *PairToken) HycoNames() (entra, sas string) {
+	if t.result != nil {
+		return t.result.EntraHycoName, t.result.SASHycoName
+	}
 	return "e2e-entra-" + t.suffix, "e2e-sas-" + t.suffix
 }
 
-// Teardown deletes both hybrid connections. Safe to call multiple
-// times: only the first call performs the deletes; subsequent calls
-// return the same error.
+// Teardown deletes the hybrid connections recorded on this token
+// (the SAS hyco, and the entra hyco unless SkipEntra was set at
+// Provision time and left Result.EntraHycoName empty). Safe to call
+// multiple times: only the first call performs the deletes;
+// subsequent calls return the same error.
 //
 // Teardown strips cancellation from ctx (via context.WithoutCancel)
 // so cleanup completes even when the test's ctx has been cancelled
@@ -245,8 +255,10 @@ func (t *PairToken) Teardown(ctx context.Context) error {
 		}
 		var errs []error
 		entra, sas := t.HycoNames()
-		if err := t.deleteFn(ctx, entra); err != nil {
-			errs = append(errs, fmt.Errorf("delete %s: %w", entra, err))
+		if entra != "" {
+			if err := t.deleteFn(ctx, entra); err != nil {
+				errs = append(errs, fmt.Errorf("delete %s: %w", entra, err))
+			}
 		}
 		if err := t.deleteFn(ctx, sas); err != nil {
 			errs = append(errs, fmt.Errorf("delete %s: %w", sas, err))

--- a/e2e/azrelay/provider_test.go
+++ b/e2e/azrelay/provider_test.go
@@ -260,6 +260,106 @@ func TestPairToken_ResultPassesThrough(t *testing.T) {
 	}
 }
 
+// TestPairToken_HycoNamesSkipEntraSurfacesEmpty asserts that when a
+// PairToken has a populated Result whose EntraHycoName is empty
+// (SkipEntra mode), HycoNames returns the empty entra name from the
+// Result rather than falling back to the suffix-derived synthetic
+// name. This locks in "result wins over suffix" at the PairToken
+// level.
+func TestPairToken_HycoNamesSkipEntraSurfacesEmpty(t *testing.T) {
+	const suffix = "00112233aabb"
+	tok := &PairToken{
+		suffix: suffix,
+		result: &Result{
+			EntraHycoName: "",
+			SASHycoName:   "e2e-sas-" + suffix,
+		},
+	}
+	entra, sas := tok.HycoNames()
+	if entra != "" {
+		t.Errorf("entra = %q, want empty (Result wins over suffix)", entra)
+	}
+	if sas != "e2e-sas-"+suffix {
+		t.Errorf("sas = %q, want %q", sas, "e2e-sas-"+suffix)
+	}
+}
+
+// TestPairToken_TeardownSkipsEntraWhenResultEntraEmpty asserts that
+// Teardown invokes deleteFn exactly once (SAS only) when the Result
+// records SkipEntra (EntraHycoName empty), and that the count holds
+// across repeat calls.
+func TestPairToken_TeardownSkipsEntraWhenResultEntraEmpty(t *testing.T) {
+	const suffix = "feedface1234"
+	var calls atomic.Int32
+	var mu sync.Mutex
+	var capturedNames []string
+	tok := &PairToken{
+		suffix: suffix,
+		result: &Result{
+			EntraHycoName: "",
+			SASHycoName:   "e2e-sas-" + suffix,
+		},
+		deleteFn: func(ctx context.Context, name string) error {
+			calls.Add(1)
+			mu.Lock()
+			capturedNames = append(capturedNames, name)
+			mu.Unlock()
+			return nil
+		},
+	}
+
+	if err := tok.Teardown(t.Context()); err != nil {
+		t.Fatalf("first teardown: %v", err)
+	}
+	if got := calls.Load(); got != 1 {
+		t.Errorf("deleteFn invoked %d times, want 1 (SkipEntra: SAS only)", got)
+	}
+	if len(capturedNames) != 1 || capturedNames[0] != "e2e-sas-"+suffix {
+		t.Errorf("captured names = %v, want [%q]", capturedNames, "e2e-sas-"+suffix)
+	}
+
+	if err := tok.Teardown(t.Context()); err != nil {
+		t.Fatalf("second teardown: %v", err)
+	}
+	if got := calls.Load(); got != 1 {
+		t.Errorf("after second teardown, deleteFn invoked %d times, want still 1", got)
+	}
+}
+
+// TestPairToken_TeardownErrorOnSASOnly asserts that a deleteFn error
+// on the SAS-only Teardown path is wrapped, replayed identically on
+// subsequent calls, and that the underlying sentinel is recoverable
+// via errors.Is — matching the production idempotency contract for
+// the both-hycos path.
+func TestPairToken_TeardownErrorOnSASOnly(t *testing.T) {
+	const suffix = "deadbabe5678"
+	sentinel := errors.New("sas-only boom")
+	var calls atomic.Int32
+	tok := &PairToken{
+		suffix: suffix,
+		result: &Result{
+			EntraHycoName: "",
+			SASHycoName:   "e2e-sas-" + suffix,
+		},
+		deleteFn: func(ctx context.Context, name string) error {
+			calls.Add(1)
+			return sentinel
+		},
+	}
+
+	err1 := tok.Teardown(t.Context())
+	if err1 == nil || !errors.Is(err1, sentinel) {
+		t.Fatalf("first teardown err = %v; want errors.Is(sentinel)", err1)
+	}
+	err2 := tok.Teardown(t.Context())
+	if err2 != err1 {
+		t.Errorf("second teardown err = %v; want same value as first (%v)", err2, err1)
+	}
+	if got := calls.Load(); got != 1 {
+		t.Errorf("deleteFn invoked %d times across 2 teardowns, want 1 (SkipEntra)", got)
+	}
+}
+
 // TestPairToken_TeardownHonoursCallerDeadline verifies that a
 // deadline set on the caller's context is preserved across the
 // cancellation strip in Teardown. Specifically: a deadline shorter

--- a/e2e/azrelay/provisioner.go
+++ b/e2e/azrelay/provisioner.go
@@ -90,6 +90,16 @@ type Config struct {
 	// the single-use Provisioner type (it serialises by construction).
 	Concurrency int
 
+	// SkipEntra suppresses creation of the Entra-auth hyco. When true,
+	// Provision creates only the SAS hyco and leaves
+	// Result.EntraHycoName empty; Teardown skips the Delete on the
+	// empty name. Used by the e2e test harness when running in
+	// SAS-only mode (no Azure Relay data-plane role assignment), where
+	// the entra hyco would be created and torn down only to never be
+	// used. Safe to leave false in CI and any other path that
+	// exercises both auth methods.
+	SkipEntra bool
+
 	// RunRules supplies the namespace-permanent SAS rules whose keys
 	// every PairToken Result stamps onto its ListenerKey/SenderKey
 	// fields. Required for NewProvider and Provisioner; AcquireRunRules
@@ -168,15 +178,17 @@ func New(cfg Config) (*Provisioner, error) {
 	return &Provisioner{cfg: cfg, hycos: hycos, suffix: suffix}, nil
 }
 
-// Provision creates the Entra and SAS hybrid connections and stamps the
-// namespace SAS rule key info from cfg.RunRules onto the returned
-// Result. If any step fails after a hyco has been created, Provision
-// attempts a best-effort teardown before returning the error so the
-// caller does not need to handle partial state.
+// Provision creates the SAS hybrid connection (and the entra hybrid
+// connection unless Config.SkipEntra is true, in which case
+// Result.EntraHycoName is left empty) and stamps the namespace SAS
+// rule key info from Config.RunRules onto the returned Result. If
+// any step fails after a hyco has been created, Provision attempts
+// a best-effort teardown before returning the error so the caller
+// does not need to handle partial state.
 //
 // Authorization rules are NOT created here — they live at namespace
 // scope and are provisioned once per `go test` invocation via
-// AcquireRunRules. cfg.RunRules must be non-nil.
+// AcquireRunRules. Config.RunRules must be non-nil.
 func (p *Provisioner) Provision(ctx context.Context) (*Result, error) {
 	if p.result != nil {
 		return nil, errors.New("provisioner already used")
@@ -185,18 +197,23 @@ func (p *Provisioner) Provision(ctx context.Context) (*Result, error) {
 		return nil, errors.New("azrelay.Config.RunRules is required (call AcquireRunRules first)")
 	}
 
-	entraName := "e2e-entra-" + p.suffix
 	sasName := "e2e-sas-" + p.suffix
-
-	if err := p.createHyco(ctx, entraName); err != nil {
-		// On error the hyco may or may not exist server-side (ARM PUTs
-		// can fail post-create). Best-effort delete covers the orphan
-		// case; the janitor will catch anything we miss.
-		p.bestEffortDelete(ctx, entraName)
-		return nil, fmt.Errorf("create %s: %w", entraName, err)
+	var entraName string
+	if !p.cfg.SkipEntra {
+		entraName = "e2e-entra-" + p.suffix
+		if err := p.createHyco(ctx, entraName); err != nil {
+			// On error the hyco may or may not exist server-side (ARM
+			// PUTs can fail post-create). Best-effort delete covers
+			// the orphan case; the janitor will catch anything we
+			// miss.
+			p.bestEffortDelete(ctx, entraName)
+			return nil, fmt.Errorf("create %s: %w", entraName, err)
+		}
 	}
 	if err := p.createHyco(ctx, sasName); err != nil {
-		p.bestEffortDelete(ctx, entraName)
+		if entraName != "" {
+			p.bestEffortDelete(ctx, entraName)
+		}
 		p.bestEffortDelete(ctx, sasName)
 		return nil, fmt.Errorf("create %s: %w", sasName, err)
 	}
@@ -235,8 +252,10 @@ func (p *Provisioner) Teardown(ctx context.Context) error {
 	defer cancel()
 
 	var errs []error
-	if _, err := p.hycos.Delete(ctx, p.cfg.ResourceGroup, p.cfg.Namespace, p.result.EntraHycoName, nil); err != nil && !isNotFound(err) {
-		errs = append(errs, fmt.Errorf("delete %s: %w", p.result.EntraHycoName, err))
+	if p.result.EntraHycoName != "" {
+		if _, err := p.hycos.Delete(ctx, p.cfg.ResourceGroup, p.cfg.Namespace, p.result.EntraHycoName, nil); err != nil && !isNotFound(err) {
+			errs = append(errs, fmt.Errorf("delete %s: %w", p.result.EntraHycoName, err))
+		}
 	}
 	if _, err := p.hycos.Delete(ctx, p.cfg.ResourceGroup, p.cfg.Namespace, p.result.SASHycoName, nil); err != nil && !isNotFound(err) {
 		errs = append(errs, fmt.Errorf("delete %s: %w", p.result.SASHycoName, err))
@@ -247,10 +266,22 @@ func (p *Provisioner) Teardown(ctx context.Context) error {
 	return nil
 }
 
-// HycoNames returns the (entra, sas) names this provisioner created, or
-// will create when Provision is called. Useful for log messages.
+// HycoNames returns the (entra, sas) names this provisioner holds.
+// After a successful Provision the names come from the recorded
+// Result, so a SkipEntra-mode Provisioner returns
+// ("", "e2e-sas-<suffix>"). Before Provision the names are
+// synthesised from the suffix, with the entra name elided to "" when
+// Config.SkipEntra is true so callers see the same shape they will
+// see post-Provision.
 func (p *Provisioner) HycoNames() (entra, sas string) {
-	return "e2e-entra-" + p.suffix, "e2e-sas-" + p.suffix
+	if p.result != nil {
+		return p.result.EntraHycoName, p.result.SASHycoName
+	}
+	sas = "e2e-sas-" + p.suffix
+	if !p.cfg.SkipEntra {
+		entra = "e2e-entra-" + p.suffix
+	}
+	return entra, sas
 }
 
 func (p *Provisioner) createHyco(ctx context.Context, name string) error {

--- a/e2e/azrelay/provisioner_test.go
+++ b/e2e/azrelay/provisioner_test.go
@@ -177,6 +177,101 @@ func TestProvisionerHycoNamesUsesSuffix(t *testing.T) {
 	}
 }
 
+func TestProvisioner_HycoNamesPreProvision_SkipEntraElidesEntra(t *testing.T) {
+	// Before Provision runs, a Provisioner with cfg.SkipEntra=true
+	// should report ("", "e2e-sas-<suffix>") — matching the shape
+	// callers will see post-Provision and avoiding a synthetic entra
+	// name for a hyco that will never be created.
+	p := &Provisioner{
+		cfg:    Config{SkipEntra: true},
+		suffix: "0123456789ab",
+	}
+	entra, sas := p.HycoNames()
+	if entra != "" {
+		t.Errorf("entra = %q, want empty (SkipEntra elides pre-Provision)", entra)
+	}
+	if sas != "e2e-sas-0123456789ab" {
+		t.Errorf("sas = %q", sas)
+	}
+}
+
+func TestProvisioner_HycoNamesPostProvision_SkipEntra(t *testing.T) {
+	p := &Provisioner{
+		suffix: "0123456789ab",
+		result: &Result{
+			EntraHycoName: "",
+			SASHycoName:   "e2e-sas-0123456789ab",
+		},
+	}
+	entra, sas := p.HycoNames()
+	if entra != "" {
+		t.Errorf("entra name = %q, want empty (SkipEntra mode)", entra)
+	}
+	if sas != "e2e-sas-0123456789ab" {
+		t.Errorf("sas name = %q", sas)
+	}
+	if !HycoNamePattern.MatchString(sas) {
+		t.Errorf("sas name %q does not satisfy HycoNamePattern", sas)
+	}
+}
+
+func TestProvisioner_HycoNamesPostProvision_BothModes(t *testing.T) {
+	// Both Provisioners share the same suffix; the Result is what
+	// distinguishes them. Asserts "Result wins over suffix" so a
+	// SkipEntra-mode Result with empty EntraHycoName surfaces empty
+	// and a populated Result surfaces the recorded names.
+	const suffix = "abcdef012345"
+	bothMode := &Provisioner{
+		suffix: suffix,
+		result: &Result{
+			EntraHycoName: "e2e-entra-" + suffix,
+			SASHycoName:   "e2e-sas-" + suffix,
+		},
+	}
+	skipMode := &Provisioner{
+		suffix: suffix,
+		result: &Result{
+			EntraHycoName: "",
+			SASHycoName:   "e2e-sas-" + suffix,
+		},
+	}
+
+	entra, sas := bothMode.HycoNames()
+	if entra != "e2e-entra-"+suffix || sas != "e2e-sas-"+suffix {
+		t.Errorf("bothMode.HycoNames = (%q, %q); want both populated", entra, sas)
+	}
+
+	entra, sas = skipMode.HycoNames()
+	if entra != "" || sas != "e2e-sas-"+suffix {
+		t.Errorf("skipMode.HycoNames = (%q, %q); want (\"\", %q)", entra, sas, "e2e-sas-"+suffix)
+	}
+}
+
+func TestResultEnvVars_EmptyEntraHycoName(t *testing.T) {
+	// SkipEntra mode leaves Result.EntraHycoName empty. EnvVars must
+	// still emit the E2E_ENTRA_HYCO_NAME key with an empty value so
+	// downstream consumers can reason about presence via
+	// `EntraHycoName != ""` without missing-key surprises.
+	r := &Result{
+		RelayName:       "my-relay",
+		EntraHycoName:   "",
+		SASHycoName:     "e2e-sas-0123456789ab",
+		ListenerKeyName: "listener",
+		ListenerKey:     "lk",
+		SenderKeyName:   "sender",
+		SenderKey:       "sk",
+	}
+	got := r.EnvVars()
+	if v, ok := got["E2E_ENTRA_HYCO_NAME"]; !ok {
+		t.Fatal("EnvVars missing E2E_ENTRA_HYCO_NAME key (must be present even when empty)")
+	} else if v != "" {
+		t.Errorf("EnvVars[E2E_ENTRA_HYCO_NAME] = %q, want empty", v)
+	}
+	if got["E2E_SAS_HYCO_NAME"] != "e2e-sas-0123456789ab" {
+		t.Errorf("EnvVars[E2E_SAS_HYCO_NAME] = %q, want %q", got["E2E_SAS_HYCO_NAME"], "e2e-sas-0123456789ab")
+	}
+}
+
 // fastAuthRuleRetry returns a retry config that runs the same number of
 // attempts as production but with near-zero delays so unit tests don't
 // pay the 500ms…8s backoff schedule. Behaviour-equivalent for the loop's

--- a/e2e/helpers_test.go
+++ b/e2e/helpers_test.go
@@ -119,7 +119,11 @@ func requireDedicatedHyco(t testing.TB) *relayEnv {
 	}
 
 	entra, sas := tok.HycoNames()
-	t.Logf("provisioned dedicated hyco pair: %s, %s", entra, sas)
+	if entra == "" {
+		t.Logf("provisioned dedicated hyco: %s (entra skipped, SAS-only mode)", sas)
+	} else {
+		t.Logf("provisioned dedicated hyco pair: %s, %s", entra, sas)
+	}
 
 	t.Cleanup(func() {
 		ctx, cancel := context.WithTimeout(context.Background(), hycoTeardownTimeout)
@@ -128,7 +132,11 @@ func requireDedicatedHyco(t testing.TB) *relayEnv {
 			// Log only — the janitor will reap anything we miss,
 			// and failing the test on cleanup errors would mask
 			// the actual test outcome.
-			t.Logf("teardown dedicated hyco pair %s/%s: %v", entra, sas, err)
+			if entra == "" {
+				t.Logf("teardown dedicated hyco %s: %v", sas, err)
+			} else {
+				t.Logf("teardown dedicated hyco pair %s/%s: %v", entra, sas, err)
+			}
 		}
 	})
 
@@ -202,7 +210,11 @@ func leaseSharedHyco(tb testing.TB) *relayEnv {
 		tb.Fatalf("provision shared bench hyco pair: %v", err)
 	}
 	entra, sas := tok.HycoNames()
-	tb.Logf("leased shared bench hyco pair: %s, %s", entra, sas)
+	if entra == "" {
+		tb.Logf("leased shared bench hyco: %s (entra skipped, SAS-only mode)", sas)
+	} else {
+		tb.Logf("leased shared bench hyco pair: %s, %s", entra, sas)
+	}
 	benchLeaseTok = tok
 	benchLeaseEnv = resultToEnv(tok.Result())
 	return benchLeaseEnv
@@ -227,7 +239,11 @@ func drainBenchLease() {
 	benchLeaseTok = nil
 	entra, sas := tok.HycoNames()
 	if err := tok.Teardown(ctx); err != nil {
-		fmt.Fprintf(os.Stderr, "==> e2e: teardown shared bench hyco pair %s/%s: %v\n", entra, sas, err)
+		if entra == "" {
+			fmt.Fprintf(os.Stderr, "==> e2e: teardown shared bench hyco %s: %v\n", sas, err)
+		} else {
+			fmt.Fprintf(os.Stderr, "==> e2e: teardown shared bench hyco pair %s/%s: %v\n", entra, sas, err)
+		}
 	}
 }
 
@@ -294,10 +310,17 @@ func availableAuths(t testing.TB, env *relayEnv) []authConfig {
 // E2E_AUTH=entra, ["sas"] when E2E_AUTH=sas. Any other value fails
 // the caller.
 //
-// The shared Provider always provisions both an Entra hyco and a SAS
-// hyco per call, so there is no "auth method is unavailable" branch
-// here — every name returned is guaranteed buildable by authFromEnv
-// once a fresh env is in hand.
+// The shared Provider provisions the SAS hyco unconditionally and
+// the entra hyco unless Config.SkipEntra is true. TestMain enables
+// SkipEntra only when E2E_AUTH=="sas" or when E2E_AUTH is unset
+// (LookupEnv reports !isSet) and resolved.Local.SASOnly is true —
+// both paths produce a filter that excludes "entra" from the names
+// returned here (E2E_AUTH=="sas" directly, or the upstream setenv
+// block forcing E2E_AUTH=sas in the unset+SASOnly case). When
+// "entra" is in the returned names the entra hyco is always
+// provisioned and every name is guaranteed buildable by authFromEnv
+// once a fresh env is in hand — there is no "auth method is
+// unavailable" branch.
 func availableAuthNames(t testing.TB) []string {
 	t.Helper()
 	filter := os.Getenv("E2E_AUTH")
@@ -316,8 +339,10 @@ func availableAuthNames(t testing.TB) []string {
 // freshly-provisioned env. Used by azureBackend.Setup to derive the
 // concrete auth (hyco + optional SAS creds) AFTER each Setup call
 // provisions its own hyco pair. The env is assumed to have been
-// produced by Provider.Provision (i.e. both entra and SAS slots are
-// populated); a missing field will fail the test rather than skip.
+// produced by Provider.Provision with the slot for `name` populated
+// (SAS is always populated; entra is populated unless
+// Config.SkipEntra was true at Provision time); a missing field
+// will fail the test rather than skip.
 func authFromEnv(t testing.TB, env *relayEnv, name string) authConfig {
 	t.Helper()
 	switch name {

--- a/e2e/testmain_test.go
+++ b/e2e/testmain_test.go
@@ -134,11 +134,34 @@ func testMain(m *testing.M) int {
 
 	conc := readConcurrencyEnv()
 
+	// SAS-only mode signal: when the test process will only exercise
+	// SAS, skip provisioning an entra hyco. E2E_AUTH is authoritative
+	// — an explicit E2E_AUTH=entra (e.g. the user was granted the
+	// role but hasn't refreshed .local.json yet) keeps entra
+	// provisioning enabled even when SASOnly is persisted. When
+	// E2E_AUTH is unset, fall back to resolved.Local.SASOnly so a
+	// future contributor deleting the setenv block above does not
+	// silently regress SkipEntra. (When SASOnly is true and E2E_AUTH
+	// was unset on entry, the setenv block above has already forced
+	// E2E_AUTH=sas, so this fallback only fires when both signals
+	// would have produced the same answer.)
+	skipEntra := false
+	v, isSet := os.LookupEnv("E2E_AUTH")
+	switch {
+	case isSet && v == "sas":
+		skipEntra = true
+	case !isSet:
+		if resolved.Local != nil && resolved.Local.SASOnly {
+			skipEntra = true
+		}
+	}
+
 	cfg := azrelay.Config{
 		SubscriptionID: resolved.Subscription,
 		ResourceGroup:  resolved.ResourceGroup,
 		Namespace:      resolved.RelayName,
 		Concurrency:    conc,
+		SkipEntra:      skipEntra,
 	}
 
 	// Acquire the namespace SAS rule keys. The rules


### PR DESCRIPTION
Two independent local-dev quality-of-life fixes to the e2e target,
both surfaced by a single `make e2e` run.

## `make e2e` streams output again

`go test` buffers each test binary's combined stdout+stderr until
that binary exits when multiple packages share one invocation, so
`-v` does not stream output across packages. With both `./e2e/azrelay/`
and `./e2e/` collapsed into a single invocation, the slow `./e2e/`
binary produces zero output for ~7 minutes before dumping its
whole transcript at the end. Splitting into two invocations (one
per package) gives live output for both binaries. The
per-invocation timeout is 20 m; the GHA job-level timeout-minutes
is the binding CI constraint and is unaffected.

A Makefile comment documents the streaming behavior and asks
future contributors not to re-collapse the invocations.

## Skip entra hyco provisioning when SAS-only

`azrelay.Provider.Provision` always created an `e2e-entra-<hex>`
hyco in addition to the `e2e-sas-<hex>` hyco. When the test
process runs in SAS-only mode (no Azure Relay data-plane role
assignment, or an explicit `E2E_AUTH=sas`), the entra hyco is
created and torn down without ever being used — ~2 wasted ARM
round-trips per test multiplied across the suite.

This PR adds `azrelay.Config.SkipEntra bool`. When set,
`Provision` creates only the SAS hyco and leaves
`Result.EntraHycoName == ""`; the Teardown / per-token deleteFn
skips the Delete on the empty name. The downstream
`availableAuths` test helper already gates entra on `env.hyco !=
""`, so an empty `EntraHycoName` naturally translates to "entra
auth unavailable" without further wiring.

TestMain plumbs the flag from `resolved.Local.SASOnly == true`
(set by `make e2e-setup` when the RBAC grant fails) and from an
explicit `E2E_AUTH=sas` env override. The CI path (where both
auth methods exist) is unchanged: `SkipEntra` stays false and
both hycos are provisioned as before.

The provisioning log line in `requireDedicatedHyco` (and the
shared-bench equivalent in `leaseSharedHyco`) adapts to surface
the SAS-only mode visibly:

```
scenarios.go:NN: provisioned dedicated hyco: e2e-sas-<hex> (entra skipped, SAS-only mode)
```

Validated locally on a SAS-only `make e2e` run: zero `e2e-entra-`
hyco names in the test transcript, full suite passes, output
streams from the first `./e2e/` test onward.
