### PR TITLE
fix(relay): force P-384 key_share to avoid Azure Relay HelloRetryRequest

### DIFF
--- a/internal/relay/client.go
+++ b/internal/relay/client.go
@@ -18,7 +18,9 @@ type ClientOptions struct {
 	// the wss dial. Typically used to set InsecureSkipVerify for mock
 	// or self-signed relays. The shared ClientSessionCache and TLS
 	// 1.3 minimum are always applied — caller fields for those two
-	// knobs are overridden.
+	// knobs are overridden. CurvePreferences defaults to
+	// relayCurvePreferences (P-384 first) when the caller leaves it
+	// empty; a caller-supplied non-empty list is preserved.
 	TLSConfig *tls.Config
 }
 
@@ -29,6 +31,49 @@ type ClientOptions struct {
 // tickets and skip the full handshake on repeat dials. The LRU is
 // safe for concurrent use and is bounded by NewLRUClientSessionCache.
 var sessionCache = tls.NewLRUClientSessionCache(0)
+
+// relayCurvePreferences is the default TLS 1.3 key-exchange group set
+// used for relay dials when the caller has not supplied their own
+// CurvePreferences.
+//
+// Azure Relay's TLS frontends prefer secp384r1 (CurveP384) for the
+// initial key share. Go's default supportedCurves list leads with
+// X25519MLKEM768 and X25519 (and, on Go 1.26, two additional
+// SecP*MLKEM* PQ hybrids), so an unconfigured client sends a
+// ClientHello whose key_share is for X25519MLKEM768 (+ X25519
+// fallback). Azure rejects this with a HelloRetryRequest naming
+// P-384, costing a full extra network round trip on every cold relay
+// dial.
+//
+// Important Go-internal behavior: as of Go 1.24+, the *order* of the
+// user-supplied tls.Config.CurvePreferences slice is ignored. Go
+// filters its internal default list to retain only the entries the
+// user named and uses the (default-order) first surviving entry to
+// pick the curve for the initial key_share. The doc on Config
+// .CurvePreferences also warns that the implicit key_share selection
+// "may change in the future" — see golang/go#69393, which signals
+// the Go team intends to take full control of which key_shares get
+// sent. The most defensive position against that future shift is to
+// list a single curve: with only one allowed group, Go has no choice
+// but to send a key_share for it (or for something that includes it
+// as a fallback share).
+//
+// Therefore: a single-element list with CurveP384. No CurveP521 or
+// other fallback — if Azure ever rotates its preference, the e2e
+// suite against the real frontend will catch it loudly, which is
+// preferable to silently masking a regression behind a longer
+// supported_groups list that would HRR to whatever curve survived.
+//
+// Trade-off: this opts the relay channel out of the X25519MLKEM768
+// post-quantum hybrid. Azure Relay clearly does not support that
+// hybrid today (that is the source of the HRR), so there is no PQ
+// protection to lose at present. Including SecP384r1MLKEM1024 would
+// also send a P-384 fallback share alongside the hybrid and avoid
+// HRR, but it bloats the ClientHello from ~300 bytes to ~1.8 KB
+// (extra TCP segments), which is exactly the round-trip overhead
+// this default is meant to remove. Revisit if/when Azure Relay
+// advertises PQ support.
+var relayCurvePreferences = []tls.CurveID{tls.CurveP384}
 
 // wssBase returns the URL prefix for relay URLs given this client's
 // endpoint host[:port]. aztunnel only dials TLS-protected relays, so
@@ -51,14 +96,18 @@ func (o ClientOptions) dialOptions() *websocket.DialOptions {
 // would have used (preferring http.DefaultClient.Transport when set,
 // falling back to http.DefaultTransport — see defaultTransportClone),
 // with a TLS configuration that always attaches the shared session
-// cache and forces a TLS 1.3 minimum.
+// cache, forces a TLS 1.3 minimum, and (when the caller has not
+// supplied their own) installs relayCurvePreferences so the initial
+// ClientHello key_share is P-384 and Azure Relay does not respond
+// with a HelloRetryRequest.
 //
 // headers may be nil; baseTLS may be nil. When baseTLS is nil and the
 // cloned transport already carries a TLSClientConfig (test harnesses
 // install one on http.DefaultTransport to inject InsecureSkipVerify
 // for self-signed test servers), that config is carried forward —
-// then the cache and MinVersion are stamped on top, overriding any
-// caller-supplied values for those two fields.
+// then the cache, MinVersion, and (if empty) CurvePreferences are
+// stamped on top, overriding any caller-supplied values for the cache
+// and MinVersion fields.
 //
 // The supplied TLSConfig is cloned per dial so concurrent dials don't
 // share mutable state (http.Transport's lazy ALPN initialization may
@@ -90,6 +139,13 @@ func WSDialOptions(headers http.Header, baseTLS *tls.Config) *websocket.DialOpti
 // Caller-supplied ClientSessionCache and MinVersion are overwritten;
 // other fields (notably InsecureSkipVerify for mock-relay tests) are
 // preserved.
+//
+// CurvePreferences defaults to relayCurvePreferences (P-384-first,
+// see that var's doc) when base.CurvePreferences is empty, to avoid
+// a one-RTT HelloRetryRequest from Azure Relay on every cold dial. A
+// caller-supplied non-empty CurvePreferences slice is preserved — but
+// any list whose default-order first survivor is not CurveP384 will
+// reintroduce the HRR against real Azure Relay.
 func tlsConfigForDial(base *tls.Config) *tls.Config {
 	var cfg *tls.Config
 	if base != nil {
@@ -99,6 +155,9 @@ func tlsConfigForDial(base *tls.Config) *tls.Config {
 	}
 	cfg.ClientSessionCache = sessionCache
 	cfg.MinVersion = tls.VersionTLS13
+	if len(cfg.CurvePreferences) == 0 {
+		cfg.CurvePreferences = relayCurvePreferences
+	}
 	return cfg
 }
 

--- a/internal/relay/client_test.go
+++ b/internal/relay/client_test.go
@@ -5,6 +5,7 @@ import (
 	"crypto/tls"
 	"net/http"
 	"net/http/httptest"
+	"slices"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -64,6 +65,49 @@ func TestTLSConfigForDial(t *testing.T) {
 		base.InsecureSkipVerify = true
 		if cfg.InsecureSkipVerify {
 			t.Error("returned cfg shares mutable state with base — Clone() not applied")
+		}
+	})
+
+	t.Run("nil base installs relayCurvePreferences", func(t *testing.T) {
+		cfg := tlsConfigForDial(nil)
+		if !slices.Equal(cfg.CurvePreferences, relayCurvePreferences) {
+			t.Errorf("CurvePreferences = %v, want %v", cfg.CurvePreferences, relayCurvePreferences)
+		}
+	})
+
+	t.Run("empty CurvePreferences populated with relayCurvePreferences", func(t *testing.T) {
+		base := &tls.Config{CurvePreferences: []tls.CurveID{}}
+		cfg := tlsConfigForDial(base)
+		if !slices.Equal(cfg.CurvePreferences, relayCurvePreferences) {
+			t.Errorf("CurvePreferences = %v, want %v (empty slice should be treated as unset)", cfg.CurvePreferences, relayCurvePreferences)
+		}
+	})
+
+	t.Run("caller-supplied CurvePreferences preserved verbatim", func(t *testing.T) {
+		caller := []tls.CurveID{tls.X25519, tls.CurveP256}
+		base := &tls.Config{CurvePreferences: caller}
+		cfg := tlsConfigForDial(base)
+		if !slices.Equal(cfg.CurvePreferences, caller) {
+			t.Errorf("CurvePreferences = %v, want %v (caller value must not be overridden)", cfg.CurvePreferences, caller)
+		}
+	})
+
+	t.Run("relayCurvePreferences is exactly [CurveP384]", func(t *testing.T) {
+		// Guards two invariants:
+		//
+		//  1. CurveP384 is the only allowed group, so Go (Azure
+		//     Relay's HRR-avoidance fix depends on this) has no
+		//     choice but to send a key_share for P-384 (or for
+		//     a hybrid whose fallback share is P-384).
+		//
+		//  2. No curve has been added that sorts before CurveP384
+		//     in Go's defaultCurvePreferences (X25519MLKEM768,
+		//     SecP256r1MLKEM768, SecP384r1MLKEM1024, X25519,
+		//     CurveP256), which would win the "default-order first
+		//     survivor" race and reintroduce the HRR.
+		want := []tls.CurveID{tls.CurveP384}
+		if !slices.Equal(relayCurvePreferences, want) {
+			t.Errorf("relayCurvePreferences = %v, want %v", relayCurvePreferences, want)
 		}
 	})
 }
@@ -266,6 +310,77 @@ func TestWSDialOptionsSessionResumption(t *testing.T) {
 	for _, n := range resumedOn {
 		if n == 1 {
 			t.Errorf("first dial reported DidResume — impossible without prior cache state")
+		}
+	}
+}
+
+// TestWSDialOptionsAdvertisesP384First asserts the end-to-end
+// behavior that makes the Azure Relay HelloRetryRequest fix work: a
+// dial via WSDialOptions with no caller-supplied CurvePreferences
+// must produce a ClientHello whose supported_groups extension lists
+// CurveP384 first. Per Go 1.24+ documented behavior, the first
+// supported group is the one the client sends an initial key_share
+// for; this test relies on that invariant rather than parsing the
+// raw ClientHello key_share extension.
+//
+// Uses a single dial against a fresh httptest TLS server to avoid
+// session resumption (a resumed handshake might skip the curve
+// selection path entirely).
+func TestWSDialOptionsAdvertisesP384First(t *testing.T) {
+	var (
+		mu  sync.Mutex
+		chi *tls.ClientHelloInfo
+	)
+
+	srv := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ws, err := websocket.Accept(w, r, nil)
+		if err != nil {
+			return
+		}
+		_ = ws.Close(websocket.StatusNormalClosure, "ok")
+	}))
+	// httptest.NewTLSServer attaches a default TLSConfig; we need to
+	// install GetConfigForClient before Start so it captures the
+	// first (and only) ClientHello.
+	srv.TLS = &tls.Config{
+		GetConfigForClient: func(info *tls.ClientHelloInfo) (*tls.Config, error) {
+			mu.Lock()
+			chi = info
+			mu.Unlock()
+			return nil, nil
+		},
+	}
+	srv.StartTLS()
+	t.Cleanup(srv.Close)
+
+	//nolint:gosec // test server uses self-signed cert
+	baseTLS := &tls.Config{InsecureSkipVerify: true}
+	wssURL := "wss://" + strings.TrimPrefix(srv.URL, "https://")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	ws, _, err := websocket.Dial(ctx, wssURL, WSDialOptions(nil, baseTLS))
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	_, _, _ = ws.Read(ctx)
+	_ = ws.CloseNow()
+
+	mu.Lock()
+	defer mu.Unlock()
+	if chi == nil {
+		t.Fatal("GetConfigForClient was not invoked — server did not see a ClientHello")
+	}
+	if len(chi.SupportedCurves) == 0 {
+		t.Fatal("ClientHello SupportedCurves is empty")
+	}
+	if chi.SupportedCurves[0] != tls.CurveP384 {
+		t.Errorf("ClientHello SupportedCurves[0] = %v, want CurveP384 (Azure Relay would HRR otherwise); full list = %v", chi.SupportedCurves[0], chi.SupportedCurves)
+	}
+	for _, c := range chi.SupportedCurves {
+		switch c {
+		case tls.X25519MLKEM768, tls.SecP256r1MLKEM768, tls.SecP384r1MLKEM1024, tls.X25519, tls.CurveP256:
+			t.Errorf("ClientHello SupportedCurves contains %v, which sorts before CurveP384 in Go's defaultCurvePreferences and would reintroduce the HRR; full list = %v", c, chi.SupportedCurves)
 		}
 	}
 }


### PR DESCRIPTION
## Problem

Cold relay dials to Azure Relay take an extra TLS round trip. A packet capture against the live frontend shows two `ClientHello` / `ServerHello` exchanges per handshake: the server replies to our first `ClientHello` with a TLS 1.3 HelloRetryRequest (HRR) naming `secp384r1`, the client retries with a P-384 key_share, and only then does the real `ServerHello` flight arrive. Every cold dial — control channel, bridge, arc — pays for this.

The cause is the curve Go offers in the initial `key_share`. Azure Relay prefers P-384, but Go's default `supportedCurves` list leads with `X25519MLKEM768` and `X25519`, so the first `key_share` is something Azure cannot use.

## Fix

In `internal/relay/client.go`'s `tlsConfigForDial`, install a single-curve allowlist (`[CurveP384]`) when the caller has not supplied their own `CurvePreferences`. Azure now finds a usable `key_share` in the first `ClientHello` and the handshake completes in one RTT.

## Impact

- One TLS round trip removed from every cold dial to Azure Relay (control channel, bridge, arc endpoint).
- No behavior change on warm dials (session resumption already skips the full handshake).
- Caller-supplied non-empty `CurvePreferences` slices are preserved verbatim.

## Trade-off

This opts the relay channel out of Go's X25519MLKEM768 post-quantum hybrid. Azure Relay clearly does not support that yet (it would not be HRR'ing to P-384 if it did), and the only available alternative — `SecP384r1MLKEM1024` — would bloat the `ClientHello` by ~1.5 KB across multiple TCP segments, defeating the latency goal this change exists to achieve. Worth revisiting if/when Azure Relay advertises PQ support.

## Tests

- `TestTLSConfigForDial` — nine subtests covering nil/empty/caller-supplied `tls.Config` permutations and an exact-equality guard on `relayCurvePreferences`.
- `TestWSDialOptionsAdvertisesP384First` — end-to-end test driving the real `WSDialOptions` dialer through `httptest` and asserting `ClientHelloInfo.SupportedCurves[0] == tls.CurveP384`.