### PR TITLE
feat(relay): TLS session caching and TLS 1.3 minimum for relay dials

### DIFF
--- a/internal/arc/arc.go
+++ b/internal/arc/arc.go
@@ -195,9 +195,7 @@ func Dial(ctx context.Context, info *RelayInfo, port int) (*websocket.Conn, erro
 	headers.Set("Service-Configuration-Token", info.ServiceConfigurationToken)
 	headers.Set("Microsoft-Guestgateway-Target", fmt.Sprintf("localhost:%d", port))
 
-	ws, _, err := websocket.Dial(ctx, connectURL, &websocket.DialOptions{
-		HTTPHeader: headers,
-	})
+	ws, _, err := websocket.Dial(ctx, connectURL, relay.WSDialOptions(headers, nil))
 	if err != nil {
 		return nil, fmt.Errorf("dial arc relay: %w", sanitizeErr(err))
 	}
@@ -282,9 +280,7 @@ func DialWithOptions(ctx context.Context, info *RelayInfo, port int, logger *slo
 			wssHost, info.HybridConnectionName, newUUID())
 
 		dialCtx, cancel := context.WithTimeout(ctx, dialTimeout)
-		ws, resp, err := websocket.Dial(dialCtx, connectURL, &websocket.DialOptions{
-			HTTPHeader: headers,
-		})
+		ws, resp, err := websocket.Dial(dialCtx, connectURL, relay.WSDialOptions(headers, nil))
 		cancel()
 
 		if err == nil {

--- a/internal/relay/client.go
+++ b/internal/relay/client.go
@@ -11,14 +11,24 @@ import (
 // connections (listener control channel, sender rendezvous, and the
 // listener's outbound rendezvous dial).
 //
-// The zero value uses the secure wss:// scheme via http.DefaultClient and
-// is compatible with real Azure Relay.
+// The zero value uses the secure wss:// scheme and is compatible with
+// real Azure Relay.
 type ClientOptions struct {
-	// TLSConfig, when non-nil, overrides the TLS settings used for the
-	// wss dial. Typically used to set InsecureSkipVerify for mock or
-	// self-signed relays.
+	// TLSConfig, when non-nil, supplies extra TLS settings used for
+	// the wss dial. Typically used to set InsecureSkipVerify for mock
+	// or self-signed relays. The shared ClientSessionCache and TLS
+	// 1.3 minimum are always applied — caller fields for those two
+	// knobs are overridden.
 	TLSConfig *tls.Config
 }
+
+// sessionCache is the process-wide TLS client session cache shared by
+// every aztunnel relay dial (this package and internal/arc). Sharing
+// one cache means a listener's many accept dials and a sender's many
+// rendezvous dials to the same Azure Relay frontend reuse session
+// tickets and skip the full handshake on repeat dials. The LRU is
+// safe for concurrent use and is bounded by NewLRUClientSessionCache.
+var sessionCache = tls.NewLRUClientSessionCache(0)
 
 // wssBase returns the URL prefix for relay URLs given this client's
 // endpoint host[:port]. aztunnel only dials TLS-protected relays, so
@@ -27,33 +37,87 @@ func (o ClientOptions) wssBase(endpoint string) string {
 	return "wss://" + endpoint
 }
 
-// dialOptions returns websocket.DialOptions suitable for the configured
-// transport. Returns nil when no override is needed (zero options →
-// websocket.Dial defaults).
-//
-// When TLSConfig is set, the returned options carry a custom *http.Client
-// whose transport is a clone of http.DefaultTransport — this preserves
-// proxy, dialer, and idle-timeout defaults that production deployments
-// may depend on, instead of constructing a bare new transport. The
-// supplied TLSConfig is cloned per dial so concurrent dials don't share
-// mutable state (e.g. http.Transport's lazy ALPN initialization may
-// touch TLSConfig.NextProtos).
+// dialOptions returns websocket.DialOptions for this ClientOptions.
+// Delegates to WSDialOptions so the relay package's own dials get the
+// same shared session cache / TLS-hygiene defaults as callers in
+// internal/arc.
 func (o ClientOptions) dialOptions() *websocket.DialOptions {
-	if o.TLSConfig == nil {
-		return nil
-	}
+	return WSDialOptions(nil, o.TLSConfig)
+}
+
+// WSDialOptions builds *websocket.DialOptions for a wss dial to Azure
+// Relay. The returned options carry a per-dial *http.Client whose
+// transport is a clone of the *http.Transport that http.DefaultClient
+// would have used (preferring http.DefaultClient.Transport when set,
+// falling back to http.DefaultTransport — see defaultTransportClone),
+// with a TLS configuration that always attaches the shared session
+// cache and forces a TLS 1.3 minimum.
+//
+// headers may be nil; baseTLS may be nil. When baseTLS is nil and the
+// cloned transport already carries a TLSClientConfig (test harnesses
+// install one on http.DefaultTransport to inject InsecureSkipVerify
+// for self-signed test servers), that config is carried forward —
+// then the cache and MinVersion are stamped on top, overriding any
+// caller-supplied values for those two fields.
+//
+// The supplied TLSConfig is cloned per dial so concurrent dials don't
+// share mutable state (http.Transport's lazy ALPN initialization may
+// touch TLSConfig.NextProtos). The ClientSessionCache field is a
+// pointer to a shared, concurrency-safe LRU, so cloning still shares
+// the same cache across dials — which is what makes resumption work.
+func WSDialOptions(headers http.Header, baseTLS *tls.Config) *websocket.DialOptions {
 	tr := defaultTransportClone()
-	tr.TLSClientConfig = o.TLSConfig.Clone()
+	if baseTLS == nil && tr.TLSClientConfig != nil {
+		baseTLS = tr.TLSClientConfig
+	}
+	tr.TLSClientConfig = tlsConfigForDial(baseTLS)
+
+	var c http.Client
+	if dc := http.DefaultClient; dc != nil {
+		c = *dc
+	}
+	c.Transport = tr
 	return &websocket.DialOptions{
-		HTTPClient: &http.Client{Transport: tr},
+		HTTPHeader: headers,
+		HTTPClient: &c,
 	}
 }
 
-// defaultTransportClone returns a clone of http.DefaultTransport, or a
-// fresh *http.Transport if the default has been replaced with something
-// that isn't an *http.Transport (defensive, should not happen in
-// practice).
+// tlsConfigForDial returns a fresh *tls.Config derived from base with
+// the shared ClientSessionCache and a TLS 1.3 minimum stamped on
+// unconditionally. aztunnel only dials Azure Relay, which supports
+// TLS 1.3 across all regions, so we don't fall back to TLS 1.2.
+// Caller-supplied ClientSessionCache and MinVersion are overwritten;
+// other fields (notably InsecureSkipVerify for mock-relay tests) are
+// preserved.
+func tlsConfigForDial(base *tls.Config) *tls.Config {
+	var cfg *tls.Config
+	if base != nil {
+		cfg = base.Clone()
+	} else {
+		cfg = &tls.Config{}
+	}
+	cfg.ClientSessionCache = sessionCache
+	cfg.MinVersion = tls.VersionTLS13
+	return cfg
+}
+
+// defaultTransportClone returns a clone of the *http.Transport that
+// http.DefaultClient would have used: prefer http.DefaultClient.Transport
+// when it is an *http.Transport, otherwise fall back to
+// http.DefaultTransport, otherwise return a fresh *http.Transport.
+//
+// A non-*http.Transport RoundTripper installed on
+// http.DefaultClient.Transport (e.g. an observability wrapper) is not
+// honored, because TLSClientConfig must be set per dial and arbitrary
+// RoundTrippers expose no general way to do that. No caller in this
+// codebase installs a wrapped RoundTripper.
 func defaultTransportClone() *http.Transport {
+	if dc := http.DefaultClient; dc != nil {
+		if t, ok := dc.Transport.(*http.Transport); ok {
+			return t.Clone()
+		}
+	}
 	if t, ok := http.DefaultTransport.(*http.Transport); ok {
 		return t.Clone()
 	}

--- a/internal/relay/client_test.go
+++ b/internal/relay/client_test.go
@@ -1,0 +1,271 @@
+package relay
+
+import (
+	"context"
+	"crypto/tls"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/coder/websocket"
+)
+
+func TestTLSConfigForDial(t *testing.T) {
+	t.Run("nil base populates cache and MinVersion", func(t *testing.T) {
+		cfg := tlsConfigForDial(nil)
+		if cfg.ClientSessionCache != sessionCache {
+			t.Errorf("ClientSessionCache = %v, want shared sessionCache", cfg.ClientSessionCache)
+		}
+		if cfg.MinVersion != tls.VersionTLS13 {
+			t.Errorf("MinVersion = %#x, want %#x", cfg.MinVersion, tls.VersionTLS13)
+		}
+	})
+
+	t.Run("preserves caller InsecureSkipVerify", func(t *testing.T) {
+		//nolint:gosec // test only
+		base := &tls.Config{InsecureSkipVerify: true}
+		cfg := tlsConfigForDial(base)
+		if !cfg.InsecureSkipVerify {
+			t.Error("InsecureSkipVerify was not preserved")
+		}
+		if cfg.ClientSessionCache != sessionCache {
+			t.Error("shared session cache not attached")
+		}
+		if cfg.MinVersion != tls.VersionTLS13 {
+			t.Errorf("MinVersion = %#x, want %#x", cfg.MinVersion, tls.VersionTLS13)
+		}
+	})
+
+	t.Run("overrides caller-supplied session cache", func(t *testing.T) {
+		userCache := tls.NewLRUClientSessionCache(8)
+		base := &tls.Config{ClientSessionCache: userCache}
+		cfg := tlsConfigForDial(base)
+		if cfg.ClientSessionCache != sessionCache {
+			t.Error("caller-supplied ClientSessionCache was not replaced with shared cache")
+		}
+	})
+
+	t.Run("overrides caller-supplied MinVersion", func(t *testing.T) {
+		base := &tls.Config{MinVersion: tls.VersionTLS12}
+		cfg := tlsConfigForDial(base)
+		if cfg.MinVersion != tls.VersionTLS13 {
+			t.Errorf("MinVersion = %#x, want %#x (caller value must not lower the floor)", cfg.MinVersion, tls.VersionTLS13)
+		}
+	})
+
+	t.Run("clones base — caller mutation does not affect returned cfg", func(t *testing.T) {
+		base := &tls.Config{}
+		cfg := tlsConfigForDial(base)
+		//nolint:gosec // test only
+		base.InsecureSkipVerify = true
+		if cfg.InsecureSkipVerify {
+			t.Error("returned cfg shares mutable state with base — Clone() not applied")
+		}
+	})
+}
+
+func TestWSDialOptionsAlwaysAttachesSessionCache(t *testing.T) {
+	t.Run("nil base", func(t *testing.T) {
+		opts := WSDialOptions(nil, nil)
+		if opts == nil || opts.HTTPClient == nil {
+			t.Fatal("WSDialOptions returned nil HTTPClient")
+		}
+		tr, ok := opts.HTTPClient.Transport.(*http.Transport)
+		if !ok {
+			t.Fatalf("Transport is %T, want *http.Transport", opts.HTTPClient.Transport)
+		}
+		if tr.TLSClientConfig == nil || tr.TLSClientConfig.ClientSessionCache == nil {
+			t.Error("TLSClientConfig.ClientSessionCache not set")
+		}
+		if tr.TLSClientConfig.MinVersion != tls.VersionTLS13 {
+			t.Errorf("MinVersion = %#x, want %#x", tr.TLSClientConfig.MinVersion, tls.VersionTLS13)
+		}
+	})
+
+	t.Run("caller InsecureSkipVerify preserved", func(t *testing.T) {
+		//nolint:gosec // test only
+		opts := WSDialOptions(nil, &tls.Config{InsecureSkipVerify: true})
+		tr := opts.HTTPClient.Transport.(*http.Transport)
+		if !tr.TLSClientConfig.InsecureSkipVerify {
+			t.Error("InsecureSkipVerify not preserved into dial options")
+		}
+		if tr.TLSClientConfig.ClientSessionCache == nil {
+			t.Error("session cache missing")
+		}
+	})
+
+	t.Run("preserves mutated http.DefaultTransport TLSClientConfig", func(t *testing.T) {
+		orig := http.DefaultTransport
+		t.Cleanup(func() { http.DefaultTransport = orig })
+
+		//nolint:gosec // test only
+		http.DefaultTransport = &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		}
+
+		opts := WSDialOptions(nil, nil)
+		tr := opts.HTTPClient.Transport.(*http.Transport)
+		if !tr.TLSClientConfig.InsecureSkipVerify {
+			t.Error("InsecureSkipVerify from http.DefaultTransport was lost")
+		}
+		if tr.TLSClientConfig.ClientSessionCache == nil {
+			t.Error("session cache missing")
+		}
+	})
+
+	t.Run("prefers http.DefaultClient.Transport over http.DefaultTransport", func(t *testing.T) {
+		// When http.DefaultClient.Transport is an *http.Transport,
+		// WSDialOptions uses it (preserving DefaultClient-level
+		// transport tuning) instead of falling through to
+		// http.DefaultTransport.
+		origC := http.DefaultClient
+		origT := http.DefaultTransport
+		t.Cleanup(func() {
+			http.DefaultClient = origC
+			http.DefaultTransport = origT
+		})
+
+		sentinel := &http.Transport{
+			MaxIdleConnsPerHost: 7,
+			//nolint:gosec // test only
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		}
+		http.DefaultClient = &http.Client{Transport: sentinel}
+		http.DefaultTransport = &http.Transport{MaxIdleConnsPerHost: 13}
+
+		opts := WSDialOptions(nil, nil)
+		tr := opts.HTTPClient.Transport.(*http.Transport)
+		if tr.MaxIdleConnsPerHost != 7 {
+			t.Errorf("MaxIdleConnsPerHost = %d, want 7 (DefaultClient.Transport ignored)", tr.MaxIdleConnsPerHost)
+		}
+		if !tr.TLSClientConfig.InsecureSkipVerify {
+			t.Error("DefaultClient.Transport TLSClientConfig was lost")
+		}
+	})
+
+	t.Run("preserves caller headers", func(t *testing.T) {
+		h := http.Header{}
+		h.Set("X-Test", "value")
+		opts := WSDialOptions(h, nil)
+		if got := opts.HTTPHeader.Get("X-Test"); got != "value" {
+			t.Errorf("HTTPHeader.X-Test = %q, want %q", got, "value")
+		}
+	})
+
+	t.Run("does not mutate caller TLSConfig", func(t *testing.T) {
+		//nolint:gosec // test only
+		base := &tls.Config{InsecureSkipVerify: true}
+		_ = WSDialOptions(nil, base)
+		if base.ClientSessionCache != nil {
+			t.Error("caller's *tls.Config was mutated (ClientSessionCache set)")
+		}
+		if base.MinVersion != 0 {
+			t.Error("caller's *tls.Config was mutated (MinVersion set)")
+		}
+	})
+
+	t.Run("uses shallow copy of http.DefaultClient", func(t *testing.T) {
+		orig := http.DefaultClient
+		t.Cleanup(func() { http.DefaultClient = orig })
+
+		http.DefaultClient = &http.Client{
+			Timeout: 7 * time.Second,
+		}
+
+		opts := WSDialOptions(nil, nil)
+		if opts.HTTPClient.Timeout != 7*time.Second {
+			t.Errorf("Timeout = %v, want 7s — http.DefaultClient.Timeout was not preserved", opts.HTTPClient.Timeout)
+		}
+		if opts.HTTPClient == http.DefaultClient {
+			t.Error("returned HTTPClient is the SAME *http.Client as http.DefaultClient — should be a shallow copy")
+		}
+	})
+
+	t.Run("does not panic when http.DefaultClient is nil", func(t *testing.T) {
+		orig := http.DefaultClient
+		t.Cleanup(func() { http.DefaultClient = orig })
+
+		http.DefaultClient = nil
+
+		opts := WSDialOptions(nil, nil)
+		if opts == nil || opts.HTTPClient == nil {
+			t.Fatal("WSDialOptions returned nil HTTPClient")
+		}
+		tr, ok := opts.HTTPClient.Transport.(*http.Transport)
+		if !ok || tr.TLSClientConfig == nil || tr.TLSClientConfig.ClientSessionCache == nil {
+			t.Error("session cache not attached when DefaultClient is nil")
+		}
+	})
+}
+
+// TestWSDialOptionsSessionResumption verifies that two sequential
+// dials through WSDialOptions actually resume the TLS session: the
+// second connection sees ConnectionState.DidResume == true on the
+// server side. End-to-end proof that the shared session cache is
+// wired correctly through coder/websocket → http.Transport.
+func TestWSDialOptionsSessionResumption(t *testing.T) {
+	var (
+		mu        sync.Mutex
+		resumedOn []int // 1-indexed dial numbers that resumed
+		dialNum   atomic.Int32
+	)
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := int(dialNum.Add(1))
+		if r.TLS != nil && r.TLS.DidResume {
+			mu.Lock()
+			resumedOn = append(resumedOn, n)
+			mu.Unlock()
+		}
+		ws, err := websocket.Accept(w, r, nil)
+		if err != nil {
+			return
+		}
+		_ = ws.Close(websocket.StatusNormalClosure, "ok")
+	})
+
+	srv := httptest.NewTLSServer(handler)
+	t.Cleanup(srv.Close)
+
+	// Caller TLSConfig reused across dials. tlsConfigForDial stamps
+	// the package sessionCache on the cloned config — that shared
+	// cache is what enables resumption.
+	//nolint:gosec // test server uses self-signed cert
+	baseTLS := &tls.Config{InsecureSkipVerify: true}
+
+	wssURL := "wss://" + strings.TrimPrefix(srv.URL, "https://")
+
+	dial := func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		ws, _, err := websocket.Dial(ctx, wssURL, WSDialOptions(nil, baseTLS))
+		if err != nil {
+			t.Fatalf("dial: %v", err)
+		}
+		// Drain the close so the server-side handler completes and
+		// records its DidResume observation before the next dial.
+		// This read also drives the client past the TLS 1.3
+		// post-handshake NewSessionTicket frame, so the ticket is
+		// stored in the cache before the next dial begins.
+		_, _, _ = ws.Read(ctx)
+		_ = ws.CloseNow()
+	}
+
+	dial()
+	dial()
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(resumedOn) == 0 {
+		t.Fatal("no dial reported DidResume — session cache not effective")
+	}
+	for _, n := range resumedOn {
+		if n == 1 {
+			t.Errorf("first dial reported DidResume — impossible without prior cache state")
+		}
+	}
+}


### PR DESCRIPTION
All aztunnel client-side relay dials (listener control channel,
sender rendezvous, listener outbound rendezvous, and arc package
dials) now share a process-wide TLS LRU client session cache.
Repeat dials to the same Azure Relay frontend reuse session
tickets and skip the full handshake, cutting per-dial latency
materially when many connections flow to one hyco.

All relay dials are also pinned to TLS 1.3 minimum. Azure Relay
supports TLS 1.3 across all regions, so a 1.2 fallback isn't
required; the floor gives us mandatory forward secrecy plus a
1-RTT handshake that compounds with the session cache.