### PR TITLE
Model Entra token-acquisition cost in the mock relay backend

### DIFF
--- a/e2e/backends/mock/backend.go
+++ b/e2e/backends/mock/backend.go
@@ -20,6 +20,7 @@ import (
 	"net"
 	"net/http/httptest"
 	"net/url"
+	"sort"
 	"strings"
 	"sync"
 	"testing"
@@ -34,11 +35,29 @@ import (
 	dto "github.com/prometheus/client_model/go"
 )
 
+// Auth method names for the MockBackend auth axis. They mirror the
+// `provider` metric label values (relay.ProviderSAS / ProviderEntra)
+// so a cell's name and its token-fetch metric line up.
+const (
+	authSAS   = "sas"
+	authEntra = "entra"
+)
+
+// defaultEntraAcquireDelay is the synthetic cold token-acquisition
+// latency the entra cell models, approximating the AAD round trip a
+// real aztunnel process pays on its first dial. Calibrated against
+// observed Azure entra-vs-sas cold-start divergence (~450 ms).
+const defaultEntraAcquireDelay = 450 * time.Millisecond
+
 // MockBackend implements scenarios.Backend by standing up a mock
 // relay server + aztunnel listener(s) + aztunnel sender(s) all in the
 // same process. It is the fast, deterministic side of the mock-vs-
 // Azure conformance matrix and runs in the default
 // `go test ./mockrelay/...` job.
+//
+// The zero value runs SAS-only with no axis layer (what bench_test.go
+// wants). Construct via NewAuthAxisBackend to opt into the {sas, entra}
+// auth axis that mirrors the Azure backend's matrix.
 type MockBackend struct {
 	// DelayProfile parameterizes the synthetic per-step sleeps the
 	// mock relay applies on every leg of the rendezvous protocol.
@@ -51,28 +70,93 @@ type MockBackend struct {
 	// server.DelayProfileDefault so the mock approximates the
 	// wireshark-observed wall-clock shape.
 	DelayProfile server.DelayProfile
+
+	// axis is non-nil only on a factory backend (built by
+	// NewAuthAxisBackend); the harness enumerates it to render the
+	// auth sub-path layer. Cell-pinned backends carry axis == nil.
+	axis *mockAuthAxis
+
+	// authName is the auth method this (pinned) backend speaks:
+	// authSAS (the zero value / default) or authEntra. It selects the
+	// token provider built in newTokenProvider — and, for the entra
+	// cell, drives the modelled cold token-acquisition cost.
+	authName string
+
+	// entraAcquireDelay is the synthetic cold-acquisition latency the
+	// entra cell's fake credential sleeps on a cache miss. Zero means
+	// defaultEntraAcquireDelay.
+	entraAcquireDelay time.Duration
 }
 
-// Name returns the backend identifier (always "mock"). The harness
-// does not embed it in sub-test paths — MockBackend has no axes,
-// so scenarios run directly under the test entry point — but
-// scenarios and external callers may surface it in debug output.
+// mockAuthAxis is the scenarios.Axis the MockBackend varies over when
+// constructed via NewAuthAxisBackend. It mirrors the Azure backend's
+// authAxis so both backends render the same {sas, entra} sub-paths.
+type mockAuthAxis struct {
+	values []string
+}
+
+func (*mockAuthAxis) Name() string       { return "auth" }
+func (a *mockAuthAxis) Values() []string { return a.values }
+
+// NewAuthAxisBackend returns a factory MockBackend whose Axes() lists
+// the {sas, entra} auth methods and whose Cell(values) returns a fresh
+// backend pinned to values["auth"]. Use this from the e2e entry point
+// (TestE2E_Mock) so the mock runs the full scenario suite once per auth
+// method, mirroring the Azure backend's matrix. profile is carried
+// through to every pinned cell.
+func NewAuthAxisBackend(profile server.DelayProfile) *MockBackend {
+	return &MockBackend{
+		DelayProfile: profile,
+		axis:         &mockAuthAxis{values: []string{authSAS, authEntra}},
+	}
+}
+
+// Name returns the backend identifier (always "mock"). Factory
+// backends surface the auth dimension via the axis t.Run wrapping
+// rather than the name; scenarios and external callers may surface
+// the name in debug output.
 func (*MockBackend) Name() string { return "mock" }
 
-// Axes returns the matrix dimensions this backend varies over. The
-// mock has none — it only speaks SAS against an in-process server,
-// so the harness runs scenarios directly under the test entry point
-// with no axis sub-path layer.
-func (*MockBackend) Axes() []scenarios.Axis { return nil }
-
-// Cell returns the backend pinned to the cell described by values.
-// MockBackend has no axes so values must be empty; Cell returns the
-// receiver unchanged.
-func (m *MockBackend) Cell(values map[string]string) scenarios.Backend {
-	if len(values) != 0 {
-		panic("MockBackend.Cell: no axes, expected empty values")
+// Axes returns the matrix dimensions this backend varies over.
+// Factory backends (built by NewAuthAxisBackend) return the auth
+// axis; the zero value and pinned backends (returned from Cell)
+// return nil, so the harness runs scenarios directly under the entry
+// point with no axis sub-path layer.
+func (b *MockBackend) Axes() []scenarios.Axis {
+	if b.axis == nil {
+		return nil
 	}
-	return m
+	return []scenarios.Axis{b.axis}
+}
+
+// Cell returns a fresh *MockBackend pinned to the cell described by
+// values. Factory backends require values["auth"]; the zero value and
+// pinned backends (axis == nil) accept only an empty values map and
+// return a clone of the receiver. DelayProfile and entraAcquireDelay
+// are carried through to the pinned cell.
+func (b *MockBackend) Cell(values map[string]string) scenarios.Backend {
+	if b.axis == nil {
+		if len(values) != 0 {
+			panic("MockBackend.Cell: pinned backend accepts no axis values")
+		}
+		return &MockBackend{
+			DelayProfile:      b.DelayProfile,
+			authName:          b.authName,
+			entraAcquireDelay: b.entraAcquireDelay,
+		}
+	}
+	auth, ok := values["auth"]
+	if !ok {
+		panic("MockBackend.Cell: missing required axis key \"auth\"")
+	}
+	if len(values) != 1 {
+		panic("MockBackend.Cell: expected exactly one axis value (auth)")
+	}
+	return &MockBackend{
+		DelayProfile:      b.DelayProfile,
+		authName:          auth,
+		entraAcquireDelay: b.entraAcquireDelay,
+	}
 }
 
 // ConnectLatencyThreshold returns the per-backend connect-latency
@@ -88,12 +172,51 @@ func (*MockBackend) ConnectLatencyThreshold() time.Duration {
 }
 
 // ColdStartLatencyThreshold returns the per-backend ceiling for the
-// first connection through a freshly-started sender. The mock has
-// no per-process credential cache to warm — every dial pays the
-// same rendezvous delay regardless of order — so the cold-start
-// budget intentionally matches ConnectLatencyThreshold.
-func (*MockBackend) ColdStartLatencyThreshold() time.Duration {
+// first connection through a freshly-started sender. For the SAS cell
+// (and the axis-less zero value) the budget matches
+// ConnectLatencyThreshold: every dial pays the same rendezvous delay
+// regardless of order. The entra cell additionally pays a one-off
+// synthetic token-acquisition cost on that first dial (the modelled
+// AAD round trip, absorbed thereafter by the client token cache), so
+// its budget is widened to keep comfortable headroom over the cold
+// fetch on noisy CI.
+func (b *MockBackend) ColdStartLatencyThreshold() time.Duration {
+	if b.authName == authEntra {
+		return 5 * time.Second
+	}
 	return 3 * time.Second
+}
+
+// newTokenProvider builds a fresh token provider for one aztunnel
+// instance (one listener, sender, or connect invocation), wrapped to
+// record the aztunnel_token_fetch_* metrics on m under this cell's
+// provider label. Each call returns an INDEPENDENT provider so every
+// instance owns its own credential cache — mirroring separate aztunnel
+// processes, which is what makes the entra cell's per-process cold-start
+// cost visible (a shared provider would warm a sibling's cache and mask
+// it).
+//
+// SAS cell (and the zero value): a real relay.SASTokenProvider, which
+// re-signs locally per call (free). Entra cell: a real
+// relay.EntraTokenProvider backed by fakeEntraCredential, so the
+// production token cache is exercised end-to-end and the modelled
+// ~450 ms acquisition cost is paid only on the cold cache miss.
+func (b *MockBackend) newTokenProvider(m *metrics.Metrics) relay.TokenProvider {
+	switch b.authName {
+	case authEntra:
+		delay := b.entraAcquireDelay
+		if delay == 0 {
+			delay = defaultEntraAcquireDelay
+		}
+		inner, _ := newFakeEntraProvider(delay)
+		return relay.WithMetrics(inner, m, relay.ProviderEntra)
+	default: // authSAS or "" (zero value)
+		inner := &relay.SASTokenProvider{
+			KeyName: server.DefaultSASKeyName,
+			Key:     server.DefaultSASKey,
+		}
+		return relay.WithMetrics(inner, m, relay.ProviderSAS)
+	}
 }
 
 // Setup brings up the in-process topology described by opts and blocks
@@ -135,10 +258,6 @@ func (b *MockBackend) Setup(t testing.TB, opts scenarios.SetupOptions) *scenario
 	})
 
 	entity := mustEntityName(t)
-	tokenProvider := &relay.SASTokenProvider{
-		KeyName: server.DefaultSASKeyName,
-		Key:     server.DefaultSASKey,
-	}
 
 	tun := &scenarios.Tunnel{}
 
@@ -158,7 +277,7 @@ func (b *MockBackend) Setup(t testing.TB, opts scenarios.SetupOptions) *scenario
 		cfg := listener.Config{
 			Endpoint:       host,
 			EntityPath:     entity,
-			TokenProvider:  tokenProvider,
+			TokenProvider:  b.newTokenProvider(m),
 			ClientOptions:  clientOpts,
 			AllowList:      opts.AllowedTargets,
 			MaxConnections: opts.MaxConnections,
@@ -218,6 +337,7 @@ func (b *MockBackend) Setup(t testing.TB, opts scenarios.SetupOptions) *scenario
 	// MaxConnections.
 	startOneSender := func() *scenarios.Sender {
 		m := metrics.New()
+		senderTP := b.newTokenProvider(m)
 		logs := newCaptureBuffer()
 		senderLogger := slog.New(slog.NewTextHandler(logs, &slog.HandlerOptions{Level: slog.LevelDebug}))
 		sctx, scancel := context.WithCancel(ctx)
@@ -240,7 +360,7 @@ func (b *MockBackend) Setup(t testing.TB, opts scenarios.SetupOptions) *scenario
 				err = sender.PortForward(sctx, sender.PortForwardConfig{
 					Endpoint:      host,
 					EntityPath:    entity,
-					TokenProvider: tokenProvider,
+					TokenProvider: senderTP,
 					ClientOptions: clientOpts,
 					Target:        opts.Target,
 					BindAddress:   "127.0.0.1:0",
@@ -252,7 +372,7 @@ func (b *MockBackend) Setup(t testing.TB, opts scenarios.SetupOptions) *scenario
 				err = sender.SOCKS5Proxy(sctx, sender.SOCKS5Config{
 					Endpoint:      host,
 					EntityPath:    entity,
-					TokenProvider: tokenProvider,
+					TokenProvider: senderTP,
 					ClientOptions: clientOpts,
 					BindAddress:   "127.0.0.1:0",
 					Logger:        senderLogger,
@@ -287,6 +407,7 @@ func (b *MockBackend) Setup(t testing.TB, opts scenarios.SetupOptions) *scenario
 			Completed:           counterReader(m, "aztunnel_connections_total"),
 			Active:              gaugeReader(m, "aztunnel_active_connections"),
 			DialDurationSamples: histogramSampleCount(m, "aztunnel_dial_duration_seconds"),
+			TokenFetchOK:        tokenFetchOKReader(m),
 			Stop:                stop,
 			Logs:                logs.String,
 		}
@@ -308,7 +429,7 @@ func (b *MockBackend) Setup(t testing.TB, opts scenarios.SetupOptions) *scenario
 	}
 
 	if opts.SenderMode == scenarios.ModeConnect {
-		tun.SetOpenConnect(b.makeOpenConnect(ctx, &wg, host, entity, clientOpts, tokenProvider))
+		tun.SetOpenConnect(b.makeOpenConnect(ctx, &wg, host, entity, clientOpts, b.newTokenProvider))
 	}
 
 	return tun
@@ -320,12 +441,17 @@ func (b *MockBackend) Setup(t testing.TB, opts scenarios.SetupOptions) *scenario
 // ConnectClient bridges the OTHER ends of those pipes; closing it
 // cancels the sender's context, closes both pipes, and drains the
 // goroutine via the parent wg.
+//
+// newProvider builds the token provider for a single connect
+// invocation against that invocation's private metrics surface; it is
+// called once per OpenConnect so each connect "process" owns its own
+// credential cache (mirroring the per-instance contract in Setup).
 func (b *MockBackend) makeOpenConnect(
 	parentCtx context.Context,
 	wg *sync.WaitGroup,
 	host, entity string,
 	clientOpts relay.ClientOptions,
-	tokenProvider relay.TokenProvider,
+	newProvider func(*metrics.Metrics) relay.TokenProvider,
 ) func(t testing.TB, target string) scenarios.ConnectClient {
 	return func(t testing.TB, target string) scenarios.ConnectClient {
 		t.Helper()
@@ -348,17 +474,19 @@ func (b *MockBackend) makeOpenConnect(
 			defer close(done)
 			// sender.Connect dereferences cfg.Metrics.InstrumentedDial
 			// unconditionally despite the doc-comment claiming Metrics
-			// is optional. Pass a fresh metrics.New() per call.
+			// is optional. Pass a fresh metrics.New() per call and build
+			// this connect's provider against it.
+			cm := metrics.New()
 			exitErr = sender.Connect(ctx, sender.ConnectConfig{
 				Endpoint:      host,
 				EntityPath:    entity,
-				TokenProvider: tokenProvider,
+				TokenProvider: newProvider(cm),
 				ClientOptions: clientOpts,
 				Target:        target,
 				Stdin:         stdinR,
 				Stdout:        stdoutW,
 				Logger:        senderLogger,
-				Metrics:       metrics.New(),
+				Metrics:       cm,
 			})
 			// Close the stdout writer so Read on the other end
 			// returns EOF instead of blocking forever.
@@ -553,11 +681,17 @@ func (b *MockBackend) SetupExpectingFailure(t testing.TB, opts scenarios.SetupOp
 	}
 
 	if opts.SenderMode == scenarios.ModeConnect {
-		// The test will drive the failure via Tunnel.OpenConnect.
+		// Auth-rejection scenarios pin the credential explicitly
+		// (good or deliberately-bad SAS) regardless of the cell's
+		// auth method — this path tests data-plane SAS validation,
+		// not provider selection, matching the Azure backend's
+		// BadSASKey handling. Wrap the fixed provider in a factory so
+		// every OpenConnect call reuses it.
 		return &mockFailureHandle{
 			listenerLogs: listenerLogs.String,
 			senderLogs:   senderLogs.String,
-			openConnect:  b.makeOpenConnect(ctx, &wg, host, entity, clientOpts, senderProvider),
+			openConnect: b.makeOpenConnect(ctx, &wg, host, entity, clientOpts,
+				func(*metrics.Metrics) relay.TokenProvider { return senderProvider }),
 		}
 	}
 
@@ -890,6 +1024,91 @@ func histogramSampleCount(m *metrics.Metrics, name string) func() uint64 {
 		}
 		return total
 	}
+}
+
+// tokenFetchOKReader returns a closure that reports one
+// scenarios.TokenFetchObservation per `provider` label observed with
+// result="ok" on m's registry, reading the counter
+// aztunnel_token_fetch_total and the histogram
+// aztunnel_token_fetch_seconds (its _count) for that sender. Returns
+// nil before any token fetch has been recorded, matching the optional-
+// nil contract on Sender.TokenFetchOK.
+//
+// Counter and histogram are read from a SINGLE Registry.Gather()
+// snapshot so a concurrent token fetch can never be seen half-applied
+// (counter incremented but histogram not, or vice versa); the
+// observability wrapper records both per call, so within one snapshot
+// they agree.
+func tokenFetchOKReader(m *metrics.Metrics) func() []scenarios.TokenFetchObservation {
+	const (
+		counterFamily = "aztunnel_token_fetch_total"
+		histFamily    = "aztunnel_token_fetch_seconds"
+	)
+	return func() []scenarios.TokenFetchObservation {
+		families, err := m.Registry.Gather()
+		if err != nil {
+			return nil
+		}
+		counters := map[string]uint64{}
+		hists := map[string]uint64{}
+		for _, f := range families {
+			switch f.GetName() {
+			case counterFamily:
+				for _, sample := range f.GetMetric() {
+					if !labelMatches(sample.GetLabel(), "result", "ok") {
+						continue
+					}
+					if c := sample.GetCounter(); c != nil {
+						counters[providerLabel(sample.GetLabel())] += uint64(c.GetValue())
+					}
+				}
+			case histFamily:
+				for _, sample := range f.GetMetric() {
+					if !labelMatches(sample.GetLabel(), "result", "ok") {
+						continue
+					}
+					if h := sample.GetHistogram(); h != nil {
+						hists[providerLabel(sample.GetLabel())] += h.GetSampleCount()
+					}
+				}
+			}
+		}
+		if len(counters) == 0 && len(hists) == 0 {
+			return nil
+		}
+		seen := map[string]struct{}{}
+		for p := range counters {
+			seen[p] = struct{}{}
+		}
+		for p := range hists {
+			seen[p] = struct{}{}
+		}
+		providers := make([]string, 0, len(seen))
+		for p := range seen {
+			providers = append(providers, p)
+		}
+		sort.Strings(providers)
+		out := make([]scenarios.TokenFetchObservation, 0, len(providers))
+		for _, p := range providers {
+			out = append(out, scenarios.TokenFetchObservation{
+				Provider:       p,
+				CounterValue:   counters[p],
+				HistogramCount: hists[p],
+			})
+		}
+		return out
+	}
+}
+
+// providerLabel returns the value of the `provider` label, or "" when
+// absent.
+func providerLabel(pairs []*dto.LabelPair) string {
+	for _, lp := range pairs {
+		if lp.GetName() == "provider" {
+			return lp.GetValue()
+		}
+	}
+	return ""
 }
 
 // captureBuffer is a goroutine-safe io.Writer used as the destination

--- a/e2e/backends/mock/e2e_test.go
+++ b/e2e/backends/mock/e2e_test.go
@@ -16,11 +16,17 @@ import (
 // TestE2E_Azure in e2e/backends/azure to surface any behavioural
 // divergence between the mock and Azure.
 //
+// The backend is built via NewAuthAxisBackend so the suite runs once
+// per auth method (sas, entra), mirroring the Azure backend's matrix.
+// The entra cell models the client-side token-acquisition cost (a
+// one-off cold AAD round trip, cached thereafter) that real Entra auth
+// pays and SAS does not.
+//
 // DelayProfileDefault is the recommended profile for e2e-style runs:
 // it approximates the wireshark-observed wall-clock shape from real
 // Azure Relay captures so timing thresholds calibrated against Azure
 // also fire against the mock.
 func TestE2E_Mock(t *testing.T) {
-	b := mock.MockBackend{DelayProfile: server.DelayProfileDefault}
-	scenarios.RunAllScenarios(t, &b)
+	b := mock.NewAuthAxisBackend(server.DelayProfileDefault)
+	scenarios.RunAllScenarios(t, b)
 }

--- a/e2e/backends/mock/entracred.go
+++ b/e2e/backends/mock/entracred.go
@@ -1,0 +1,88 @@
+package mock
+
+import (
+	"context"
+	"sync/atomic"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/philsphicas/aztunnel/internal/relay"
+	"github.com/philsphicas/aztunnel/mockrelay/server"
+)
+
+// fakeEntraCredential is an azcore.TokenCredential that models the
+// wall-clock cost of a real Entra ID token acquisition (the AAD round
+// trip aztunnel pays inside EntraTokenProvider on a cache miss) without
+// contacting any identity authority.
+//
+// It is delivered through the *real* relay.EntraTokenProvider (via
+// relay.NewEntraTokenProviderWithCredential), so every call exercises
+// the production cache: single-flight, tokenFresh, and the ExpiresOn/
+// RefreshOn refresh window. That is what lets the mock assert the cache
+// actually works — break EntraTokenProvider's caching and `calls` jumps
+// from 1 to N.
+//
+// The token string it returns is a genuine SAS token signed with the
+// mock relay's default key, because mockrelay/server.validateSAS only
+// accepts SharedAccessSignature-shaped tokens. The mock does not compare
+// the token audience (sr) against the request URI, so a single fixed
+// resource URI signs a token valid for every entity. This is a
+// deliberate fidelity trade: we model Entra *client acquisition timing +
+// caching + metrics*, NOT Entra cryptography, OAuth scopes, audience
+// binding, or server-side RBAC (none of which the mock server can
+// validate). The trade is only safe because production EntraTokenProvider
+// never parses the returned token string — it trusts AccessToken.ExpiresOn
+// directly (internal/relay/auth.go) — so a SAS-shaped string is opaque to
+// it. Revisit if EntraTokenProvider ever starts parsing the token body.
+type fakeEntraCredential struct {
+	// delay is the synthetic per-acquisition latency, modelling the
+	// AAD round trip. Applied on every underlying GetToken call (i.e.
+	// every cache miss), before the token is returned.
+	delay time.Duration
+
+	// calls counts underlying acquisitions. With a working cache this
+	// is 1 per provider for the life of a steady-state test; a value
+	// of N after N dials means the cache is not being consulted.
+	calls atomic.Int64
+}
+
+func (c *fakeEntraCredential) GetToken(ctx context.Context, _ policy.TokenRequestOptions) (azcore.AccessToken, error) {
+	c.calls.Add(1)
+	if c.delay > 0 {
+		select {
+		case <-time.After(c.delay):
+		case <-ctx.Done():
+			return azcore.AccessToken{}, ctx.Err()
+		}
+	}
+	// Sign a SAS token the mock relay will accept. The audience is a
+	// fixed placeholder — validateSAS does not bind sr to the request
+	// URI — and outlives the test so the cache treats it as fresh.
+	const tokenLifetime = time.Hour
+	tok, err := relay.GenerateSASToken(
+		"https://mock-entra.invalid/fake",
+		server.DefaultSASKeyName,
+		server.DefaultSASKey,
+		tokenLifetime,
+	)
+	if err != nil {
+		return azcore.AccessToken{}, err
+	}
+	return azcore.AccessToken{
+		Token:     tok,
+		ExpiresOn: time.Now().Add(tokenLifetime),
+		// RefreshOn left zero: EntraTokenProvider falls back to the
+		// ExpiresOn-minus-skew freshness rule, so the token stays a
+		// cache hit until ~5 min before expiry (i.e. the whole test).
+	}, nil
+}
+
+// newFakeEntraProvider builds a real EntraTokenProvider backed by a
+// fakeEntraCredential, returning both so callers can assert on the
+// credential's call count. Each call produces an independent provider
+// with its own cache, mirroring a separate aztunnel process.
+func newFakeEntraProvider(delay time.Duration) (relay.TokenProvider, *fakeEntraCredential) {
+	cred := &fakeEntraCredential{delay: delay}
+	return relay.NewEntraTokenProviderWithCredential(cred), cred
+}

--- a/e2e/backends/mock/entracred_test.go
+++ b/e2e/backends/mock/entracred_test.go
@@ -1,0 +1,166 @@
+//go:build e2e
+
+package mock
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/philsphicas/aztunnel/internal/listener"
+	"github.com/philsphicas/aztunnel/internal/metrics"
+	"github.com/philsphicas/aztunnel/internal/sender"
+	"github.com/philsphicas/aztunnel/mockrelay/server"
+)
+
+// TestMockEmulates_EntraTokenAcquisitionDelay demonstrates that the
+// in-process mock can reproduce the entra-vs-sas timing divergence we
+// measure against real Azure Relay — a one-off cold-start token-fetch
+// cost on each process's first dial, absorbed thereafter by the client
+// token cache — purely from the harness side, with no production change.
+//
+// It asserts two things:
+//
+//   - Cache correctness (the hard check): across many serial dials the
+//     sender acquires a token exactly once, proving EntraTokenProvider's
+//     cache is consulted. Listener acquires once for its control channel.
+//
+//   - Cold-start shape (a coarse timing check): the first connection
+//     through the freshly-started sender pays roughly the acquisition
+//     delay on top of the rendezvous cost; subsequent connections do
+//     not. Kept loose (> delay/2) because rendezvous DelayProfile sleeps
+//     and CI scheduling add noise.
+func TestMockEmulates_EntraTokenAcquisitionDelay(t *testing.T) {
+	const acquireDelay = 450 * time.Millisecond
+	const dials = 6
+
+	host, clientOpts := startMockRelay(t, server.DelayProfileDefault)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	var wg sync.WaitGroup
+	t.Cleanup(func() { cancel(); wg.Wait() })
+
+	entity := mustEntityName(t)
+	silentLogger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	// Separate providers => separate caches => each "process" pays its
+	// own cold acquisition, exactly as separate aztunnel processes do.
+	listenerTP, listenerCred := newFakeEntraProvider(acquireDelay)
+	senderTP, senderCred := newFakeEntraProvider(acquireDelay)
+
+	echoLn, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen echo: %v", err)
+	}
+	t.Cleanup(func() { _ = echoLn.Close() })
+	go runEchoServerEmul(echoLn)
+
+	m := metrics.New()
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		err := listener.ListenAndServe(ctx, listener.Config{
+			Endpoint:      host,
+			EntityPath:    entity,
+			TokenProvider: listenerTP,
+			ClientOptions: clientOpts,
+			AllowList:     []string{echoLn.Addr().String()},
+			Logger:        silentLogger,
+			Metrics:       m,
+		})
+		if err != nil && ctx.Err() == nil {
+			t.Logf("listener exited: %v", err)
+		}
+	}()
+	if !waitForGauge(m, "aztunnel_control_channel_connected", 1, 15*time.Second) {
+		t.Fatalf("listener never reported control_channel_connected")
+	}
+
+	addrCh := make(chan net.Addr, 1)
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		err := sender.PortForward(ctx, sender.PortForwardConfig{
+			Endpoint:      host,
+			EntityPath:    entity,
+			TokenProvider: senderTP,
+			ClientOptions: clientOpts,
+			Target:        echoLn.Addr().String(),
+			BindAddress:   "127.0.0.1:0",
+			Logger:        silentLogger,
+			Metrics:       metrics.New(),
+			Ready: func(a net.Addr) {
+				select {
+				case addrCh <- a:
+				default:
+				}
+			},
+		})
+		if err != nil && ctx.Err() == nil {
+			t.Logf("sender exited: %v", err)
+		}
+	}()
+
+	var senderAddr net.Addr
+	select {
+	case senderAddr = <-addrCh:
+	case <-time.After(15 * time.Second):
+		t.Fatalf("sender never became ready")
+	}
+
+	durations := make([]time.Duration, dials)
+	for i := 0; i < dials; i++ {
+		durations[i] = echoRoundTrip(t, senderAddr.String())
+	}
+
+	// Hard check: the cache was consulted. One acquisition for the
+	// sender across all dials; one for the listener's control channel.
+	if got := senderCred.calls.Load(); got != 1 {
+		t.Errorf("sender token acquisitions = %d, want 1 (cache not consulted across %d dials)", got, dials)
+	}
+	if got := listenerCred.calls.Load(); got != 1 {
+		t.Errorf("listener token acquisitions = %d, want 1", got)
+	}
+
+	// Coarse cold-start shape: first dial pays ~acquireDelay more than
+	// the steady-state median. Loose threshold to tolerate rendezvous
+	// sleeps + CI noise.
+	var rest time.Duration
+	for _, d := range durations[1:] {
+		rest += d
+	}
+	median := rest / time.Duration(dials-1)
+	coldPremium := durations[0] - median
+	t.Logf("cold dial=%s steady-median=%s cold-premium=%s (modelled acquireDelay=%s)",
+		durations[0], median, coldPremium, acquireDelay)
+	if coldPremium < acquireDelay/2 {
+		t.Errorf("cold-start premium = %s, want > %s (cold acquisition cost not visible)",
+			coldPremium, acquireDelay/2)
+	}
+}
+
+// echoRoundTrip dials the sender's local bind, writes one line, reads
+// the echo back, and returns the wall-clock time for the round trip.
+func echoRoundTrip(t *testing.T, addr string) time.Duration {
+	t.Helper()
+	start := time.Now()
+	conn, err := net.DialTimeout("tcp", addr, 10*time.Second)
+	if err != nil {
+		t.Fatalf("dial sender: %v", err)
+	}
+	defer conn.Close() //nolint:errcheck // best-effort cleanup
+	_ = conn.SetDeadline(time.Now().Add(15 * time.Second))
+	payload := []byte("entra-cold-start\n")
+	if _, err := conn.Write(payload); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	buf := make([]byte, len(payload))
+	if _, err := io.ReadFull(conn, buf); err != nil {
+		t.Fatalf("read echo: %v", err)
+	}
+	return time.Since(start)
+}

--- a/e2e/scenarios/backend.go
+++ b/e2e/scenarios/backend.go
@@ -397,12 +397,12 @@ type Sender struct {
 	// sender's /metrics surface, filtered to result="ok". Returns
 	// nil when no observations have been recorded yet.
 	//
-	// Used by ScenarioTokenFetchMetric (scope=AzureOnly) to assert
-	// that exactly one token-provider was used and that the counter
-	// and histogram counts agree. Optional: backends that do not
-	// fetch real credentials (the in-process mock) leave this nil;
-	// the scenario itself carries scope=AzureOnly so the mock skips
-	// it before dereferencing this field.
+	// Used by ScenarioTokenFetchMetric to assert that exactly one
+	// token-provider was used and that the counter and histogram
+	// counts agree. Optional: backends that do not wire token-fetch
+	// metrics leave this nil and the scenario skips. Both the Azure
+	// backend and the in-process mock (via its {sas, entra} auth axis)
+	// populate it.
 	TokenFetchOK func() []TokenFetchObservation
 
 	// Stop drops this sender. Idempotent.

--- a/e2e/scenarios/observability.go
+++ b/e2e/scenarios/observability.go
@@ -30,9 +30,9 @@ func RunObservabilityScenarios(t *testing.T, b Backend) {
 
 // observabilityCases is the metadata-only registry of observability
 // scenarios. The cross-backend log-shape parity gate is what makes
-// the suite meaningful, so every entry is AnyBackend except
-// TokenFetchMetric — which exists only on Azure because the mock has
-// no Entra/SAS provider to fetch from.
+// the suite meaningful, so every entry is AnyBackend — including
+// TokenFetchMetric, which the mock now satisfies via its {sas, entra}
+// auth axis and per-sender token-fetch metrics.
 func observabilityCases() []scenarioCase {
 	return []scenarioCase{
 		{name: "BridgeID_Correlation", scope: AnyBackend, run: ScenarioBridgeID_Correlation},
@@ -46,12 +46,7 @@ func observabilityCases() []scenarioCase {
 		{name: "Metrics_DialDuration", scope: AnyBackend, run: ScenarioMetrics_DialDuration},
 		{name: "ListenerID_PropagatesAndChangesOnRestart", scope: AnyBackend, run: ScenarioListenerID_PropagatesAndChangesOnRestart},
 		{name: "AcceptID_Saturation", scope: AnyBackend, run: ScenarioAcceptID_Saturation},
-		{
-			name:   "TokenFetchMetric",
-			scope:  AzureOnly,
-			reason: "exercises real Entra/SAS provider token fetch wiring; the mock relay does not fetch credentials",
-			run:    ScenarioTokenFetchMetric,
-		},
+		{name: "TokenFetchMetric", scope: AnyBackend, run: ScenarioTokenFetchMetric},
 	}
 }
 
@@ -1074,9 +1069,11 @@ func waitForLogSubstring(logs func() string, substr string, timeout time.Duratio
 // Backend.Sender.TokenFetchOK reports observed providers via the
 // returned []TokenFetchObservation slice.
 //
-// scope=AzureOnly via the observability registry: the in-process
-// mock has no Entra/SAS provider to fetch from. The mock-side
-// emulation of the metric SHAPE lives in
+// scope=AnyBackend: both the Azure backend and the in-process mock
+// (whose {sas, entra} auth axis wraps its providers with
+// relay.WithMetrics) expose Sender.TokenFetchOK. A backend that leaves
+// TokenFetchOK nil skips. The mock's lower-level wrapper coverage
+// (including the result="error" path) lives in
 // TestMockEmulates_TokenFetchMetric.
 func ScenarioTokenFetchMetric(t *testing.T, b Backend) {
 	t.Helper()

--- a/e2e/scenarios/scenarios_registry_test.go
+++ b/e2e/scenarios/scenarios_registry_test.go
@@ -68,8 +68,6 @@ func TestScenarioCases_AzureOnlyScopes(t *testing.T) {
 		"AuthRejection_BadHyco":    "reliability",
 		"AuthRejection_CrossClaim": "reliability",
 		"LongLivedConnection":      "reliability",
-		// observability
-		"TokenFetchMetric": "observability",
 	}
 
 	gotAzureOnly := map[string]string{}


### PR DESCRIPTION
## Summary

The in-process mock relay backend now models the client-side **Entra token-acquisition cost** that real Azure Relay pays, so the mock and Azure conformance matrices line up on auth behaviour.

Real clients pay a one-off cold AAD round trip on a fresh process when using Entra auth, absorbed thereafter by the client token cache; SAS signs locally for free. The mock previously spoke only SAS and ignored this, so it could not reproduce the entra-vs-sas timing divergence seen against real Azure Relay, and `TokenFetchMetric` only ran on the Azure backend.

## What's new

- **Auth axis `{sas, entra}`** on `MockBackend`, mirroring the Azure backend's matrix. The shared scenario suite runs once per auth method, so the entra cell now exercises cold-start and token-fetch behaviour on every scenario.
- **Real cold-acquisition modelling**: the entra cell drives the *real* `EntraTokenProvider` (exercising its production single-flight cache end to end) behind a synthetic-latency credential, so the cache is genuinely validated rather than approximated.
- **Per-process providers**: each listener, sender, and connect invocation owns its own credential cache — mirroring separate aztunnel processes — so the cold-start cost is visible instead of masked by a shared cache.
- **Token-fetch metrics on the mock**: providers are instrumented per sender, so `TokenFetchMetric` now runs on both backends (flipped from Azure-only).

Auth cost is orthogonal to the geographic `DelayProfile` and composes with it. The zero-value `MockBackend` stays SAS-only and single-axis, so benchmarks are unaffected.

## Behaviour

- Entra cold-start ≈ 1.20s vs SAS ≈ 0.75s — the modelled ~450ms acquisition premium, matching observed Azure data.
- Full mock e2e suite passes on both cells; the entra cell's cold-start budget is widened to 5s to keep headroom over the cold fetch.

No production aztunnel code is changed — the modelling lives entirely in the e2e harness.