### PR TITLE
Add mockrelay delay-profile registry and E2E_DELAY toggle

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -27,9 +27,9 @@ in roughly the walltime of the slower backend.
 
 ### Environment knobs
 
-| Variable    | Backend | Values                          | Effect                                                                                                                                            |
-| ----------- | ------- | ------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `E2E_AUTH`  | Azure   | `entra`, `sas`, unset (both)    | Pins the auth axis to one method.                                                                                                                 |
+| Variable    | Backend | Values                                       | Effect                                                                                                                                                          |
+| ----------- | ------- | -------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `E2E_AUTH`  | Azure   | `entra`, `sas`, unset (both)                 | Pins the auth axis to one method.                                                                                                                               |
 | `E2E_DELAY` | mock    | a registered profile name, unset (`default`) | Selects the mockrelay synthetic-delay profile for `TestE2E_Mock`. Names come from the registry in `mockrelay/server/delay_profile.go` (e.g. `zero`, `default`). |
 
 ```bash

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -25,6 +25,18 @@ e2e/
 provisions per-test hycos), so `make -j2 e2e` runs them in parallel and finishes
 in roughly the walltime of the slower backend.
 
+### Environment knobs
+
+| Variable    | Backend | Values                          | Effect                                                                                                                                            |
+| ----------- | ------- | ------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `E2E_AUTH`  | Azure   | `entra`, `sas`, unset (both)    | Pins the auth axis to one method.                                                                                                                 |
+| `E2E_DELAY` | mock    | a registered profile name, unset (`default`) | Selects the mockrelay synthetic-delay profile for `TestE2E_Mock`. Names come from the registry in `mockrelay/server/delay_profile.go` (e.g. `zero`, `default`). |
+
+```bash
+# Run the mock scenarios with no synthetic relay delay:
+E2E_DELAY=zero make e2e-mock
+```
+
 ## Adding tests
 
 Use the testing-discipline taxonomy below to pick where a new test lives.

--- a/e2e/backends/mock/README.md
+++ b/e2e/backends/mock/README.md
@@ -9,6 +9,17 @@ make e2e-mock
 
 Runs anywhere Go runs. No subscription, no `az login`, no per-developer infra.
 
+By default `TestE2E_Mock` uses the wire-faithful `default` delay profile so
+timing thresholds calibrated against Azure also fire here. Override it for a
+single run with the `E2E_DELAY` environment variable, naming any profile from
+the registry in `mockrelay/server/delay_profile.go`:
+
+```bash
+E2E_DELAY=zero make e2e-mock   # no synthetic relay delay (fast)
+```
+
+An unrecognised name fails the test loudly and prints the known profile names.
+
 ## What it is
 
 `backend.go` exports `MockBackend`, an implementation of

--- a/e2e/backends/mock/e2e_test.go
+++ b/e2e/backends/mock/e2e_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/philsphicas/aztunnel/e2e/backends/mock"
 	"github.com/philsphicas/aztunnel/e2e/scenarios"
-	"github.com/philsphicas/aztunnel/mockrelay/server"
 )
 
 // TestE2E_Mock runs the shared e2e scenarios against the in-process
@@ -19,8 +18,11 @@ import (
 // DelayProfileDefault is the recommended profile for e2e-style runs:
 // it approximates the wireshark-observed wall-clock shape from real
 // Azure Relay captures so timing thresholds calibrated against Azure
-// also fire against the mock.
+// also fire against the mock. Override the profile for a single run
+// with the E2E_DELAY environment variable (e.g. `E2E_DELAY=zero`); see
+// delayProfileFromEnv and the mockrelay profile registry for the set
+// of selectable names.
 func TestE2E_Mock(t *testing.T) {
-	b := mock.MockBackend{DelayProfile: server.DelayProfileDefault}
+	b := mock.MockBackend{DelayProfile: delayProfileFromEnv(t)}
 	scenarios.RunAllScenarios(t, &b)
 }

--- a/e2e/backends/mock/env_test.go
+++ b/e2e/backends/mock/env_test.go
@@ -1,0 +1,35 @@
+//go:build e2e
+
+package mock_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/philsphicas/aztunnel/mockrelay/server"
+)
+
+// delayProfileFromEnv resolves the DelayProfile for the mock e2e
+// scenario run from the E2E_DELAY environment variable, mirroring the
+// E2E_AUTH knob the Azure backend uses to pin its auth axis.
+//
+// Unset (or empty) selects "default" — the wire-faithful profile the
+// e2e timing thresholds are calibrated against — so the historical
+// behaviour of TestE2E_Mock is unchanged. Any other value is looked up
+// in the mockrelay profile registry (server.ProfileByName); an
+// unrecognised name fails the test loudly with the list of known
+// profiles, so a typo never silently falls through to the wrong timing
+// model. Adding a profile to the registry makes it selectable here
+// with no change to this helper.
+func delayProfileFromEnv(t testing.TB) server.DelayProfile {
+	t.Helper()
+	name := os.Getenv("E2E_DELAY")
+	if name == "" {
+		name = "default"
+	}
+	p, err := server.ProfileByName(name)
+	if err != nil {
+		t.Fatalf("E2E_DELAY: %v", err)
+	}
+	return p
+}

--- a/mockrelay/server/delay_profile.go
+++ b/mockrelay/server/delay_profile.go
@@ -3,6 +3,8 @@ package server
 import (
 	"context"
 	"fmt"
+	"sort"
+	"strings"
 	"time"
 )
 
@@ -102,6 +104,44 @@ var DelayProfileDefault = DelayProfile{
 	DNSLookup:         40 * time.Millisecond,
 	AuthInternal:      10 * time.Millisecond,
 	MatchMakeInternal: 50 * time.Millisecond,
+}
+
+// registry is the single source of truth mapping canonical profile
+// names to DelayProfiles. Selection sites — the E2E_DELAY env toggle,
+// docs, and any future CLI or test-matrix axis — resolve through
+// ProfileByName / ProfileNames rather than referencing the package
+// vars directly, so adding a profile is a one-line change here that
+// every consumer picks up automatically. Keep keys lowercase and
+// hyphen-free so they read cleanly as env-var values and sub-test
+// path segments.
+var registry = map[string]DelayProfile{
+	"zero":    DelayProfileZero,
+	"default": DelayProfileDefault,
+}
+
+// ProfileByName returns the named profile from the registry. The error
+// names the unknown profile and lists the known names (sorted) so a
+// typo at a selection site fails loudly instead of silently selecting
+// the wrong timing model.
+func ProfileByName(name string) (DelayProfile, error) {
+	p, ok := registry[name]
+	if !ok {
+		return DelayProfile{}, fmt.Errorf("unknown delay profile %q; known profiles: %s",
+			name, strings.Join(ProfileNames(), ", "))
+	}
+	return p, nil
+}
+
+// ProfileNames returns the registered profile names in sorted order.
+// Drives stable error messages and lets docs or a test-matrix axis
+// enumerate the profiles from the single registry source of truth.
+func ProfileNames() []string {
+	names := make([]string, 0, len(registry))
+	for n := range registry {
+		names = append(names, n)
+	}
+	sort.Strings(names)
+	return names
 }
 
 // WithDelayProfile arms the per-lane synthetic-delay model. The zero

--- a/mockrelay/server/delay_profile_test.go
+++ b/mockrelay/server/delay_profile_test.go
@@ -8,6 +8,8 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"runtime"
+	"slices"
+	"sort"
 	"strings"
 	"testing"
 	"time"
@@ -432,6 +434,70 @@ func TestDelayProfile_AuthFailurePaysLane(t *testing.T) {
 		(hopsHandshake+hopsWSGet+hopsResponse)*fastProfile.LLatency +
 		fastProfile.AuthInternal
 	withinTolerance(t, "401 auth-fail lane", elapsed, predicted, predicted+500*time.Millisecond)
+}
+
+// TestProfileRegistry_KnownNames asserts the registry resolves its
+// canonical names to the expected profiles and that ProfileNames
+// returns them sorted. Adding a profile to the registry should extend
+// — not break — these expectations.
+func TestProfileRegistry_KnownNames(t *testing.T) {
+	cases := map[string]DelayProfile{
+		"zero":    DelayProfileZero,
+		"default": DelayProfileDefault,
+	}
+	for name, want := range cases {
+		got, err := ProfileByName(name)
+		if err != nil {
+			t.Fatalf("ProfileByName(%q): unexpected error %v", name, err)
+		}
+		if got != want {
+			t.Errorf("ProfileByName(%q) = %+v, want %+v", name, got, want)
+		}
+	}
+
+	names := ProfileNames()
+	if !sort.StringsAreSorted(names) {
+		t.Errorf("ProfileNames() not sorted: %v", names)
+	}
+	for name := range cases {
+		if !slices.Contains(names, name) {
+			t.Errorf("ProfileNames() %v missing %q", names, name)
+		}
+	}
+}
+
+// TestProfileByName_UnknownIsLoud asserts an unregistered name yields
+// an error naming the bad input and listing the known profiles, so a
+// typo at a selection site fails loudly rather than silently picking
+// the wrong timing model.
+func TestProfileByName_UnknownIsLoud(t *testing.T) {
+	_, err := ProfileByName("does-not-exist")
+	if err == nil {
+		t.Fatalf("ProfileByName(unknown): expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "does-not-exist") {
+		t.Errorf("error %q does not name the unknown profile", err.Error())
+	}
+	for _, name := range ProfileNames() {
+		if !strings.Contains(err.Error(), name) {
+			t.Errorf("error %q does not list known profile %q", err.Error(), name)
+		}
+	}
+}
+
+// TestProfileRegistry_AllValid asserts every registered profile passes
+// WithDelayProfile validation, so a future profile with a negative
+// field is caught by this unit test rather than at e2e selection time.
+func TestProfileRegistry_AllValid(t *testing.T) {
+	for _, name := range ProfileNames() {
+		p, err := ProfileByName(name)
+		if err != nil {
+			t.Fatalf("ProfileByName(%q): %v", name, err)
+		}
+		if err := p.validate(); err != nil {
+			t.Errorf("registered profile %q fails validation: %v", name, err)
+		}
+	}
 }
 
 // runAcceptEchoer reads accept frames from a listener control WS,


### PR DESCRIPTION
## Summary

Adds a named registry of mockrelay synthetic delay profiles as a single source of truth, and lets the mock e2e scenario run select one via the `E2E_DELAY` environment variable.

Previously the mock e2e entrypoint hard-coded `server.DelayProfileDefault`, and each profile was a bare package var referenced directly by every consumer. Adding more profiles would mean hand-maintaining the same list across test entrypoints, docs, and error messages — which drifts.

## What this enables

- Select the delay profile for `TestE2E_Mock` without editing source:
  ```bash
  E2E_DELAY=zero make e2e-mock     # no synthetic relay delay
  make e2e-mock                    # unset → default (unchanged)
  ```
- `ProfileByName` / `ProfileNames` resolve profiles by canonical name (`zero`, `default`). Selection sites go through the registry instead of referencing package vars directly.
- An unrecognised `E2E_DELAY` value fails the test loudly and lists the known profiles, so a typo never silently selects the wrong timing model.
- Unset preserves the prior `default` profile — existing runs are unchanged.

## Adding a profile later

A one-line registry entry is automatically selectable via `E2E_DELAY`, listed in error messages, validated by `TestProfileRegistry_AllValid`, and surfaced in the docs guidance.

The `E2E_DELAY` knob mirrors the existing `E2E_AUTH` convention used by the Azure backend. Documented in `e2e/README.md` and `e2e/backends/mock/README.md`.