### PR TITLE
Rename perf characterization metrics to honest RTT vocabulary

### DIFF
--- a/e2e/scenarios/performance.go
+++ b/e2e/scenarios/performance.go
@@ -494,10 +494,11 @@ func timeOneConnect(senderAddr, target string, mode SenderMode, payload, buf []b
 // requests are discarded from the reported stats.
 //
 //	cold-path scenarios (ConnPerRequest, ConnReused):
-//	  WarmupRequests = 0 — first request times count as ttfw/ttc
+//	  WarmupRequests = 0 — the first request's round-trip is reported
+//	  as cold_rtt (includes connection establishment)
 //	steady-state scenarios (ConnPrewarmed):
 //	  WarmupRequests = 1 — first request is discarded; the rest are
-//	  reported as warm_min/mean/p50/p95/p99/max
+//	  reported as warm_rtt_min/mean/p50/p95/p99/max
 type WorkloadShape struct {
 	TotalConns      int
 	Concurrency     int
@@ -612,8 +613,13 @@ type connResult struct {
 }
 
 type firstReqTiming struct {
-	TTFW time.Duration // dial → first write complete (request transmitted to local sender; NOT the conventional "time to first byte received")
-	TTC  time.Duration // dial → first read complete (full request → response round-trip including dial)
+	// ColdRTT is the cold-path round-trip: open → first response
+	// received on a fresh connection. It spans the full
+	// request → target → response round-trip and, because the
+	// connection is new, includes connection establishment. With a
+	// tiny payload against an instant echo target, "first response"
+	// coincides with "round-trip complete", so this is an honest RTT.
+	ColdRTT time.Duration
 }
 
 func runRound(t *testing.T, tun *Tunnel, addrs []string, threshold time.Duration, w WorkloadShape) {
@@ -641,15 +647,15 @@ func runRound(t *testing.T, tun *Tunnel, addrs []string, threshold time.Duration
 			switch {
 			case w.WarmupRequests > 0 && len(r.Warm) > 0:
 				wmin, wmax, wmean := minMaxMean(r.Warm)
-				t.Logf("conn[%d] warm_n=%d warm_min=%v warm_mean=%v warm_max=%v",
+				t.Logf("conn[%d] warm_n=%d warm_rtt_min=%v warm_rtt_mean=%v warm_rtt_max=%v",
 					i, len(r.Warm), wmin, wmean, wmax)
 			case len(r.Warm) > 0:
 				wmin, wmax, wmean := minMaxMean(r.Warm)
-				t.Logf("conn[%d] first_req_ttfw=%v first_req_ttc=%v warm_n=%d warm_min=%v warm_mean=%v warm_max=%v",
-					i, r.FirstReq.TTFW, r.FirstReq.TTC, len(r.Warm), wmin, wmean, wmax)
+				t.Logf("conn[%d] cold_rtt=%v warm_n=%d warm_rtt_min=%v warm_rtt_mean=%v warm_rtt_max=%v",
+					i, r.FirstReq.ColdRTT, len(r.Warm), wmin, wmean, wmax)
 			default:
-				t.Logf("conn[%d] ttfw=%v ttc=%v",
-					i, r.FirstReq.TTFW, r.FirstReq.TTC)
+				t.Logf("conn[%d] cold_rtt=%v",
+					i, r.FirstReq.ColdRTT)
 			}
 		}(i)
 	}
@@ -657,15 +663,14 @@ func runRound(t *testing.T, tun *Tunnel, addrs []string, threshold time.Duration
 	wall := time.Since(start)
 
 	var failures int
-	var coldTTFW, coldTTC, warmAll []time.Duration
+	var coldRTT, warmAll []time.Duration
 	for _, r := range results {
 		if r.Err != nil {
 			failures++
 			continue
 		}
 		if w.WarmupRequests == 0 {
-			coldTTFW = append(coldTTFW, r.FirstReq.TTFW)
-			coldTTC = append(coldTTC, r.FirstReq.TTC)
+			coldRTT = append(coldRTT, r.FirstReq.ColdRTT)
 		}
 		warmAll = append(warmAll, r.Warm...)
 	}
@@ -682,19 +687,16 @@ func runRound(t *testing.T, tun *Tunnel, addrs []string, threshold time.Duration
 	// `TestE2E_Azure/entra/Parallel_ConnPrewarmedEcho_SOCKS5`).
 	parts = append(parts, "workload-summary", fmt.Sprintf("scenario=%s", t.Name()))
 
-	if len(coldTTFW) > 0 {
-		parts = append(parts,
-			fmtDist("ttfw", coldTTFW),
-			fmtDist("ttc", coldTTC),
-		)
+	if len(coldRTT) > 0 {
+		parts = append(parts, fmtDist("cold_rtt", coldRTT))
 	}
 	if len(warmAll) > 0 {
-		parts = append(parts, fmtDist("warm", warmAll))
+		parts = append(parts, fmtDist("warm_rtt", warmAll))
 	}
 	parts = append(parts,
 		fmt.Sprintf("wall=%v", wall),
 		fmt.Sprintf("budget=%v", budget),
-		fmt.Sprintf("cold_n=%d", len(coldTTFW)),
+		fmt.Sprintf("cold_n=%d", len(coldRTT)),
 		fmt.Sprintf("warm_n=%d", len(warmAll)),
 		fmt.Sprintf("num_targets=%d", len(addrs)),
 		fmt.Sprintf("success=%d/%d", w.TotalConns-failures, w.TotalConns),
@@ -843,9 +845,6 @@ func runOneConn(senderAddr, target string, w WorkloadShape, roundDeadline time.T
 			res.Err = fmt.Errorf("write[%d]: %w", i, err)
 			return res
 		}
-		if i == 0 && w.WarmupRequests == 0 {
-			res.FirstReq.TTFW = time.Since(dialStart)
-		}
 		if _, err = io.ReadFull(conn, buf); err != nil {
 			res.Err = fmt.Errorf("read[%d]: %w", i, err)
 			return res
@@ -857,7 +856,7 @@ func runOneConn(senderAddr, target string, w WorkloadShape, roundDeadline time.T
 		elapsed := time.Since(reqStart)
 		switch {
 		case i == 0 && w.WarmupRequests == 0:
-			res.FirstReq.TTC = time.Since(dialStart)
+			res.FirstReq.ColdRTT = time.Since(dialStart)
 		case i >= w.WarmupRequests:
 			res.Warm = append(res.Warm, elapsed)
 		}


### PR DESCRIPTION
## What

The client-side performance characterization harness emits `workload-summary` log lines as its product. This renames those metrics so the labels are honest about what they measure, from the client/black-box perspective.

- **`cold_rtt`** (was `ttc`): the first request's full round-trip on a fresh connection, including connection establishment.
- **`warm_rtt_*`** (was `warm_*`): steady-state round-trip on an already-established connection.
- **`ttfw` is removed.** It only measured how quickly the local aztunnel sender accepted the request into its send buffer — not a round-trip — and was misleading.

`cold_rtt − warm_rtt` now gives a meaningful approximation of connection-establishment cost.

## Why

The previous vocabulary (`ttfw`/`ttc`) borrowed HTTP-ish "time to first byte/write" framing that didn't match what the harness actually times. The new names state the measurement honestly and read consistently across port-forward and SOCKS5 modes.

## Compatibility

No test, CI job, or script parses these labels (only a human-facing Makefile comment references the summary line), so the rename is consumer-safe.

## Example output

```
workload-summary scenario=.../Serial_ConnReusedEcho_PortForward cold_rtt_min=751ms ... warm_rtt_min=121ms warm_rtt_p95=122ms ... cold_n=1 warm_n=29 num_targets=1 success=1/1
```

## Verification

- `go build -tags e2e ./...` + `go vet` clean
- Full mock perf suite (`TestE2E_Mock`, sas+entra × port-forward/SOCKS5) passes; summary lines emit `cold_rtt_*`/`warm_rtt_*`/`cold_n`/`warm_n` correctly.