### PR TITLE
Fan mock e2e scenarios over a composable auth × delay matrix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ LDFLAGS  := -ldflags "-X main.version=$(VERSION)"
 CGO    := $(shell go env CGO_ENABLED)
 RACE   := $(if $(filter 1,$(CGO)),-race,)
 
-.PHONY: build test cover lint clean install docker docker-alpine docker-bookworm fmt fmt-check e2e e2e-mock e2e-azure e2e-docker e2e-setup e2e-attach e2e-status e2e-clean e2e-grant e2e-ci e2e-janitor perf perf-mock perf-azure vulncheck bench bench-azure check-installable help
+.PHONY: build test cover lint clean install docker docker-alpine docker-bookworm fmt fmt-check e2e e2e-mock e2e-mock-fast e2e-mock-matrix e2e-azure e2e-docker e2e-setup e2e-attach e2e-status e2e-clean e2e-grant e2e-ci e2e-janitor perf perf-mock perf-azure vulncheck bench bench-azure check-installable help
 
 .DEFAULT_GOAL := help
 
@@ -94,8 +94,14 @@ fmt-check: ## Check formatting (same as CI)
 # timeout still covers the whole job (checkout, build, azrelay,
 # backend) so the workflow envelope remains the outer cap if the
 # preceding steps consume too much of it. See golang/go#24929.
-e2e-mock: ## Run e2e scenarios against the in-process mock relay
+e2e-mock: ## Run e2e scenarios against the in-process mock relay (both auth methods, default delay profile)
 	cd e2e && go test -tags=e2e -timeout=20m -v ./backends/mock/...
+
+e2e-mock-fast: ## Run mock e2e as fast as possible: zero delay profile, no synthetic token-acquisition cost (both auth methods)
+	cd e2e && E2E_DELAY=zero go test -tags=e2e -timeout=20m -v ./backends/mock/...
+
+e2e-mock-matrix: ## Run mock e2e over the full auth x delay-profile matrix (both auth methods x every registered profile)
+	cd e2e && E2E_DELAY=all go test -tags=e2e -timeout=40m -v ./backends/mock/...
 
 e2e-azure: build ## Run e2e scenarios against a real Azure Relay namespace (configure via `make e2e-setup`)
 	@cd e2e && { \

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -15,11 +15,13 @@ e2e/
 
 ## Make targets
 
-| Target           | Backend     | Setup required                | Use when                                   |
-| ---------------- | ----------- | ----------------------------- | ------------------------------------------ |
-| `make e2e-mock`  | mock        | none                          | local iteration; CI sanity gate            |
-| `make e2e-azure` | Azure Relay | `make e2e-setup` + `az login` | smoke against the real relay control plane |
-| `make e2e`       | both        | both                          | full local validation before opening a PR  |
+| Target                 | Backend     | Setup required                | Use when                                            |
+| ---------------------- | ----------- | ----------------------------- | --------------------------------------------------- |
+| `make e2e-mock`        | mock        | none                          | local iteration; CI sanity gate (both auth methods) |
+| `make e2e-mock-fast`   | mock        | none                          | quickest mock signal: zero delay, no token cost     |
+| `make e2e-mock-matrix` | mock        | none                          | full auth × delay-profile matrix                    |
+| `make e2e-azure`       | Azure Relay | `make e2e-setup` + `az login` | smoke against the real relay control plane          |
+| `make e2e`             | both        | both                          | full local validation before opening a PR           |
 
 `make e2e` runs both targets. They share no infra (mock is in-process; Azure
 provisions per-test hycos), so `make -j2 e2e` runs them in parallel and finishes
@@ -27,15 +29,36 @@ in roughly the walltime of the slower backend.
 
 ### Environment knobs
 
-| Variable    | Backend | Values                                       | Effect                                                                                                                                                          |
-| ----------- | ------- | -------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `E2E_AUTH`  | Azure   | `entra`, `sas`, unset (both)                 | Pins the auth axis to one method.                                                                                                                               |
-| `E2E_DELAY` | mock    | a registered profile name, unset (`default`) | Selects the mockrelay synthetic-delay profile for `TestE2E_Mock`. Names come from the registry in `mockrelay/server/delay_profile.go` (e.g. `zero`, `default`). |
+| Variable    | Backend      | Values                                                               | Effect                                                                                                                                                                                                                                                                                                  |
+| ----------- | ------------ | -------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `E2E_AUTH`  | Azure + mock | `entra`, `sas`, unset (both)                                         | Pins the auth axis to one method; unset runs both. For the mock, the `entra` cell additionally models the cold token-acquisition cost (see `E2E_DELAY`).                                                                                                                                                |
+| `E2E_DELAY` | mock         | unset (`default`), `all`, or a comma-separated list of profile names | Selects which mockrelay synthetic-delay profiles `TestE2E_Mock` runs. Names come from the registry in `mockrelay/server/delay_profile.go` (e.g. `zero`, `default`). Two or more profiles fan the suite out over a `delay` matrix axis. The `zero` profile also zeroes the entra token-acquisition cost. |
 
 ```bash
-# Run the mock scenarios with no synthetic relay delay:
+# Run the mock scenarios with no synthetic relay delay (and no entra
+# token-acquisition cost) — the fastest signal. Same as `make e2e-mock-fast`:
 E2E_DELAY=zero make e2e-mock
+
+# Fan the whole suite out over every registered profile (`make e2e-mock-matrix`):
+E2E_DELAY=all make e2e-mock
+
+# Run an explicit subset (sub-test paths gain a /<profile>/ layer):
+E2E_DELAY=zero,default make e2e-mock
+
+# Pin a single auth method (applies to both mock and Azure):
+E2E_AUTH=entra make e2e-mock
 ```
+
+`E2E_AUTH` and `E2E_DELAY` are independent dimensions that compose into one
+matrix: `TestE2E_Mock` runs once per (auth, delay) cell. A dimension with a
+single selected value (including the unset defaults — both auth methods, the
+`default` profile) adds no sub-test layer for that dimension, so
+`-run TestE2E_Mock/Performance/...` selectors keep matching. A dimension with two
+or more values nests scenarios under `TestE2E_Mock/<auth>/<profile>/<scenario>`
+(auth outermost, mirroring the Azure backend). Per-profile latency thresholds
+scale with the profile's predicted cost, so slower profiles don't mask
+regressions, and the entra cold-start budget widens only when the profile models
+a token-acquisition cost.
 
 ## Adding tests
 

--- a/e2e/backends/azure/helpers_test.go
+++ b/e2e/backends/azure/helpers_test.go
@@ -97,6 +97,24 @@ func requireProvider(t testing.TB) *azrelay.Provider {
 	return relayProvider
 }
 
+// hycoLabel renders a provisioned hyco set for logging, covering the
+// three auth modes the azrelay provider supports: a full entra+sas
+// pair, an Entra-only lease (E2E_AUTH=entra), and a SAS-only lease
+// (E2E_AUTH=sas). The mode is stated positively rather than as a
+// "skipped" side effect, and the entra-only and sas-only forms mirror
+// each other. Both names empty is degenerate and not expected to
+// reach a log site.
+func hycoLabel(entra, sas string) string {
+	switch {
+	case entra != "" && sas != "":
+		return fmt.Sprintf("pair %s, %s", entra, sas)
+	case entra != "":
+		return fmt.Sprintf("%s (Entra-only mode)", entra)
+	default:
+		return fmt.Sprintf("%s (SAS-only mode)", sas)
+	}
+}
+
 // requireDedicatedHyco provisions a fresh (entra, sas) hyco pair for
 // the calling test, registers a t.Cleanup that tears the pair down,
 // and returns its connection metadata in the legacy *relayEnv shape.
@@ -150,11 +168,7 @@ func requireDedicatedHyco(t testing.TB) *relayEnv {
 	}
 
 	entra, sas := tok.HycoNames()
-	if entra == "" {
-		t.Logf("provisioned dedicated hyco: %s (entra skipped, SAS-only mode)", sas)
-	} else {
-		t.Logf("provisioned dedicated hyco pair: %s, %s", entra, sas)
-	}
+	t.Logf("provisioned dedicated hyco %s", hycoLabel(entra, sas))
 
 	t.Cleanup(func() {
 		ctx, cancel := context.WithTimeout(context.Background(), hycoTeardownTimeout)
@@ -163,11 +177,7 @@ func requireDedicatedHyco(t testing.TB) *relayEnv {
 			// Log only — the janitor will reap anything we miss,
 			// and failing the test on cleanup errors would mask
 			// the actual test outcome.
-			if entra == "" {
-				t.Logf("teardown dedicated hyco %s: %v", sas, err)
-			} else {
-				t.Logf("teardown dedicated hyco pair %s/%s: %v", entra, sas, err)
-			}
+			t.Logf("teardown dedicated hyco %s: %v", hycoLabel(entra, sas), err)
 		}
 	})
 
@@ -241,11 +251,7 @@ func leaseSharedHyco(tb testing.TB) *relayEnv {
 		tb.Fatalf("provision shared bench hyco pair: %v", err)
 	}
 	entra, sas := tok.HycoNames()
-	if entra == "" {
-		tb.Logf("leased shared bench hyco: %s (entra skipped, SAS-only mode)", sas)
-	} else {
-		tb.Logf("leased shared bench hyco pair: %s, %s", entra, sas)
-	}
+	tb.Logf("leased shared bench hyco %s", hycoLabel(entra, sas))
 	benchLeaseTok = tok
 	benchLeaseEnv = resultToEnv(tok.Result())
 	return benchLeaseEnv
@@ -270,11 +276,7 @@ func drainBenchLease() {
 	benchLeaseTok = nil
 	entra, sas := tok.HycoNames()
 	if err := tok.Teardown(ctx); err != nil {
-		if entra == "" {
-			fmt.Fprintf(os.Stderr, "==> e2e: teardown shared bench hyco %s: %v\n", sas, err)
-		} else {
-			fmt.Fprintf(os.Stderr, "==> e2e: teardown shared bench hyco pair %s/%s: %v\n", entra, sas, err)
-		}
+		fmt.Fprintf(os.Stderr, "==> e2e: teardown shared bench hyco %s: %v\n", hycoLabel(entra, sas), err)
 	}
 }
 

--- a/e2e/backends/mock/README.md
+++ b/e2e/backends/mock/README.md
@@ -9,16 +9,34 @@ make e2e-mock
 
 Runs anywhere Go runs. No subscription, no `az login`, no per-developer infra.
 
-By default `TestE2E_Mock` uses the wire-faithful `default` delay profile so
-timing thresholds calibrated against Azure also fire here. Override it for a
-single run with the `E2E_DELAY` environment variable, naming any profile from
-the registry in `mockrelay/server/delay_profile.go`:
+`TestE2E_Mock` runs over two independent, composable dimensions, mirroring the
+Azure backend:
+
+- **Auth method** (`E2E_AUTH`): unset runs both `sas` and `entra`; pin one with
+  `E2E_AUTH=sas` or `E2E_AUTH=entra`. The `entra` cell drives a real
+  `EntraTokenProvider` (backed by a fake credential) so the production token
+  cache is exercised end-to-end, and pays a one-off cold token-acquisition cost
+  on the first dial.
+- **Delay profile** (`E2E_DELAY`): unset uses the wire-faithful `default`
+  profile so timing thresholds calibrated against Azure also fire here. The
+  profile also owns the entra cold-acquisition cost (`TokenAcquire`), so the
+  `zero` profile is instant everywhere — entra included.
 
 ```bash
-E2E_DELAY=zero make e2e-mock   # no synthetic relay delay (fast)
+make e2e-mock                         # both auth methods × default profile
+make e2e-mock-fast                    # both auth methods × zero profile (fastest)
+make e2e-mock-matrix                  # both auth methods × every registered profile
+E2E_DELAY=zero make e2e-mock          # zero profile, no synthetic relay delay
+E2E_DELAY=all make e2e-mock           # fan out over every registered profile
+E2E_DELAY=zero,default make e2e-mock  # explicit profile subset
+E2E_AUTH=entra make e2e-mock          # pin the entra auth method
 ```
 
-An unrecognised name fails the test loudly and prints the known profile names.
+A dimension with a single value adds no sub-test layer; two or more nest
+scenarios under `TestE2E_Mock/<auth>/<profile>/<scenario>` (auth outermost).
+Per-profile latency thresholds scale with the profile's predicted cost, and the
+entra cold-start budget widens only when the profile models a token-acquisition
+cost. An unrecognised name fails the test loudly and prints the known names.
 
 ## What it is
 
@@ -38,13 +56,17 @@ exercised against Azure Relay.
 
 ## Files
 
-- `backend.go` — `MockBackend` and its `Setup`/`Cell`/`Axes` implementation.
+- `backend.go` — `MockBackend` and its `Setup`/`Cell`/`Axes` implementation,
+  including the composable auth + delay matrix (`NewMatrixBackend`).
 - `e2e_test.go` — `TestE2E_Mock`, runs `scenarios.RunAllScenarios`.
+- `env_test.go` — parses `E2E_AUTH` / `E2E_DELAY` into the matrix backend.
 - `bench_test.go` — `BenchmarkE2E_Mock`, runs `scenarios.RunAllBenchmarks`.
 - `emulates_test.go` — `TestMockEmulates_*` tests asserting wire-level parity
-  with Azure on specific scenarios (added in follow-up work).
+  with Azure on specific scenarios.
+- `entracred.go` / `entracred_test.go` — the fake Entra credential and the
+  `TestMockEmulates_EntraTokenAcquisitionDelay` cold-start proof.
 - `features_test.go` — `TestMockFeature_*` tests asserting mock-only knobs
-  (e.g. rendezvous-delay overrides; added in follow-up work).
+  (e.g. the delay-profile matrix wiring).
 
 ## Build tag
 

--- a/e2e/backends/mock/backend.go
+++ b/e2e/backends/mock/backend.go
@@ -15,6 +15,7 @@ import (
 	"crypto/rand"
 	"crypto/tls"
 	"encoding/hex"
+	"fmt"
 	"io"
 	"log/slog"
 	"net"
@@ -37,17 +38,14 @@ import (
 
 // Auth method names for the MockBackend auth axis. They mirror the
 // `provider` metric label values (relay.ProviderSAS / ProviderEntra)
-// so a cell's name and its token-fetch metric line up.
+// so a cell's name and its token-fetch metric line up. They are
+// exported because the e2e entry point (env_test.go) and the feature
+// tests (features_test.go) live in the external mock_test package and
+// pin auth methods by name.
 const (
-	authSAS   = "sas"
-	authEntra = "entra"
+	AuthSAS   = "sas"
+	AuthEntra = "entra"
 )
-
-// defaultEntraAcquireDelay is the synthetic cold token-acquisition
-// latency the entra cell models, approximating the AAD round trip a
-// real aztunnel process pays on its first dial. Calibrated against
-// observed Azure entra-vs-sas cold-start divergence (~450 ms).
-const defaultEntraAcquireDelay = 450 * time.Millisecond
 
 // MockBackend implements scenarios.Backend by standing up a mock
 // relay server + aztunnel listener(s) + aztunnel sender(s) all in the
@@ -56,8 +54,9 @@ const defaultEntraAcquireDelay = 450 * time.Millisecond
 // `go test ./mockrelay/...` job.
 //
 // The zero value runs SAS-only with no axis layer (what bench_test.go
-// wants). Construct via NewAuthAxisBackend to opt into the {sas, entra}
-// auth axis that mirrors the Azure backend's matrix.
+// wants). Construct via NewMatrixBackend to fan over the {sas, entra}
+// auth axis and/or a delay-profile axis, mirroring the Azure backend's
+// matrix.
 type MockBackend struct {
 	// DelayProfile parameterizes the synthetic per-step sleeps the
 	// mock relay applies on every leg of the rendezvous protocol.
@@ -71,120 +70,220 @@ type MockBackend struct {
 	// wireshark-observed wall-clock shape.
 	DelayProfile server.DelayProfile
 
-	// axis is non-nil only on a factory backend (built by
-	// NewAuthAxisBackend); the harness enumerates it to render the
-	// auth sub-path layer. Cell-pinned backends carry axis == nil.
-	axis *mockAuthAxis
-
-	// authName is the auth method this (pinned) backend speaks:
-	// authSAS (the zero value / default) or authEntra. It selects the
-	// token provider built in newTokenProvider — and, for the entra
-	// cell, drives the modelled cold token-acquisition cost.
+	// authName is the auth method this backend speaks: AuthSAS (the
+	// zero value / default) or AuthEntra. It selects the token provider
+	// built in newTokenProvider; on the entra path the one-off cold
+	// token-acquisition cost is taken from DelayProfile.TokenAcquire.
 	authName string
 
-	// entraAcquireDelay is the synthetic cold-acquisition latency the
-	// entra cell's fake credential sleeps on a cache miss. Zero means
-	// defaultEntraAcquireDelay.
-	entraAcquireDelay time.Duration
+	// authAxis and delayAxis put this backend in factory mode for the
+	// dimension they describe: when non-nil, Axes() advertises that
+	// dimension and Cell() pins it per cell. They are set only by
+	// NewMatrixBackend, and only for a dimension that varies (more than
+	// one value). A single-valued dimension is pre-pinned into authName
+	// / DelayProfile and carries a nil axis, so it adds no sub-test
+	// layer. A directly-constructed MockBackend{...} has both nil and
+	// therefore no axes, so the historical pinned usage (features_test,
+	// entracred_test, bench_test) is unchanged.
+	authAxis  *namedAxis
+	delayAxis *namedAxis
 }
 
-// mockAuthAxis is the scenarios.Axis the MockBackend varies over when
-// constructed via NewAuthAxisBackend. It mirrors the Azure backend's
-// authAxis so both backends render the same {sas, entra} sub-paths.
-type mockAuthAxis struct {
+// namedAxis is a scenarios.Axis with a fixed name and value set. The
+// mock backend uses one instance per matrix dimension it varies over
+// (auth, delay). The values are the cell keys the harness passes back
+// to Cell: auth-method names for the auth axis, registry profile names
+// for the delay axis.
+type namedAxis struct {
+	name   string
 	values []string
 }
 
-func (*mockAuthAxis) Name() string       { return "auth" }
-func (a *mockAuthAxis) Values() []string { return a.values }
+func (a *namedAxis) Name() string { return a.name }
 
-// NewAuthAxisBackend returns a factory MockBackend whose Axes() lists
-// the {sas, entra} auth methods and whose Cell(values) returns a fresh
-// backend pinned to values["auth"]. Use this from the e2e entry point
-// (TestE2E_Mock) so the mock runs the full scenario suite once per auth
-// method, mirroring the Azure backend's matrix. profile is carried
-// through to every pinned cell.
-func NewAuthAxisBackend(profile server.DelayProfile) *MockBackend {
-	return &MockBackend{
-		DelayProfile: profile,
-		axis:         &mockAuthAxis{values: []string{authSAS, authEntra}},
-	}
+// Values returns a defensive copy so callers (and the harness) cannot
+// mutate the axis's backing slice.
+func (a *namedAxis) Values() []string {
+	out := make([]string, len(a.values))
+	copy(out, a.values)
+	return out
 }
 
-// Name returns the backend identifier (always "mock"). Factory
-// backends surface the auth dimension via the axis t.Run wrapping
-// rather than the name; scenarios and external callers may surface
-// the name in debug output.
+// NewMatrixBackend returns a factory MockBackend that fans the e2e
+// scenario suite over the cartesian product of the named auth methods
+// and delay profiles. Use it from a test entry point (TestE2E_Mock) so
+// the mock runs the full suite once per (auth, delay) cell, mirroring
+// the Azure backend's matrix.
+//
+// Each dimension is advertised as an axis only when it has more than
+// one value; a single-valued dimension is pinned directly (into
+// authName or DelayProfile) and adds no sub-test layer. So
+// NewMatrixBackend([]string{AuthSAS}, []string{"default"}) is a fully
+// pinned backend with no axes, while NewMatrixBackend([]string{AuthSAS,
+// AuthEntra}, []string{"zero", "default"}) advertises both axes (auth
+// outermost, mirroring Azure) for four cells.
+//
+// Panics on an empty list, an unknown auth method, or an unregistered
+// profile — all caller bugs (the E2E_AUTH / E2E_DELAY entry point
+// validates input first).
+func NewMatrixBackend(authNames, delayNames []string) *MockBackend {
+	if len(authNames) == 0 {
+		panic("NewMatrixBackend: authNames must be non-empty")
+	}
+	if len(delayNames) == 0 {
+		panic("NewMatrixBackend: delayNames must be non-empty")
+	}
+	for _, a := range authNames {
+		if a != AuthSAS && a != AuthEntra {
+			panic("NewMatrixBackend: unknown auth method " + a)
+		}
+	}
+	for _, n := range delayNames {
+		if _, err := server.ProfileByName(n); err != nil {
+			panic("NewMatrixBackend: " + err.Error())
+		}
+	}
+
+	b := &MockBackend{}
+	if len(authNames) == 1 {
+		b.authName = authNames[0]
+	} else {
+		b.authAxis = &namedAxis{name: "auth", values: append([]string(nil), authNames...)}
+	}
+	if len(delayNames) == 1 {
+		// ProfileByName already validated this name above.
+		b.DelayProfile, _ = server.ProfileByName(delayNames[0])
+	} else {
+		b.delayAxis = &namedAxis{name: "delay", values: append([]string(nil), delayNames...)}
+	}
+	return b
+}
+
+// Name returns the backend identifier (always "mock"). The harness
+// fills sub-test paths from axis values rather than the name; scenarios
+// and external callers may still surface it in debug output.
 func (*MockBackend) Name() string { return "mock" }
 
-// Axes returns the matrix dimensions this backend varies over.
-// Factory backends (built by NewAuthAxisBackend) return the auth
-// axis; the zero value and pinned backends (returned from Cell)
-// return nil, so the harness runs scenarios directly under the entry
-// point with no axis sub-path layer.
+// Axes returns the matrix dimensions this backend varies over, in the
+// order [auth, delay] (auth outermost, mirroring the Azure backend). A
+// dimension pinned to a single value is omitted, so a fully pinned
+// backend returns nil and the harness runs scenarios directly under the
+// entry point with no axis sub-path layer.
 func (b *MockBackend) Axes() []scenarios.Axis {
-	if b.axis == nil {
-		return nil
+	var axes []scenarios.Axis
+	if b.authAxis != nil {
+		axes = append(axes, b.authAxis)
 	}
-	return []scenarios.Axis{b.axis}
+	if b.delayAxis != nil {
+		axes = append(axes, b.delayAxis)
+	}
+	return axes
 }
 
 // Cell returns a fresh *MockBackend pinned to the cell described by
-// values. Factory backends require values["auth"]; the zero value and
-// pinned backends (axis == nil) accept only an empty values map and
-// return a clone of the receiver. DelayProfile and entraAcquireDelay
-// are carried through to the pinned cell.
+// values. It reads exactly the keys for the axes this backend
+// advertises (see Axes): "auth" when the auth axis is live, "delay"
+// when the delay axis is live. Pinned dimensions are carried through
+// from the receiver. An axis-less backend accepts only an empty map and
+// returns a clone. Panics on a missing key, an unknown value, or an
+// unexpected number of values — all harness-contract violations.
 func (b *MockBackend) Cell(values map[string]string) scenarios.Backend {
-	if b.axis == nil {
-		if len(values) != 0 {
-			panic("MockBackend.Cell: pinned backend accepts no axis values")
+	cell := &MockBackend{
+		DelayProfile: b.DelayProfile,
+		authName:     b.authName,
+	}
+	want := 0
+	if b.authAxis != nil {
+		want++
+		v, ok := values["auth"]
+		if !ok {
+			panic(`MockBackend.Cell: missing required axis key "auth"`)
 		}
-		return &MockBackend{
-			DelayProfile:      b.DelayProfile,
-			authName:          b.authName,
-			entraAcquireDelay: b.entraAcquireDelay,
+		if v != AuthSAS && v != AuthEntra {
+			panic("MockBackend.Cell: unknown auth method " + v)
 		}
+		cell.authName = v
 	}
-	auth, ok := values["auth"]
-	if !ok {
-		panic("MockBackend.Cell: missing required axis key \"auth\"")
+	if b.delayAxis != nil {
+		want++
+		v, ok := values["delay"]
+		if !ok {
+			panic(`MockBackend.Cell: missing required axis key "delay"`)
+		}
+		p, err := server.ProfileByName(v)
+		if err != nil {
+			panic("MockBackend.Cell: " + err.Error())
+		}
+		cell.DelayProfile = p
 	}
-	if len(values) != 1 {
-		panic("MockBackend.Cell: expected exactly one axis value (auth)")
+	if len(values) != want {
+		panic(fmt.Sprintf("MockBackend.Cell: expected %d axis value(s), got %d", want, len(values)))
 	}
-	return &MockBackend{
-		DelayProfile:      b.DelayProfile,
-		authName:          auth,
-		entraAcquireDelay: b.entraAcquireDelay,
-	}
+	return cell
 }
 
-// ConnectLatencyThreshold returns the per-backend connect-latency
-// ceiling for the Performance suite. 3 s leaves comfortable headroom
-// for CI scheduling noise on any reasonable DelayProfile without
-// masking regressions of the order of seconds.
+// mockLatencyFloor is the minimum per-connection latency ceiling. It
+// keeps near-zero profiles stable against CI scheduling jitter; slower
+// profiles scale above it via mockLatencyBudget.
+const mockLatencyFloor = 3 * time.Second
+
+// mockLatencyBudget derives the per-connection latency ceiling for a
+// pinned profile. It is affine in the profile's predicted cost — one
+// cold rendezvous plus one bridge echo, the shape the ConnectLatency
+// scenarios measure (dial -> 1-byte echo) — so a slow profile gets a
+// proportionally larger budget that still trips on a real regression,
+// rather than a flat constant that would mask seconds-scale slowdowns.
+// The 3 s floor preserves the historical budget for the zero/default
+// profiles (both predict well under it).
 //
-// The mock returns one value regardless of cell — MockBackend has
-// no axes, and the DelayProfile field affects timing but is not
-// itself an axis the harness enumerates over.
-func (*MockBackend) ConnectLatencyThreshold() time.Duration {
-	return 3 * time.Second
+// Note: the workload scenarios' warm-request budget (roundBudget in
+// e2e/scenarios/performance.go) is a flat 500 ms per request and is
+// NOT derived from the profile; a profile whose PredictedBridgeEcho
+// exceeds that would need roundBudget made delay-aware. Both currently
+// registered profiles (zero, default) are well within it.
+func mockLatencyBudget(p server.DelayProfile) time.Duration {
+	predicted := p.PredictedRendezvous() + p.PredictedBridgeEcho()
+	budget := predicted*3/2 + 2*time.Second
+	if budget < mockLatencyFloor {
+		budget = mockLatencyFloor
+	}
+	return budget
+}
+
+// ConnectLatencyThreshold returns the per-connection connect-latency
+// ceiling for the Performance suite, derived from this backend's
+// pinned DelayProfile so the budget scales with the profile (see
+// mockLatencyBudget). A directly-constructed zero-profile backend
+// yields the 3 s floor — the historical value.
+func (b *MockBackend) ConnectLatencyThreshold() time.Duration {
+	return mockLatencyBudget(b.DelayProfile)
 }
 
 // ColdStartLatencyThreshold returns the per-backend ceiling for the
-// first connection through a freshly-started sender. For the SAS cell
-// (and the axis-less zero value) the budget matches
-// ConnectLatencyThreshold: every dial pays the same rendezvous delay
-// regardless of order. The entra cell additionally pays a one-off
-// synthetic token-acquisition cost on that first dial (the modelled
-// AAD round trip, absorbed thereafter by the client token cache), so
-// its budget is widened to keep comfortable headroom over the cold
-// fetch on noisy CI.
+// first connection through a freshly-started sender. The warm budget is
+// mockLatencyBudget (every dial pays the same rendezvous delay). The
+// entra path additionally pays a one-off cold token acquisition on that
+// first dial — the modelled AAD round trip in DelayProfile.TokenAcquire,
+// absorbed thereafter by the client token cache — so its budget is
+// widened by entraColdStartHeadroom. With the zero profile TokenAcquire
+// is 0, so entra and sas share the same (floored) cold-start budget,
+// keeping "zero means instant everywhere" intact.
 func (b *MockBackend) ColdStartLatencyThreshold() time.Duration {
-	if b.authName == authEntra {
-		return 5 * time.Second
+	budget := mockLatencyBudget(b.DelayProfile)
+	if b.authName == AuthEntra {
+		budget += entraColdStartHeadroom(b.DelayProfile)
 	}
-	return 3 * time.Second
+	return budget
+}
+
+// entraColdStartHeadroom is the extra cold-start ceiling the entra path
+// gets on top of the warm rendezvous budget, to keep comfortable
+// headroom over the modelled token acquisition on noisy CI. It scales
+// with the profile's TokenAcquire (4x the modelled fetch ~= 1.8 s for
+// the default profile's 450 ms, recovering the historical ~5 s entra
+// ceiling) and is exactly 0 for the zero profile.
+func entraColdStartHeadroom(p server.DelayProfile) time.Duration {
+	return 4 * p.TokenAcquire
 }
 
 // newTokenProvider builds a fresh token provider for one aztunnel
@@ -200,17 +299,14 @@ func (b *MockBackend) ColdStartLatencyThreshold() time.Duration {
 // re-signs locally per call (free). Entra cell: a real
 // relay.EntraTokenProvider backed by fakeEntraCredential, so the
 // production token cache is exercised end-to-end and the modelled
-// ~450 ms acquisition cost is paid only on the cold cache miss.
+// DelayProfile.TokenAcquire cost is paid only on the cold cache miss
+// (zero for the zero profile, so entra is then instant too).
 func (b *MockBackend) newTokenProvider(m *metrics.Metrics) relay.TokenProvider {
 	switch b.authName {
-	case authEntra:
-		delay := b.entraAcquireDelay
-		if delay == 0 {
-			delay = defaultEntraAcquireDelay
-		}
-		inner, _ := newFakeEntraProvider(delay)
+	case AuthEntra:
+		inner, _ := newFakeEntraProvider(b.DelayProfile.TokenAcquire)
 		return relay.WithMetrics(inner, m, relay.ProviderEntra)
-	default: // authSAS or "" (zero value)
+	default: // AuthSAS or "" (zero value)
 		inner := &relay.SASTokenProvider{
 			KeyName: server.DefaultSASKeyName,
 			Key:     server.DefaultSASKey,

--- a/e2e/backends/mock/e2e_test.go
+++ b/e2e/backends/mock/e2e_test.go
@@ -5,7 +5,6 @@ package mock_test
 import (
 	"testing"
 
-	"github.com/philsphicas/aztunnel/e2e/backends/mock"
 	"github.com/philsphicas/aztunnel/e2e/scenarios"
 )
 
@@ -15,20 +14,26 @@ import (
 // TestE2E_Azure in e2e/backends/azure to surface any behavioural
 // divergence between the mock and Azure.
 //
-// The backend is built via NewAuthAxisBackend so the suite runs once
-// per auth method (sas, entra), mirroring the Azure backend's matrix.
-// The entra cell models the client-side token-acquisition cost (a
-// one-off cold AAD round trip, cached thereafter) that real Entra auth
-// pays and SAS does not.
+// The backend is built via mockBackendFromEnv, which composes two
+// independent, env-driven dimensions into one matrix:
 //
-// DelayProfileDefault is the recommended profile for e2e-style runs:
-// it approximates the wireshark-observed wall-clock shape from real
-// Azure Relay captures so timing thresholds calibrated against Azure
-// also fire against the mock. Override the profile for a single run
-// with the E2E_DELAY environment variable (e.g. `E2E_DELAY=zero`); see
-// delayProfileFromEnv and the mockrelay profile registry for the set
-// of selectable names.
+//   - E2E_AUTH selects the auth method(s): unset runs both {sas, entra}
+//     (mirroring the Azure backend), or pin one with E2E_AUTH=sas /
+//     E2E_AUTH=entra. The entra cell models the client-side
+//     token-acquisition cost (a one-off cold AAD round trip, cached
+//     thereafter) that real Entra auth pays and SAS does not — its size
+//     comes from the selected delay profile's TokenAcquire.
+//   - E2E_DELAY selects the delay profile(s): unset runs the
+//     wire-faithful "default" profile (whose wall-clock approximates
+//     wireshark-observed real Azure Relay captures, so timing
+//     thresholds calibrated against Azure also fire against the mock),
+//     "all" runs every registered profile, or pass a comma-separated
+//     list. The "zero" profile disables all synthetic delay, including
+//     the entra token-acquisition cost, for a fast smoke run.
+//
+// A dimension with a single value adds no sub-test layer; with two or
+// more it does (auth outermost, then delay). See env_test.go and the
+// mockrelay profile registry for details.
 func TestE2E_Mock(t *testing.T) {
-	b := mock.NewAuthAxisBackend(delayProfileFromEnv(t))
-	scenarios.RunAllScenarios(t, b)
+	scenarios.RunAllScenarios(t, mockBackendFromEnv(t))
 }

--- a/e2e/backends/mock/entracred_test.go
+++ b/e2e/backends/mock/entracred_test.go
@@ -35,7 +35,9 @@ import (
 //     not. Kept loose (> delay/2) because rendezvous DelayProfile sleeps
 //     and CI scheduling add noise.
 func TestMockEmulates_EntraTokenAcquisitionDelay(t *testing.T) {
-	const acquireDelay = 450 * time.Millisecond
+	// Source the modelled acquisition cost from the default profile so
+	// this PoC and the production newTokenProvider path stay in lockstep.
+	acquireDelay := server.DelayProfileDefault.TokenAcquire
 	const dials = 6
 
 	host, clientOpts := startMockRelay(t, server.DelayProfileDefault)

--- a/e2e/backends/mock/env_test.go
+++ b/e2e/backends/mock/env_test.go
@@ -4,32 +4,84 @@ package mock_test
 
 import (
 	"os"
+	"strings"
 	"testing"
 
+	"github.com/philsphicas/aztunnel/e2e/backends/mock"
 	"github.com/philsphicas/aztunnel/mockrelay/server"
 )
 
-// delayProfileFromEnv resolves the DelayProfile for the mock e2e
-// scenario run from the E2E_DELAY environment variable, mirroring the
-// E2E_AUTH knob the Azure backend uses to pin its auth axis.
+// mockBackendFromEnv builds the MockBackend for the e2e scenario run
+// from the E2E_AUTH and E2E_DELAY environment variables, mirroring the
+// knobs the Azure backend uses to vary its matrix. The two dimensions
+// are independent and compose: the suite runs once per (auth, delay)
+// cell.
 //
-// Unset (or empty) selects "default" — the wire-faithful profile the
-// e2e timing thresholds are calibrated against — so the historical
-// behaviour of TestE2E_Mock is unchanged. Any other value is looked up
-// in the mockrelay profile registry (server.ProfileByName); an
-// unrecognised name fails the test loudly with the list of known
-// profiles, so a typo never silently falls through to the wrong timing
-// model. Adding a profile to the registry makes it selectable here
-// with no change to this helper.
-func delayProfileFromEnv(t testing.TB) server.DelayProfile {
+// A dimension with a single selected value is pinned with no axis, so
+// the common `make e2e-mock` sub-test paths are unchanged and `-run`
+// selectors keep matching; a dimension with two or more values adds a
+// sub-test layer (auth outermost, then delay), e.g.
+// TestE2E_Mock/entra/default/Performance/... Unknown values fail the
+// test loudly.
+func mockBackendFromEnv(t testing.TB) *mock.MockBackend {
 	t.Helper()
-	name := os.Getenv("E2E_DELAY")
-	if name == "" {
-		name = "default"
+	return mock.NewMatrixBackend(authNamesFromEnv(t), delayProfileNamesFromEnv(t))
+}
+
+// authNamesFromEnv parses E2E_AUTH into the ordered set of auth methods
+// to run, mirroring the Azure backend's E2E_AUTH knob:
+//
+//   - unset / empty -> both {sas, entra} (the default matrix).
+//   - "sas" / "entra" -> that single method, pinned (no auth axis).
+//
+// Any other value fails the test loudly.
+func authNamesFromEnv(t testing.TB) []string {
+	t.Helper()
+	switch raw := strings.TrimSpace(os.Getenv("E2E_AUTH")); raw {
+	case "":
+		return []string{mock.AuthSAS, mock.AuthEntra}
+	case mock.AuthSAS, mock.AuthEntra:
+		return []string{raw}
+	default:
+		t.Fatalf("E2E_AUTH=%q: want %q, %q, or unset (both)", raw, mock.AuthSAS, mock.AuthEntra)
+		return nil
 	}
-	p, err := server.ProfileByName(name)
-	if err != nil {
-		t.Fatalf("E2E_DELAY: %v", err)
+}
+
+// delayProfileNamesFromEnv parses E2E_DELAY into the ordered, deduped
+// set of profile names to run, mirroring the E2E_AUTH knob:
+//
+//   - unset / empty -> the single "default" profile (the wire-faithful
+//     profile the e2e timing thresholds are calibrated against).
+//   - "all"         -> every registered profile, in sorted order.
+//   - "a,b,c"       -> the listed profiles, in the given order, deduped.
+//
+// Every name is validated against the mockrelay registry; an empty
+// element or unknown name fails the test.
+func delayProfileNamesFromEnv(t testing.TB) []string {
+	t.Helper()
+	raw := os.Getenv("E2E_DELAY")
+	switch raw {
+	case "":
+		return []string{"default"}
+	case "all":
+		return server.ProfileNames()
 	}
-	return p
+	seen := make(map[string]struct{})
+	var names []string
+	for _, part := range strings.Split(raw, ",") {
+		name := strings.TrimSpace(part)
+		if name == "" {
+			t.Fatalf("E2E_DELAY: empty profile name in %q", raw)
+		}
+		if _, err := server.ProfileByName(name); err != nil {
+			t.Fatalf("E2E_DELAY: %v", err)
+		}
+		if _, dup := seen[name]; dup {
+			continue
+		}
+		seen[name] = struct{}{}
+		names = append(names, name)
+	}
+	return names
 }

--- a/e2e/backends/mock/features_test.go
+++ b/e2e/backends/mock/features_test.go
@@ -6,6 +6,7 @@ import (
 	"bytes"
 	"io"
 	"net"
+	"slices"
 	"testing"
 	"time"
 
@@ -46,6 +47,97 @@ func TestMockFeature_ZeroDelayProfile(t *testing.T) {
 	if elapsed > upperBound {
 		t.Fatalf("round-trip took %v with zero DelayProfile; want < %v",
 			elapsed, upperBound)
+	}
+}
+
+// TestMockFeature_DelayMatrix verifies the matrix wiring a
+// NewMatrixBackend exposes to the harness when only the delay
+// dimension varies: a single "delay" axis whose values are the
+// requested profiles, a Cell() that pins each profile and reports no
+// further axes, and a per-profile latency threshold that scales above
+// the floor for a slow profile. It stands up no topology — it exercises
+// the Backend matrix contract directly.
+func TestMockFeature_DelayMatrix(t *testing.T) {
+	b := mock.NewMatrixBackend([]string{mock.AuthSAS}, []string{"zero", "default"})
+
+	axes := b.Axes()
+	if len(axes) != 1 || axes[0].Name() != "delay" {
+		t.Fatalf("expected a single \"delay\" axis, got %v", axes)
+	}
+	if got := axes[0].Values(); !slices.Equal(got, []string{"zero", "default"}) {
+		t.Fatalf("axis values = %v, want [zero default]", got)
+	}
+
+	// Each cell pins the named profile and advertises no further axes.
+	def := b.Cell(map[string]string{"delay": "default"})
+	pinned, ok := def.(*mock.MockBackend)
+	if !ok {
+		t.Fatalf("Cell returned %T, want *mock.MockBackend", def)
+	}
+	if pinned.Axes() != nil {
+		t.Errorf("pinned cell backend should report nil Axes(), got %v", pinned.Axes())
+	}
+
+	// A slow profile's derived threshold scales above the 3 s floor,
+	// proving the budget tracks the profile rather than a flat constant.
+	slow := mock.MockBackend{DelayProfile: server.DelayProfile{
+		SLatency: 2 * time.Second,
+		LLatency: 2 * time.Second,
+	}}
+	if got := slow.ConnectLatencyThreshold(); got <= 3*time.Second {
+		t.Errorf("slow-profile ConnectLatencyThreshold = %v, want > 3s (budget should scale)", got)
+	}
+}
+
+// TestMockFeature_AuthDelayMatrix verifies that NewMatrixBackend
+// composes the auth and delay dimensions: when both vary it advertises
+// two axes in the order [auth, delay] (auth outermost, mirroring the
+// Azure backend), Cell() pins both from the supplied keys, and a
+// single-valued dimension is pinned with no axis. It also checks the
+// entra cold-start budget carries headroom over the SAS budget when the
+// profile models a token-acquisition cost, and collapses to equality
+// under the zero profile.
+func TestMockFeature_AuthDelayMatrix(t *testing.T) {
+	b := mock.NewMatrixBackend([]string{mock.AuthSAS, mock.AuthEntra}, []string{"zero", "default"})
+
+	axes := b.Axes()
+	if len(axes) != 2 || axes[0].Name() != "auth" || axes[1].Name() != "delay" {
+		t.Fatalf("expected axes [auth delay], got %v", axes)
+	}
+	if got := axes[0].Values(); !slices.Equal(got, []string{mock.AuthSAS, mock.AuthEntra}) {
+		t.Fatalf("auth axis values = %v, want [sas entra]", got)
+	}
+
+	// A fully specified cell pins both dimensions and advertises none.
+	cell := b.Cell(map[string]string{"auth": mock.AuthEntra, "delay": "default"})
+	pinned, ok := cell.(*mock.MockBackend)
+	if !ok {
+		t.Fatalf("Cell returned %T, want *mock.MockBackend", cell)
+	}
+	if pinned.Axes() != nil {
+		t.Errorf("pinned cell should report nil Axes(), got %v", pinned.Axes())
+	}
+
+	// A single-valued auth dimension is pinned with no axis; only the
+	// delay axis remains.
+	delayOnly := mock.NewMatrixBackend([]string{mock.AuthEntra}, []string{"zero", "default"})
+	if axes := delayOnly.Axes(); len(axes) != 1 || axes[0].Name() != "delay" {
+		t.Fatalf("single-auth backend axes = %v, want [delay] only", axes)
+	}
+
+	// Entra's cold-start budget exceeds SAS's under a token-acquisition
+	// profile, but equals it under the zero profile (TokenAcquire == 0).
+	entraDefault := b.Cell(map[string]string{"auth": mock.AuthEntra, "delay": "default"}).(*mock.MockBackend)
+	sasDefault := b.Cell(map[string]string{"auth": mock.AuthSAS, "delay": "default"}).(*mock.MockBackend)
+	if entraDefault.ColdStartLatencyThreshold() <= sasDefault.ColdStartLatencyThreshold() {
+		t.Errorf("entra cold-start budget %v should exceed sas %v under default profile",
+			entraDefault.ColdStartLatencyThreshold(), sasDefault.ColdStartLatencyThreshold())
+	}
+	entraZero := b.Cell(map[string]string{"auth": mock.AuthEntra, "delay": "zero"}).(*mock.MockBackend)
+	sasZero := b.Cell(map[string]string{"auth": mock.AuthSAS, "delay": "zero"}).(*mock.MockBackend)
+	if entraZero.ColdStartLatencyThreshold() != sasZero.ColdStartLatencyThreshold() {
+		t.Errorf("entra %v and sas %v cold-start budgets should match under zero profile",
+			entraZero.ColdStartLatencyThreshold(), sasZero.ColdStartLatencyThreshold())
 	}
 }
 

--- a/mockrelay/server/delay_profile.go
+++ b/mockrelay/server/delay_profile.go
@@ -33,6 +33,17 @@ import (
 //     and the response being emitted that is NOT explained by lane
 //     transit: SAS-token validation for AuthInternal, listener lookup
 //     plus cross-relay-node dispatch for MatchMakeInternal.
+//
+//   - Client-side credential cost (TokenAcquire). The one-off cold
+//     token-acquisition latency a real aztunnel process pays the first
+//     time it fetches an Entra token (the AAD round trip), absorbed
+//     thereafter by the client token cache. It is NOT a relay-side
+//     sleep — the mock relay server ignores it — but it lives here so a
+//     single profile owns all synthetic wall-clock: the zero profile is
+//     instant everywhere (including the entra cold start) and a
+//     wire-faithful profile models the real cold-start premium. The SAS
+//     path pays nothing (it re-signs locally), so this field is read
+//     only on the entra path.
 type DelayProfile struct {
 	// SLatency is the one-way wire transit time between the sender
 	// and the relay. Used to model TCP+TLS+WS upgrade hops on the
@@ -69,6 +80,17 @@ type DelayProfile struct {
 	// in addition to AuthInternal (the two costs sum in handleConnect
 	// because matchmake happens after auth).
 	MatchMakeInternal time.Duration
+
+	// TokenAcquire models the one-off cold Entra token-acquisition
+	// latency (the AAD round trip a real aztunnel process pays the
+	// first time it fetches a token, absorbed thereafter by the client
+	// token cache). Unlike the other fields this is a CLIENT-side cost,
+	// not a relay-side sleep: the mock relay server never reads it. It
+	// is consumed only by the e2e harness on the entra auth path, so a
+	// single profile owns all synthetic wall-clock — zero is instant
+	// everywhere, default models the real cold-start premium. The SAS
+	// path re-signs locally and pays nothing.
+	TokenAcquire time.Duration
 }
 
 // Hop accounting constants. The decomposition comes from wireshark
@@ -104,6 +126,7 @@ var DelayProfileDefault = DelayProfile{
 	DNSLookup:         40 * time.Millisecond,
 	AuthInternal:      10 * time.Millisecond,
 	MatchMakeInternal: 50 * time.Millisecond,
+	TokenAcquire:      450 * time.Millisecond,
 }
 
 // registry is the single source of truth mapping canonical profile
@@ -144,6 +167,31 @@ func ProfileNames() []string {
 	return names
 }
 
+// PredictedRendezvous returns the synthetic wall-clock this profile
+// adds to a single cold hyco rendezvous (listener already attached):
+// both fresh DNS lookups, the sender and listener lane transits, the
+// shared response leg, and the relay-internal auth + matchmake costs.
+// It is the synthetic-delay component only — the in-process baseline
+// (~6 ms) is not included. The decomposition follows the hop
+// accounting above; see docs/internals/sequences/ for the wireshark
+// basis. For the zero profile this is zero.
+func (p DelayProfile) PredictedRendezvous() time.Duration {
+	return 2*p.DNSLookup +
+		(hopsHandshake+hopsWSGet)*p.SLatency +
+		(hopsHandshake+hopsWSGet+hopsAcceptFrame)*p.LLatency +
+		hopsResponse*max(p.SLatency, p.LLatency) +
+		p.AuthInternal + p.MatchMakeInternal
+}
+
+// PredictedBridgeEcho returns the synthetic wall-clock this profile
+// adds to one request→reply round-trip through an already-established
+// bridge. Each bridge message in flight pays one one-way lane transit
+// (SLatency + LLatency), so an echo costs two. Excludes the in-process
+// baseline. For the zero profile this is zero.
+func (p DelayProfile) PredictedBridgeEcho() time.Duration {
+	return 2 * (p.SLatency + p.LLatency)
+}
+
 // WithDelayProfile arms the per-lane synthetic-delay model. The zero
 // profile applies no delay anywhere — pass DelayProfileDefault (or
 // build your own) for fidelity. Only effective when set via
@@ -178,6 +226,7 @@ func (p DelayProfile) validate() error {
 		{"DNSLookup", p.DNSLookup},
 		{"AuthInternal", p.AuthInternal},
 		{"MatchMakeInternal", p.MatchMakeInternal},
+		{"TokenAcquire", p.TokenAcquire},
 	} {
 		if f.d < 0 {
 			return fmt.Errorf("%s must be non-negative, got %v", f.name, f.d)

--- a/mockrelay/server/delay_profile_test.go
+++ b/mockrelay/server/delay_profile_test.go
@@ -500,6 +500,44 @@ func TestProfileRegistry_AllValid(t *testing.T) {
 	}
 }
 
+// TestDelayProfile_PredictedTimings asserts the predicted-timing
+// helpers match the documented hop formula, are zero for the zero
+// profile, and increase monotonically as a lane latency grows. These
+// feed the mock backend's latency-budget derivation, so a drift here
+// would silently mis-size e2e thresholds.
+func TestDelayProfile_PredictedTimings(t *testing.T) {
+	if got := DelayProfileZero.PredictedRendezvous(); got != 0 {
+		t.Errorf("zero PredictedRendezvous = %v, want 0", got)
+	}
+	if got := DelayProfileZero.PredictedBridgeEcho(); got != 0 {
+		t.Errorf("zero PredictedBridgeEcho = %v, want 0", got)
+	}
+
+	p := DelayProfileDefault
+	wantRendezvous := 2*p.DNSLookup +
+		(hopsHandshake+hopsWSGet)*p.SLatency +
+		(hopsHandshake+hopsWSGet+hopsAcceptFrame)*p.LLatency +
+		hopsResponse*max(p.SLatency, p.LLatency) +
+		p.AuthInternal + p.MatchMakeInternal
+	if got := p.PredictedRendezvous(); got != wantRendezvous {
+		t.Errorf("default PredictedRendezvous = %v, want %v", got, wantRendezvous)
+	}
+	if got, want := p.PredictedBridgeEcho(), 2*(p.SLatency+p.LLatency); got != want {
+		t.Errorf("default PredictedBridgeEcho = %v, want %v", got, want)
+	}
+
+	slow := p
+	slow.SLatency *= 2
+	if slow.PredictedRendezvous() <= p.PredictedRendezvous() {
+		t.Errorf("doubling SLatency did not increase PredictedRendezvous (%v vs %v)",
+			slow.PredictedRendezvous(), p.PredictedRendezvous())
+	}
+	if slow.PredictedBridgeEcho() <= p.PredictedBridgeEcho() {
+		t.Errorf("doubling SLatency did not increase PredictedBridgeEcho (%v vs %v)",
+			slow.PredictedBridgeEcho(), p.PredictedBridgeEcho())
+	}
+}
+
 // runAcceptEchoer reads accept frames from a listener control WS,
 // dials each rendezvous URL, and echoes every message. Used by the
 // tests that need a real bridge to pair on the listener side.


### PR DESCRIPTION
## Summary

The mock e2e backend now fans the shared scenario suite over a **composable matrix of two independent dimensions**, mirroring the Azure backend:

- **Auth method** (`E2E_AUTH`): unset runs both `sas` and `entra`; pin one with `E2E_AUTH=sas` / `E2E_AUTH=entra`.
- **Delay profile** (`E2E_DELAY`): unset runs the wire-faithful `default` profile, `all` runs every registered profile, or pass a comma-separated subset.

The two knobs compose: `TestE2E_Mock` runs once per `(auth, delay)` cell.

## What this enables

```bash
make e2e-mock          # both auth methods × default profile
make e2e-mock-fast     # both auth methods × zero profile (fastest signal)
make e2e-mock-matrix   # both auth methods × every registered profile

E2E_AUTH=entra make e2e-mock          # pin one auth method
E2E_DELAY=zero make e2e-mock          # no synthetic delay (entra included)
E2E_DELAY=zero,default make e2e-mock  # explicit profile subset
```

A dimension with a **single** selected value adds no sub-test layer (so default paths and `-run` selectors are unchanged); **two or more** values nest scenarios under `TestE2E_Mock/<auth>/<profile>/<scenario>` (auth outermost).

## Synthetic time lives in one place

The cold Entra token-acquisition cost (the one-off AAD round trip real aztunnel pays on its first dial, cached thereafter) now lives in `DelayProfile.TokenAcquire` rather than a hardcoded backend constant. So a single profile owns all synthetic wall-clock:

- the `zero` profile is **instant everywhere**, entra included;
- the `default` profile models the ~450 ms cold-start premium.

The `entra` cell drives a real `EntraTokenProvider` (backed by a fake credential), so the production token cache is exercised end-to-end while SAS pays nothing.

## Per-profile latency thresholds

Connect-latency ceilings derive from each profile's predicted rendezvous + bridge-echo wall-clock via an affine budget, so a slower profile gets a proportionally larger ceiling that still trips on a real regression instead of a flat constant. The entra cold-start budget widens only when the profile models a token-acquisition cost, and collapses to the SAS budget under the `zero` profile.

## Also

Fixes the Azure backend's hyco provisioning logs: the entra-only (`E2E_AUTH=entra`) job previously logged a malformed `hyco pair: <entra>, ` with a dangling comma, while only the SAS-only mode got a clean message. Both single-auth modes now read symmetrically and state the mode positively.
