### PR TITLE
test(e2e): dump tunnel logs when ConnectLatency scenarios fail

### DIFF
--- a/e2e/scenarios/performance.go
+++ b/e2e/scenarios/performance.go
@@ -235,6 +235,7 @@ func runSerialConnectLatency(t *testing.T, b Backend, mode SenderMode) {
 		opts.Target = echo.Addr()
 	}
 	tun := b.Setup(t, opts)
+	dumpConnectLatencyLogsOnFail(t, tun)
 
 	const iterations = 10
 	payload := []byte{0x42}
@@ -256,6 +257,53 @@ func runSerialConnectLatency(t *testing.T, b Backend, mode SenderMode) {
 			continue
 		}
 		t.Logf("ConnectLatency_Serial_%v iter %d: %v (< %v)", mode, i, elapsed, threshold)
+	}
+}
+
+// dumpConnectLatencyLogsOnFail registers a t.Cleanup that prints the
+// captured sender and listener logs for every process in the tunnel,
+// but only when the scenario has failed. The ConnectLatency_Serial
+// scenarios' dominant failure mode against real Azure Relay is a
+// single multi-second connect stall (one iteration spiking from
+// ~750 ms steady-state to >3 s, or past the 8 s i/o-timeout deadline
+// on the SOCKS5 variant). Without the binary logs that stall is
+// undiagnosable from CI output — it could be a client-side dial
+// retry / control-channel reconnect or pure Azure tail latency, and
+// the test output alone cannot distinguish them. Dumping on failure
+// makes the next occurrence actionable.
+//
+// Registering a single failure-gated cleanup (rather than dumping at
+// each failing assertion) keeps successful runs silent and emits at
+// most one dump even when multiple iterations breach the threshold;
+// Logs() returns the cumulative buffer, so one dump captures the
+// whole run. Backends that do not wire log capture (Logs == nil)
+// contribute nothing.
+func dumpConnectLatencyLogsOnFail(t *testing.T, tun *Tunnel) {
+	t.Helper()
+	t.Cleanup(func() {
+		if t.Failed() {
+			dumpTunnelLogs(t, tun)
+		}
+	})
+}
+
+// dumpTunnelLogs prints the captured sender and listener logs for
+// every process in the tunnel, skipping nil handles and backends that
+// did not wire log capture (Logs == nil). It is unconditional; the
+// failure gate lives in dumpConnectLatencyLogsOnFail's cleanup.
+func dumpTunnelLogs(t *testing.T, tun *Tunnel) {
+	t.Helper()
+	for i, s := range tun.Senders {
+		if s == nil || s.Logs == nil {
+			continue
+		}
+		t.Logf("--- sender[%d] logs ---\n%s", i, s.Logs())
+	}
+	for i, l := range tun.Listeners {
+		if l == nil || l.Logs == nil {
+			continue
+		}
+		t.Logf("--- listener[%d] logs ---\n%s", i, l.Logs())
 	}
 }
 
@@ -330,6 +378,7 @@ func runColdStartConnectLatency(t *testing.T, b Backend, mode SenderMode) {
 		opts.Target = echo.Addr()
 	}
 	tun := b.Setup(t, opts)
+	dumpConnectLatencyLogsOnFail(t, tun)
 
 	payload := []byte{0x42}
 	buf := make([]byte, 1)

--- a/e2e/scenarios/performance_test.go
+++ b/e2e/scenarios/performance_test.go
@@ -1,0 +1,52 @@
+package scenarios
+
+import (
+	"sync/atomic"
+	"testing"
+)
+
+func tunnelWithLogCounters(senderCalls, listenerCalls *atomic.Int32) *Tunnel {
+	return &Tunnel{
+		Senders: []*Sender{
+			{Logs: func() string { senderCalls.Add(1); return "sender log" }},
+			nil,         // nil handle must be skipped
+			{Logs: nil}, // nil accessor must be skipped
+		},
+		Listeners: []*Listener{
+			{Logs: func() string { listenerCalls.Add(1); return "listener log" }},
+			nil,
+			{Logs: nil},
+		},
+	}
+}
+
+// TestDumpTunnelLogs verifies the dump reads exactly the non-nil
+// sender/listener accessors and tolerates nil handles / nil accessors
+// without panicking.
+func TestDumpTunnelLogs(t *testing.T) {
+	var senderCalls, listenerCalls atomic.Int32
+	dumpTunnelLogs(t, tunnelWithLogCounters(&senderCalls, &listenerCalls))
+	if got := senderCalls.Load(); got != 1 {
+		t.Errorf("sender Logs called %d times, want 1", got)
+	}
+	if got := listenerCalls.Load(); got != 1 {
+		t.Errorf("listener Logs called %d times, want 1", got)
+	}
+}
+
+// TestDumpConnectLatencyLogsOnFail_SilentOnSuccess verifies the
+// failure-gated cleanup does not touch the captured buffers when the
+// scenario passes.
+func TestDumpConnectLatencyLogsOnFail_SilentOnSuccess(t *testing.T) {
+	var senderCalls, listenerCalls atomic.Int32
+	t.Run("inner", func(inner *testing.T) {
+		dumpConnectLatencyLogsOnFail(inner, tunnelWithLogCounters(&senderCalls, &listenerCalls))
+		// inner passes — cleanup must stay silent.
+	})
+	if got := senderCalls.Load(); got != 0 {
+		t.Errorf("sender Logs called %d times on success, want 0", got)
+	}
+	if got := listenerCalls.Load(); got != 0 {
+		t.Errorf("listener Logs called %d times on success, want 0", got)
+	}
+}


### PR DESCRIPTION
## What

When a `ConnectLatency_Serial` or `ConnectLatency_ColdStart` scenario fails — typically because a single dial through Azure Relay stalls for several seconds and trips the latency threshold (or the SOCKS5 i/o-timeout deadline) — the test now dumps the captured sender and listener logs.

## Why

Previously these scenarios failed without surfacing the aztunnel binary logs. A multi-second connect stall could be a client-side dial retry / control-channel reconnect, or pure Azure Relay tail latency, and the test output alone could not distinguish them. The captured logs (which include the relay dial-retry warnings) are exactly the evidence needed, but nothing printed them on failure.

## Behaviour

- A failure-gated `t.Cleanup` prints each captured sender and listener log buffer when the scenario fails, and stays silent on success.
- Nil-safe: backends that do not wire log capture contribute nothing.
- At most one dump per run even when multiple iterations breach the threshold (the buffer is cumulative).

Unit tests cover the nil-safety and the success-path silence.
