### PR TITLE
test(e2e): parallel auth jobs with SkipSAS

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -43,14 +43,28 @@ jobs:
         run: make e2e-mock
 
   e2e-azure:
-    name: E2E (azure)
+    name: E2E (azure / ${{ matrix.auth }})
     runs-on: ubuntu-latest
     environment: e2e-azure
+    # Parallelism strategy: split the Azure suite along the existing
+    # auth axis so the two halves of the matrix that previously ran
+    # serially within one process now run concurrently in two jobs.
+    # E2E_AUTH=${{ matrix.auth }} is read by e2e/backends/azure/testmain
+    # which wires Config.SkipEntra / Config.SkipSAS so the entra job
+    # never provisions a SAS hyco and vice-versa. fail-fast: false so
+    # one auth's failure does not cancel the other — the umbrella
+    # `e2e` aggregator below reports the worst-of-matrix.
+    strategy:
+      fail-fast: false
+      matrix:
+        auth: [entra, sas]
     # Budget: full Azure suite measured at ~40 min locally (2400 s)
     # with both entra+sas axes. LongLivedConnection contributes
     # ~4 min of pure sleep per axis. 60 min leaves headroom for cold
     # starts, relay slowness, and the occasional retry without
-    # tipping into job-level timeout flakes.
+    # tipping into job-level timeout flakes. With the matrix split,
+    # each per-axis child gets its own 60 min wall — comfortable
+    # headroom over the ~13 min per-axis wall observed in practice.
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v6
@@ -84,6 +98,7 @@ jobs:
           E2E_RELAY_NAME: ${{ vars.E2E_RELAY_NAME }}
           E2E_RESOURCE_GROUP: ${{ vars.E2E_RESOURCE_GROUP || 'aztunnel-e2e' }}
           AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+          E2E_AUTH: ${{ matrix.auth }}
         run: make e2e-azure
 
   # Umbrella status check that aggregates the two matrix jobs.

--- a/e2e/azrelay/provider.go
+++ b/e2e/azrelay/provider.go
@@ -120,9 +120,12 @@ func DefaultClientOptions() *arm.ClientOptions {
 }
 
 // Provision creates a fresh hybrid-connection pair via Provisioner:
-// the SAS hyco unconditionally, and the entra hyco unless
-// Config.SkipEntra is true (in which case Result.EntraHycoName is
-// left empty). The returned PairToken's Result is stamped with the
+// the entra hyco unless Config.SkipEntra is true (in which case
+// Result.EntraHycoName is left empty) and the SAS hyco unless
+// Config.SkipSAS is true (in which case Result.SASHycoName is left
+// empty). With both SkipEntra and SkipSAS true, no hycos are
+// created and both name fields of the returned PairToken's Result
+// are empty. The returned PairToken's Result is stamped with the
 // namespace-scoped SAS rule key info from p.cfg.RunRules. Teardown
 // deletes whichever hycos were created; the permanent run-scoped
 // rules live on past every PairToken and are not torn down by
@@ -207,7 +210,8 @@ func (t *PairToken) Result() *Result {
 
 // HycoNames returns the (entra, sas) names this token holds. After a
 // successful Provision the names come from the recorded Result, so a
-// SkipEntra-mode token returns ("", "e2e-sas-<suffix>"). When no
+// SkipEntra-mode token returns ("", "e2e-sas-<suffix>") and a
+// SkipSAS-mode token returns ("e2e-entra-<suffix>", ""). When no
 // Result is set (tests that construct a PairToken with only a
 // suffix), HycoNames synthesises both names from the suffix.
 func (t *PairToken) HycoNames() (entra, sas string) {
@@ -218,10 +222,11 @@ func (t *PairToken) HycoNames() (entra, sas string) {
 }
 
 // Teardown deletes the hybrid connections recorded on this token
-// (the SAS hyco, and the entra hyco unless SkipEntra was set at
-// Provision time and left Result.EntraHycoName empty). Safe to call
-// multiple times: only the first call performs the deletes;
-// subsequent calls return the same error.
+// (the entra hyco unless SkipEntra was set at Provision time and
+// left Result.EntraHycoName empty, and the SAS hyco unless SkipSAS
+// was set at Provision time and left Result.SASHycoName empty).
+// Safe to call multiple times: only the first call performs the
+// deletes; subsequent calls return the same error.
 //
 // Teardown strips cancellation from ctx (via context.WithoutCancel)
 // so cleanup completes even when the test's ctx has been cancelled
@@ -260,8 +265,10 @@ func (t *PairToken) Teardown(ctx context.Context) error {
 				errs = append(errs, fmt.Errorf("delete %s: %w", entra, err))
 			}
 		}
-		if err := t.deleteFn(ctx, sas); err != nil {
-			errs = append(errs, fmt.Errorf("delete %s: %w", sas, err))
+		if sas != "" {
+			if err := t.deleteFn(ctx, sas); err != nil {
+				errs = append(errs, fmt.Errorf("delete %s: %w", sas, err))
+			}
 		}
 		if len(errs) > 0 {
 			t.teardownErr = errors.Join(errs...)

--- a/e2e/azrelay/provider_test.go
+++ b/e2e/azrelay/provider_test.go
@@ -284,6 +284,30 @@ func TestPairToken_HycoNamesSkipEntraSurfacesEmpty(t *testing.T) {
 	}
 }
 
+// TestPairToken_HycoNamesSkipSASSurfacesEmpty mirrors the
+// SkipEntraSurfacesEmpty test for the symmetric SkipSAS case: when a
+// PairToken has a populated Result whose SASHycoName is empty,
+// HycoNames returns the empty sas name from the Result rather than
+// falling back to the suffix-derived synthetic name. Locks in
+// "result wins over suffix" for SkipSAS mode at the PairToken level.
+func TestPairToken_HycoNamesSkipSASSurfacesEmpty(t *testing.T) {
+	const suffix = "00112233aabb"
+	tok := &PairToken{
+		suffix: suffix,
+		result: &Result{
+			EntraHycoName: "e2e-entra-" + suffix,
+			SASHycoName:   "",
+		},
+	}
+	entra, sas := tok.HycoNames()
+	if entra != "e2e-entra-"+suffix {
+		t.Errorf("entra = %q, want %q", entra, "e2e-entra-"+suffix)
+	}
+	if sas != "" {
+		t.Errorf("sas = %q, want empty (Result wins over suffix)", sas)
+	}
+}
+
 // TestPairToken_TeardownSkipsEntraWhenResultEntraEmpty asserts that
 // Teardown invokes deleteFn exactly once (SAS only) when the Result
 // records SkipEntra (EntraHycoName empty), and that the count holds
@@ -316,6 +340,49 @@ func TestPairToken_TeardownSkipsEntraWhenResultEntraEmpty(t *testing.T) {
 	}
 	if len(capturedNames) != 1 || capturedNames[0] != "e2e-sas-"+suffix {
 		t.Errorf("captured names = %v, want [%q]", capturedNames, "e2e-sas-"+suffix)
+	}
+
+	if err := tok.Teardown(t.Context()); err != nil {
+		t.Fatalf("second teardown: %v", err)
+	}
+	if got := calls.Load(); got != 1 {
+		t.Errorf("after second teardown, deleteFn invoked %d times, want still 1", got)
+	}
+}
+
+// TestPairToken_TeardownSkipsSASWhenResultSASEmpty mirrors the
+// SkipEntra teardown test for the symmetric SkipSAS case: Teardown
+// invokes deleteFn exactly once (entra only) when the Result records
+// SkipSAS (SASHycoName empty), and the count holds across repeat
+// calls.
+func TestPairToken_TeardownSkipsSASWhenResultSASEmpty(t *testing.T) {
+	const suffix = "feedface1234"
+	var calls atomic.Int32
+	var mu sync.Mutex
+	var capturedNames []string
+	tok := &PairToken{
+		suffix: suffix,
+		result: &Result{
+			EntraHycoName: "e2e-entra-" + suffix,
+			SASHycoName:   "",
+		},
+		deleteFn: func(ctx context.Context, name string) error {
+			calls.Add(1)
+			mu.Lock()
+			capturedNames = append(capturedNames, name)
+			mu.Unlock()
+			return nil
+		},
+	}
+
+	if err := tok.Teardown(t.Context()); err != nil {
+		t.Fatalf("first teardown: %v", err)
+	}
+	if got := calls.Load(); got != 1 {
+		t.Errorf("deleteFn invoked %d times, want 1 (SkipSAS: entra only)", got)
+	}
+	if len(capturedNames) != 1 || capturedNames[0] != "e2e-entra-"+suffix {
+		t.Errorf("captured names = %v, want [%q]", capturedNames, "e2e-entra-"+suffix)
 	}
 
 	if err := tok.Teardown(t.Context()); err != nil {

--- a/e2e/azrelay/provisioner.go
+++ b/e2e/azrelay/provisioner.go
@@ -100,6 +100,18 @@ type Config struct {
 	// exercises both auth methods.
 	SkipEntra bool
 
+	// SkipSAS suppresses creation of the SAS-auth hyco. When true,
+	// Provision creates only the Entra hyco and leaves
+	// Result.SASHycoName empty; Teardown skips the Delete on the
+	// empty name. Used by the e2e test harness when running in
+	// entra-only mode (e.g. the CI matrix's E2E_AUTH=entra job),
+	// where the SAS hyco would be created and torn down only to never
+	// be used. Safe to leave false in any path that exercises both
+	// auth methods. Setting both SkipEntra and SkipSAS true is a
+	// degenerate no-op: Provision creates no hycos and Teardown has
+	// nothing to delete.
+	SkipSAS bool
+
 	// RunRules supplies the namespace-permanent SAS rules whose keys
 	// every PairToken Result stamps onto its ListenerKey/SenderKey
 	// fields. Required for NewProvider and Provisioner; AcquireRunRules
@@ -178,13 +190,16 @@ func New(cfg Config) (*Provisioner, error) {
 	return &Provisioner{cfg: cfg, hycos: hycos, suffix: suffix}, nil
 }
 
-// Provision creates the SAS hybrid connection (and the entra hybrid
-// connection unless Config.SkipEntra is true, in which case
-// Result.EntraHycoName is left empty) and stamps the namespace SAS
-// rule key info from Config.RunRules onto the returned Result. If
-// any step fails after a hyco has been created, Provision attempts
-// a best-effort teardown before returning the error so the caller
-// does not need to handle partial state.
+// Provision creates the entra hybrid connection (unless
+// Config.SkipEntra is true, in which case Result.EntraHycoName is
+// left empty) and the SAS hybrid connection (unless Config.SkipSAS
+// is true, in which case Result.SASHycoName is left empty), and
+// stamps the namespace SAS rule key info from Config.RunRules onto
+// the returned Result. With both SkipEntra and SkipSAS true,
+// Provision creates no hycos and returns a Result with both name
+// fields empty. If any step fails after a hyco has been created,
+// Provision attempts a best-effort teardown before returning the
+// error so the caller does not need to handle partial state.
 //
 // Authorization rules are NOT created here — they live at namespace
 // scope and are provisioned once per `go test` invocation via
@@ -197,8 +212,7 @@ func (p *Provisioner) Provision(ctx context.Context) (*Result, error) {
 		return nil, errors.New("azrelay.Config.RunRules is required (call AcquireRunRules first)")
 	}
 
-	sasName := "e2e-sas-" + p.suffix
-	var entraName string
+	var entraName, sasName string
 	if !p.cfg.SkipEntra {
 		entraName = "e2e-entra-" + p.suffix
 		if err := p.createHyco(ctx, entraName); err != nil {
@@ -210,12 +224,15 @@ func (p *Provisioner) Provision(ctx context.Context) (*Result, error) {
 			return nil, fmt.Errorf("create %s: %w", entraName, err)
 		}
 	}
-	if err := p.createHyco(ctx, sasName); err != nil {
-		if entraName != "" {
-			p.bestEffortDelete(ctx, entraName)
+	if !p.cfg.SkipSAS {
+		sasName = "e2e-sas-" + p.suffix
+		if err := p.createHyco(ctx, sasName); err != nil {
+			if entraName != "" {
+				p.bestEffortDelete(ctx, entraName)
+			}
+			p.bestEffortDelete(ctx, sasName)
+			return nil, fmt.Errorf("create %s: %w", sasName, err)
 		}
-		p.bestEffortDelete(ctx, sasName)
-		return nil, fmt.Errorf("create %s: %w", sasName, err)
 	}
 
 	rr := p.cfg.RunRules
@@ -257,8 +274,10 @@ func (p *Provisioner) Teardown(ctx context.Context) error {
 			errs = append(errs, fmt.Errorf("delete %s: %w", p.result.EntraHycoName, err))
 		}
 	}
-	if _, err := p.hycos.Delete(ctx, p.cfg.ResourceGroup, p.cfg.Namespace, p.result.SASHycoName, nil); err != nil && !isNotFound(err) {
-		errs = append(errs, fmt.Errorf("delete %s: %w", p.result.SASHycoName, err))
+	if p.result.SASHycoName != "" {
+		if _, err := p.hycos.Delete(ctx, p.cfg.ResourceGroup, p.cfg.Namespace, p.result.SASHycoName, nil); err != nil && !isNotFound(err) {
+			errs = append(errs, fmt.Errorf("delete %s: %w", p.result.SASHycoName, err))
+		}
 	}
 	if len(errs) > 0 {
 		return errors.Join(errs...)
@@ -269,17 +288,21 @@ func (p *Provisioner) Teardown(ctx context.Context) error {
 // HycoNames returns the (entra, sas) names this provisioner holds.
 // After a successful Provision the names come from the recorded
 // Result, so a SkipEntra-mode Provisioner returns
-// ("", "e2e-sas-<suffix>"). Before Provision the names are
+// ("", "e2e-sas-<suffix>") and a SkipSAS-mode Provisioner returns
+// ("e2e-entra-<suffix>", ""). Before Provision the names are
 // synthesised from the suffix, with the entra name elided to "" when
-// Config.SkipEntra is true so callers see the same shape they will
+// Config.SkipEntra is true and the sas name elided to "" when
+// Config.SkipSAS is true, so callers see the same shape they will
 // see post-Provision.
 func (p *Provisioner) HycoNames() (entra, sas string) {
 	if p.result != nil {
 		return p.result.EntraHycoName, p.result.SASHycoName
 	}
-	sas = "e2e-sas-" + p.suffix
 	if !p.cfg.SkipEntra {
 		entra = "e2e-entra-" + p.suffix
+	}
+	if !p.cfg.SkipSAS {
+		sas = "e2e-sas-" + p.suffix
 	}
 	return entra, sas
 }

--- a/e2e/azrelay/provisioner_test.go
+++ b/e2e/azrelay/provisioner_test.go
@@ -195,6 +195,25 @@ func TestProvisioner_HycoNamesPreProvision_SkipEntraElidesEntra(t *testing.T) {
 	}
 }
 
+func TestProvisioner_HycoNamesPreProvision_SkipSASElidesSAS(t *testing.T) {
+	// Symmetric to the SkipEntra mirror above: before Provision runs,
+	// a Provisioner with cfg.SkipSAS=true should report
+	// ("e2e-entra-<suffix>", "") — matching the shape callers will
+	// see post-Provision and avoiding a synthetic sas name for a hyco
+	// that will never be created.
+	p := &Provisioner{
+		cfg:    Config{SkipSAS: true},
+		suffix: "0123456789ab",
+	}
+	entra, sas := p.HycoNames()
+	if entra != "e2e-entra-0123456789ab" {
+		t.Errorf("entra = %q", entra)
+	}
+	if sas != "" {
+		t.Errorf("sas = %q, want empty (SkipSAS elides pre-Provision)", sas)
+	}
+}
+
 func TestProvisioner_HycoNamesPostProvision_SkipEntra(t *testing.T) {
 	p := &Provisioner{
 		suffix: "0123456789ab",
@@ -212,6 +231,49 @@ func TestProvisioner_HycoNamesPostProvision_SkipEntra(t *testing.T) {
 	}
 	if !HycoNamePattern.MatchString(sas) {
 		t.Errorf("sas name %q does not satisfy HycoNamePattern", sas)
+	}
+}
+
+func TestProvisioner_HycoNamesPostProvision_SkipSAS(t *testing.T) {
+	p := &Provisioner{
+		suffix: "0123456789ab",
+		result: &Result{
+			EntraHycoName: "e2e-entra-0123456789ab",
+			SASHycoName:   "",
+		},
+	}
+	entra, sas := p.HycoNames()
+	if entra != "e2e-entra-0123456789ab" {
+		t.Errorf("entra name = %q", entra)
+	}
+	if sas != "" {
+		t.Errorf("sas name = %q, want empty (SkipSAS mode)", sas)
+	}
+	if !HycoNamePattern.MatchString(entra) {
+		t.Errorf("entra name %q does not satisfy HycoNamePattern", entra)
+	}
+}
+
+// TestProvisioner_HycoNamesPostProvision_SkipBoth pins the
+// degenerate both-true case explicitly. Both SkipEntra and SkipSAS
+// true is permitted (mirroring how SkipEntra alone is permitted with
+// no validation pushback): Provision creates no hycos and HycoNames
+// returns ("", "") post-Provision. The choice is "no-op, not a
+// validation error" — symmetric with the existing
+// "SkipEntra unilaterally permitted" stance — and this test locks
+// it in so a future contributor adding validation for the both-true
+// case would observably break this assertion.
+func TestProvisioner_HycoNamesPostProvision_SkipBoth(t *testing.T) {
+	p := &Provisioner{
+		suffix: "0123456789ab",
+		result: &Result{
+			EntraHycoName: "",
+			SASHycoName:   "",
+		},
+	}
+	entra, sas := p.HycoNames()
+	if entra != "" || sas != "" {
+		t.Errorf("HycoNames = (%q, %q); want both empty (SkipEntra+SkipSAS degenerate no-op)", entra, sas)
 	}
 }
 
@@ -269,6 +331,32 @@ func TestResultEnvVars_EmptyEntraHycoName(t *testing.T) {
 	}
 	if got["E2E_SAS_HYCO_NAME"] != "e2e-sas-0123456789ab" {
 		t.Errorf("EnvVars[E2E_SAS_HYCO_NAME] = %q, want %q", got["E2E_SAS_HYCO_NAME"], "e2e-sas-0123456789ab")
+	}
+}
+
+// TestResultEnvVars_EmptySASHycoName mirrors the EmptyEntraHycoName
+// test for the symmetric SkipSAS case: Result.SASHycoName empty must
+// still emit the E2E_SAS_HYCO_NAME key with an empty value so
+// downstream consumers can reason about presence via
+// `SASHycoName != ""` without missing-key surprises.
+func TestResultEnvVars_EmptySASHycoName(t *testing.T) {
+	r := &Result{
+		RelayName:       "my-relay",
+		EntraHycoName:   "e2e-entra-0123456789ab",
+		SASHycoName:     "",
+		ListenerKeyName: "listener",
+		ListenerKey:     "lk",
+		SenderKeyName:   "sender",
+		SenderKey:       "sk",
+	}
+	got := r.EnvVars()
+	if v, ok := got["E2E_SAS_HYCO_NAME"]; !ok {
+		t.Fatal("EnvVars missing E2E_SAS_HYCO_NAME key (must be present even when empty)")
+	} else if v != "" {
+		t.Errorf("EnvVars[E2E_SAS_HYCO_NAME] = %q, want empty", v)
+	}
+	if got["E2E_ENTRA_HYCO_NAME"] != "e2e-entra-0123456789ab" {
+		t.Errorf("EnvVars[E2E_ENTRA_HYCO_NAME] = %q, want %q", got["E2E_ENTRA_HYCO_NAME"], "e2e-entra-0123456789ab")
 	}
 }
 

--- a/e2e/backends/azure/testmain_test.go
+++ b/e2e/backends/azure/testmain_test.go
@@ -150,11 +150,21 @@ func testMain(m *testing.M) int {
 	// was unset on entry, the setenv block above has already forced
 	// E2E_AUTH=sas, so this fallback only fires when both signals
 	// would have produced the same answer.)
+	//
+	// Entra-only mode signal (symmetric, simpler): when E2E_AUTH=entra
+	// (set by the CI matrix's entra job or by a developer pinning the
+	// axis locally), skip provisioning a SAS hyco. There is no
+	// .local.json EntraOnly counterpart today — SAS is always
+	// reachable when a namespace is configured, so the only signal
+	// for "entra-only" is the explicit env var.
 	skipEntra := false
+	skipSAS := false
 	v, isSet := os.LookupEnv("E2E_AUTH")
 	switch {
 	case isSet && v == "sas":
 		skipEntra = true
+	case isSet && v == "entra":
+		skipSAS = true
 	case !isSet:
 		if resolved.Local != nil && resolved.Local.SASOnly {
 			skipEntra = true
@@ -167,6 +177,7 @@ func testMain(m *testing.M) int {
 		Namespace:      resolved.RelayName,
 		Concurrency:    conc,
 		SkipEntra:      skipEntra,
+		SkipSAS:        skipSAS,
 	}
 
 	// Acquire the namespace SAS rule keys. The rules


### PR DESCRIPTION
## What & why

Cut the Azure E2E suite wall-clock roughly in half (~25 min → ~13 min) by splitting the `e2e-azure` GitHub Actions job into a 2-child matrix along the existing auth axis (`E2E_AUTH=entra` | `E2E_AUTH=sas`) so the two halves that previously ran serially within one process now run concurrently in two matrix children.

To stop the new entra-only job paying for SAS hycos it never uses, add a symmetric `Config.SkipSAS` option in `e2e/azrelay` mirroring the existing `Config.SkipEntra`, and wire `E2E_AUTH=entra → SkipSAS=true` in `e2e/backends/azure/testmain_test.go` alongside the existing `E2E_AUTH=sas → SkipEntra=true` branch (left byte-for-byte unchanged, including the `.local.json` `SASOnly` auto-detect and its stderr message).

User-visible: the `E2E Tests` workflow now reports `E2E (azure / entra)` and `E2E (azure / sas)` instead of a single `E2E (azure)`; both must pass for the umbrella `e2e` check to pass. Local `make e2e-azure` is unchanged — `E2E_AUTH` unset still runs both auths in one process.

## Must-preserve

- **`E2E_AUTH` unset = run both auths in one process.** The local-dev / no-matrix path stays unchanged: both `Skip*` are false and a single test process exercises the full cross-product.
- **Existing `E2E_AUTH=sas` → `SkipEntra=true` wiring** kept byte-for-byte, including the `.local.json` `SASOnly` auto-detect and the `"==> e2e: SAS-only mode per e2e/.local.json…"` stderr message.
- **`leaseSharedHyco` (bench path) unchanged** — benches continue to provision whatever `Config` they have today.
- **Hyco-name pattern matched by the janitor** — `HycoNamePattern = ^e2e-(entra|sas)-[0-9a-f]{12}$` unchanged; both naming variants continue to exist (SkipSAS run still creates `e2e-entra-<suffix>`; SkipEntra run still creates `e2e-sas-<suffix>`).
- **`Result` shape and `EnvVars()` semantics** — `Result.SASHycoName` empty (not omitted, not synthesised) when `SkipSAS` is true; `EnvVars()` emits an empty value for the unfilled slot, not omitting the key.
- **`Config.Validate` permits SkipEntra and SkipSAS independently and together.** Both-true is permitted as a degenerate no-op (Provision creates no hycos, Result has both name fields empty). Pinned by `TestProvisioner_HycoNamesPostProvision_SkipBoth`.

## Success criteria

- `.github/workflows/e2e.yml` adds `strategy.matrix.auth: [entra, sas]` with `fail-fast: false` on `e2e-azure`; each child passes `E2E_AUTH=${{ matrix.auth }}` into the test step env. Job name surfaces the auth (`E2E (azure / entra)`, `E2E (azure / sas)`).
- The umbrella `e2e` aggregator continues to gate branch protection via `needs.e2e-azure.result` (matrix worst-of semantics).
- `Config.SkipSAS bool` field mirrors `Config.SkipEntra` in placement, doc-comment style, and validation behaviour.
- `Provisioner.Provision`, `Provisioner.Teardown`, `Provisioner.HycoNames`, `PairToken.Teardown`, and `PairToken.HycoNames` all handle the empty-SAS case symmetrically to the empty-Entra case.
- `e2e/backends/azure/testmain_test.go` wires `E2E_AUTH=entra → Config.SkipSAS = true`. The existing `E2E_AUTH=sas → SkipEntra` branch is unchanged. `E2E_AUTH` unset → both `Skip*` false.

## Test plan

`make build && make test && make lint` all green locally.

New tests (all mirrors of the existing `SkipEntra` tests, in the same files):

- `e2e/azrelay/provisioner_test.go`:
  - `TestProvisioner_HycoNamesPreProvision_SkipSASElidesSAS` — pre-Provision elision (mirror of `..._SkipEntraElidesEntra`)
  - `TestProvisioner_HycoNamesPostProvision_SkipSAS` — post-Provision Result-based elision (mirror of `..._SkipEntra`)
  - `TestProvisioner_HycoNamesPostProvision_SkipBoth` — pins the degenerate both-true case as a no-op (no existing mirror)
  - `TestResultEnvVars_EmptySASHycoName` — empty SAS key emits, not omitted (mirror of `..._EmptyEntraHycoName`)
- `e2e/azrelay/provider_test.go`:
  - `TestPairToken_HycoNamesSkipSASSurfacesEmpty` — Result wins over suffix (mirror of `..._SkipEntraSurfacesEmpty`)
  - `TestPairToken_TeardownSkipsSASWhenResultSASEmpty` — Teardown invokes deleteFn exactly once (entra only) under SkipSAS (mirror of `..._SkipsEntraWhenResultEntraEmpty`)

All existing `SkipEntra` tests, bench lease tests, and janitor pattern-matching tests continue to pass unchanged.

Coverage note: matching the existing `SkipEntra` convention, the `Skip*` guards on `Provision()` itself are verified via post-state assertions (HycoNames / EnvVars / Teardown) rather than by a fake-ARM-client integration test. No fake `*armrelay.HybridConnectionsClient` exists in the package; adding one for SkipSAS would create asymmetric test density vs SkipEntra.

## Out-of-scope follow-ups

- `make` targets for axis pinning (`make e2e-azure-entra`, `make e2e-azure-sas`, `make e2e-mock-zerodelay`, etc.) — separate brief under the `e2e-axis-runners` workstream.
- Mock delay-profile axis — separate brief under the same workstream.
- Hyco pool / pre-warming / teardown barrier — `hyco-provisioning-cost` workstream, composes on top of this PR's smaller per-job provisioning footprint.
- `t.Parallel` inside `TestE2E_Azure` — requires refactoring `AssertNoLeaks` so goroutine/FD counts are per-test, not process-wide.
- Per-job concurrency caps in response to namespace 429 pressure — defer-and-observe. The empirical `DefaultProvisionerConcurrency = 4` envelope was tuned for one process; two parallel jobs can put up to 8 in flight against the same namespace. If 429s materialise, address with a follow-up that either drops per-job concurrency or adds a namespace-wide rate limit.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
