### PR TITLE
Consolidate the e2e perf harness: matrix, history, and a regression gate

### DIFF
--- a/.github/workflows/perf-nightly.yml
+++ b/.github/workflows/perf-nightly.yml
@@ -1,0 +1,118 @@
+name: Perf (nightly gate)
+
+# Nightly gross-regression gate for the mock perf suite. Runs the mock
+# placement sweep, compares it against the previous nightly baseline,
+# and fails only on a *gross* regression (default >30% AND >20ms on a
+# warm/cold p50 cell). Mock-only on purpose: the real Azure relay's
+# rendezvous latency spikes (~3-6s) swamp any gate threshold, so Azure
+# perf is measured but never gated.
+#
+# Baseline persistence: runners are ephemeral and the history dir is
+# gitignored, so the previous run's history is carried forward as a
+# build artifact. Each night we download the last *successful*
+# scheduled run's `perf-history`, add tonight's run, gate the two
+# newest, then re-upload the pruned history — but only on success, so a
+# regressing night never overwrites the known-good baseline.
+on:
+  schedule:
+    - cron: "0 7 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  actions: read
+
+concurrency:
+  group: perf-nightly
+  cancel-in-progress: false
+
+env:
+  HISTORY_DIR: e2e/perf-artifacts/history
+  KEEP_RUNS: "10"
+  FAIL_OVER: "30"
+
+jobs:
+  perf-gate:
+    name: Perf nightly gate (mock)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: read
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version: stable
+
+      - name: Build
+        run: make build
+
+      - name: Restore previous nightly baseline
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          mkdir -p "$HISTORY_DIR"
+          prev=$(gh run list \
+            --workflow "${{ github.workflow }}" \
+            --branch main --event schedule --status success \
+            --limit 1 --json databaseId -q '.[0].databaseId // empty')
+          if [ -z "$prev" ]; then
+            echo "no prior successful scheduled run — bootstrapping baseline this night"
+            exit 0
+          fi
+          echo "restoring baseline from run $prev"
+          gh run download "$prev" -n perf-history -D "$HISTORY_DIR"
+          # upload-artifact may preserve a nested path under the artifact;
+          # flatten any nested *.jsonl up to the top level so the gate,
+          # prune, and re-upload steps (which all glob the top level) see
+          # the baseline. -mindepth 2 skips files already at the top, so
+          # this never tries to move a file onto itself.
+          find "$HISTORY_DIR" -mindepth 2 -name '*.jsonl' -exec mv -t "$HISTORY_DIR" {} +
+          find "$HISTORY_DIR" -mindepth 1 -type d -empty -delete
+          count=$(find "$HISTORY_DIR" -maxdepth 1 -name '*.jsonl' | wc -l)
+          # A prior good run exists, so its artifact MUST restore at
+          # least one history file. Zero means the download silently
+          # failed — fail loudly rather than let the gate degrade into
+          # a perpetual no-op that always "passes" on an empty store.
+          if [ "$count" -lt 1 ]; then
+            echo "::error::baseline run $prev produced no history files on download" >&2
+            exit 1
+          fi
+          echo "restored $count baseline history file(s)"
+
+      - name: Run mock perf scenarios
+        run: make perf-placement
+
+      - name: Gate on gross regression
+        run: make perf-gate FAIL_OVER=$FAIL_OVER
+
+      - name: Render perf matrix into job summary
+        if: always()
+        run: |
+          {
+            echo '## Perf nightly matrix (mock)'
+            echo
+            echo '```'
+            make perf-table 2>&1 || echo '(no perf artifacts produced)'
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Prune history to most recent runs
+        run: |
+          set -euo pipefail
+          cd "$HISTORY_DIR"
+          ls -1 *.jsonl 2>/dev/null | sort | head -n -"$KEEP_RUNS" | xargs -r rm -f
+          echo "history now holds $(find . -name '*.jsonl' | wc -l) run file(s)"
+
+      # Upload only on success: a gate failure (regression) must NOT
+      # become next night's baseline. `gh run list --status success`
+      # then naturally picks the last known-good run to restore.
+      - name: Upload perf history
+        uses: actions/upload-artifact@v7
+        with:
+          name: perf-history
+          path: e2e/perf-artifacts/history/*.jsonl
+          if-no-files-found: error

--- a/.github/workflows/perf-pr.yml
+++ b/.github/workflows/perf-pr.yml
@@ -1,0 +1,67 @@
+name: Perf (PR, opt-in)
+
+# Opt-in performance characterization for a pull request. This is a
+# *measurement* lens on the mock e2e suite, not a gate: it always
+# reports green and never blocks a merge. Trigger it deliberately,
+# either by adding the `perf` label to a PR or via the Actions
+# "Run workflow" button — perf numbers are noisy enough that running
+# them on every push would be cost without signal.
+on:
+  pull_request:
+    types: [labeled]
+  workflow_dispatch:
+
+# Read-only. The mock backend needs no cloud credentials, so we never
+# grant id-token: write — PR-supplied code (`make build` /
+# `make perf-placement`) cannot mint an OIDC token. No write scope
+# means the job cannot comment on or mutate the PR either; results are
+# surfaced via the job summary and an uploaded artifact instead.
+permissions:
+  contents: read
+
+concurrency:
+  group: perf-pr-${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  perf-mock:
+    name: Perf (mock)
+    # Only run on the dispatch button or when the triggering label is
+    # exactly `perf`; otherwise every unrelated label edit would spawn
+    # a run.
+    if: github.event_name == 'workflow_dispatch' || github.event.label.name == 'perf'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version: stable
+
+      - name: Build
+        run: make build
+
+      - name: Run mock perf scenarios
+        run: make perf-placement
+
+      - name: Render perf matrix into job summary
+        if: always()
+        run: |
+          {
+            echo '## Perf matrix (mock)'
+            echo
+            echo '```'
+            make perf-table 2>&1 || echo '(no perf artifacts produced)'
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload perf history
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: perf-history-pr
+          path: e2e/perf-artifacts/history/*.jsonl
+          if-no-files-found: warn

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ bin/
 coverage.txt
 coverage.html
 e2e/.local.json
+e2e/perf-artifacts/
 
 # IDE
 .vscode/

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ LDFLAGS  := -ldflags "-X main.version=$(VERSION)"
 CGO    := $(shell go env CGO_ENABLED)
 RACE   := $(if $(filter 1,$(CGO)),-race,)
 
-.PHONY: build test cover lint clean install docker docker-alpine docker-bookworm fmt fmt-check e2e e2e-mock e2e-mock-fast e2e-mock-matrix e2e-azure e2e-docker e2e-setup e2e-attach e2e-status e2e-clean e2e-grant e2e-ci e2e-janitor perf perf-mock perf-azure vulncheck check-installable help
+.PHONY: build test cover lint clean install docker docker-alpine docker-bookworm fmt fmt-check e2e e2e-mock e2e-mock-fast e2e-mock-matrix e2e-azure e2e-docker e2e-setup e2e-attach e2e-status e2e-clean e2e-grant e2e-ci e2e-janitor perf perf-mock perf-azure perf-matrix perf-placement perf-placement-azure perf-axes-mock perf-table perf-grid perf-history perf-compare perf-clean-history perf-gate vulncheck check-installable help
 
 .DEFAULT_GOAL := help
 
@@ -100,7 +100,7 @@ e2e-mock: ## Run e2e scenarios against the in-process mock relay (both auth meth
 e2e-mock-fast: ## Run mock e2e as fast as possible: zero delay profile, no synthetic token-acquisition cost (both auth methods)
 	cd e2e && E2E_DELAY=zero go test -tags=e2e -timeout=20m -v ./backends/mock/...
 
-e2e-mock-matrix: ## Run mock e2e over the full auth x delay-profile matrix (both auth methods x every registered profile)
+e2e-mock-matrix: ## Run mock e2e over the full auth x delay-profile matrix (both auth methods x the curated functional delay set: zero + default)
 	cd e2e && E2E_DELAY=all go test -tags=e2e -timeout=40m -v ./backends/mock/...
 
 e2e-azure: build ## Run e2e scenarios against a real Azure Relay namespace (configure via `make e2e-setup`)
@@ -163,11 +163,46 @@ vulncheck: ## Check Go dependencies for known vulnerabilities
 # extract the per-shape distribution. Override the scenario filter
 # with PERF=<regex>, e.g.
 # `make perf-mock PERF=Parallel_ConnPrewarmedEcho_SOCKS5`.
-PERF_SCENARIO_FILTER = $(or $(PERF),^(ConnectLatency|ShortSession|Serial_Conn|Parallel_Conn))
+#
+# The perf -run patterns must skip the axis sub-test layer(s) that the
+# backends insert as t.Run wrappers above the scenario name. The two
+# backends differ:
+#   - Mock OMITS an axis layer for any dimension pinned to one value:
+#     auth is a layer only when E2E_AUTH is unset (both sas+entra run),
+#     and delay is a layer only when E2E_DELAY names more than one
+#     profile (a comma list, or the `all` token, which expands to the
+#     functional matrix). So mock needs 0, 1, or 2 layers — derived
+#     here as PERF_AXIS_PREFIX_MOCK.
+#   - Azure ALWAYS wraps the auth dimension in exactly one t.Run layer
+#     (even when E2E_AUTH pins a single method the layer remains) and
+#     has no delay axis, so its prefix is a fixed single `[^/]+/`.
+# Deriving the mock prefix from the env keeps `-run` matched to the
+# real sub-test depth, so `make perf-mock E2E_AUTH=sas` (or
+# `E2E_DELAY=all`) selects the intended scenarios instead of skipping
+# the filter.
+# PERF_ALL_SCENARIOS is the default scenario filter: every perf scenario
+# family. PERF=<regex> overrides it; PERF=all (in perf-placement) expands
+# back to this set.
+comma := ,
+empty :=
+space := $(empty) $(empty)
+# Mock omits a t.Run layer for any dimension pinned to a single value.
+# Auth: a layer only when E2E_AUTH is unset. Delay: a layer only when
+# more than one DISTINCT profile runs — the `all` token (expands to the
+# functional matrix) or a comma list with >1 distinct name. $(sort)
+# dedupes like delayProfileNamesFromEnv, so degenerate lists such as
+# `default,default` collapse to one word and add no layer.
+PERF_MOCK_AUTH_LAYER = $(if $(strip $(E2E_AUTH)),,[^/]+/)
+PERF_MOCK_DELAY_LAYER = $(if $(filter all,$(E2E_DELAY)),[^/]+/,$(if $(word 2,$(sort $(subst $(comma),$(space),$(E2E_DELAY)))),[^/]+/,))
+PERF_AXIS_PREFIX_MOCK = $(PERF_MOCK_AUTH_LAYER)$(PERF_MOCK_DELAY_LAYER)
+PERF_ALL_SCENARIOS = ^(ConnectLatency|ShortSession|Serial_Conn|Parallel_Conn)
+PERF_SCENARIO_FILTER = $(or $(PERF),$(PERF_ALL_SCENARIOS))
 
 perf-mock: ## Run performance characterization scenarios against the in-process mock relay
-	cd e2e && go test -tags=e2e -timeout=20m -v \
-		-run='TestE2E_Mock/$(PERF_SCENARIO_FILTER)' \
+	cd e2e && PERF_MATRIX_BACKEND=mock \
+		PERF_MATRIX_GIT_SHA="$$(git rev-parse --short HEAD 2>/dev/null)" \
+		go test -tags=e2e -count=1 -timeout=20m -v \
+		-run='TestE2E_Mock/$(PERF_AXIS_PREFIX_MOCK)$(PERF_SCENARIO_FILTER)' \
 		./backends/mock/
 
 # Pass E2E_AUTH=entra (or sas) to pin one auth method and skip the
@@ -175,11 +210,252 @@ perf-mock: ## Run performance characterization scenarios against the in-process 
 # first. Timeout matches `e2e-azure` to leave room for ARM
 # provisioning + the Performance round budgets.
 perf-azure: build ## Run performance characterization scenarios against a real Azure Relay namespace
-	cd e2e && go test -tags=e2e -timeout=35m -v \
+	cd e2e && PERF_MATRIX_BACKEND=azure \
+		PERF_MATRIX_GIT_SHA="$$(git rev-parse --short HEAD 2>/dev/null)" \
+		go test -tags=e2e -count=1 -timeout=35m -v \
 		-run='TestE2E_Azure/[^/]+/$(PERF_SCENARIO_FILTER)' \
 		./backends/azure/
 
 perf: perf-mock perf-azure ## Run performance scenarios against both backends
+
+# perf-matrix runs the mock perf scenarios and, after the usual
+# verbose output streams, re-prints just the rendered PERF MATRIX
+# block for convenience. Override the scenario filter with PERF=<regex>
+# (same as perf-mock), e.g. `make perf-matrix PERF=Parallel_Conn`.
+perf-matrix: SHELL := /bin/bash
+perf-matrix: .SHELLFLAGS := -u -o pipefail -c
+perf-matrix: ## Run mock perf scenarios and surface the human-readable PERF MATRIX
+	@cd e2e && \
+		out="$$(mktemp)"; \
+		PERF_MATRIX_BACKEND=mock \
+		PERF_MATRIX_GIT_SHA="$$(git rev-parse --short HEAD 2>/dev/null)" \
+		go test -tags=e2e -count=1 -timeout=20m -v \
+			-run='TestE2E_Mock/$(PERF_AXIS_PREFIX_MOCK)$(PERF_SCENARIO_FILTER)' \
+			./backends/mock/ | tee "$$out"; \
+		status=$$?; \
+		echo; \
+		awk '/PERF MATRIX/{p=1} p{sub(/^[[:space:]]*[^:]*:[0-9]+: /,""); print} /END PERF MATRIX/{p=0}' "$$out"; \
+		rm -f "$$out"; \
+		exit $$status
+
+# perf-placement sweeps the PERF MATRIX over the full sender×listener
+# placement grid (nine cells: each side near/mid/far from the relay) so
+# the cold_rtt / est columns vary by placement. It pins E2E_AUTH=sas
+# (placement, not auth, is the axis we want to see vary; placement
+# profiles model the SAS path) and runs E2E_DELAY over the grid. By
+# default it runs a single est-bearing scenario (Parallel_ConnReusedEcho
+# — the only scenario that fills cold, warm, and est in one row) so the
+# nine-cell sweep stays fast and the footer can show the 3x3 grid.
+# Override with PERF=<regex> for a specific scenario, or PERF=all to sweep
+# the FULL perf scenario set across the grid (slower; the footer then
+# shows the flat table since a grid needs a single scenario — use
+# `make perf-table` / `make perf-grid SCENARIO=<name>` to drill in).
+# Subset the grid with PERF_PLACEMENT=<csv> (e.g.
+# `make perf-placement PERF_PLACEMENT=nn,nf,fn,ff`). Keep at least two
+# placement values: the `[^/]+/` run filter assumes exactly one axis
+# layer (the delay axis), which only exists when the delay dimension
+# varies — same caveat as perf-mock/perf-azure.
+#
+# There is a single artifact store: the always-on per-run history dir.
+# Every run writes perf-artifacts/history/<backend>-<run id>.jsonl (tagged
+# with PERF_MATRIX_BACKEND) — no separate per-target file. Each generation
+# target pins a fresh run id, then its footer renders just the file it
+# produced; perf-table/perf-grid merge the whole history into one
+# comparison view. perf-placement-azure runs the same scenarios against a
+# real namespace; Azure has real latency (not a synthetic grid), so its
+# axis is the auth cell, not a placement code.
+PERF_PLACEMENT ?= nn,nm,nf,mn,mm,mf,fn,fm,ff
+PERF_PLACEMENT_SCENARIO = $(if $(filter all,$(PERF)),$(PERF_ALL_SCENARIOS),$(or $(PERF),Parallel_ConnReusedEcho))
+PERF_ARTIFACT_DIR ?= perf-artifacts
+PERF_HISTORY_DIR ?= $(PERF_ARTIFACT_DIR)/history
+
+# perf_run_id prints a fresh run id in the harness's native format (a
+# sortable UTC millisecond timestamp plus a short random suffix), so a
+# generation target can pin PERF_MATRIX_RUN_ID and then locate the exact
+# history file the run wrote: $(PERF_HISTORY_DIR)/<backend>-<id>.jsonl.
+perf_run_id = $$(date -u +%Y%m%dT%H%M%S.%3NZ)-$$(printf '%04x%04x' $$RANDOM $$RANDOM)
+
+perf-placement: SHELL := /bin/bash
+perf-placement: .SHELLFLAGS := -u -o pipefail -c
+perf-placement: ## Sweep the PERF MATRIX across the 3x3 mock sender/listener placement grid
+	@cd e2e && \
+		rid="$(perf_run_id)"; \
+		hist="$(PERF_HISTORY_DIR)/mock-$$rid.jsonl"; \
+		absdir="$(PERF_HISTORY_DIR)"; case "$$absdir" in /*) ;; *) absdir="$$PWD/$$absdir";; esac; \
+		PERF_MATRIX_RUN_ID="$$rid" \
+		PERF_MATRIX_HISTORY_DIR="$$absdir" \
+		PERF_MATRIX_BACKEND=mock \
+		PERF_MATRIX_GIT_SHA="$$(git rev-parse --short HEAD 2>/dev/null)" \
+		E2E_AUTH=sas E2E_DELAY=$(PERF_PLACEMENT) go test -tags=e2e -count=1 -timeout=20m \
+			-run='TestE2E_Mock/[^/]+/$(PERF_PLACEMENT_SCENARIO)' \
+			./backends/mock/; \
+		status=$$?; \
+		echo; \
+		if [ $$status -eq 0 ] && [ ! -s "$$hist" ]; then \
+			echo "perf-placement: test passed but wrote no history at e2e/$$hist" >&2; \
+			status=1; \
+		fi; \
+		if [ -s "$$hist" ]; then \
+			go run ./cmd/perfreport --format auto --mode PortForward "$$hist" || \
+				{ rc=$$?; [ $$status -eq 0 ] && status=$$rc; }; \
+			echo; \
+			echo "history:    e2e/$$hist  (jq-friendly JSON Lines)"; \
+			echo "more views: make perf-table   |   make perf-grid METRIC=est|warm|cold MODE=SOCKS5 SCENARIO=<name>"; \
+		fi; \
+		exit $$status
+
+perf-placement-azure: SHELL := /bin/bash
+perf-placement-azure: .SHELLFLAGS := -u -o pipefail -c
+perf-placement-azure: build ## Run the perf scenarios against a real Azure Relay namespace (one real placement)
+	@cd e2e && \
+		rid="$(perf_run_id)"; \
+		hist="$(PERF_HISTORY_DIR)/azure-$$rid.jsonl"; \
+		absdir="$(PERF_HISTORY_DIR)"; case "$$absdir" in /*) ;; *) absdir="$$PWD/$$absdir";; esac; \
+		PERF_MATRIX_RUN_ID="$$rid" \
+		PERF_MATRIX_HISTORY_DIR="$$absdir" \
+		PERF_MATRIX_BACKEND=azure \
+		PERF_MATRIX_GIT_SHA="$$(git rev-parse --short HEAD 2>/dev/null)" \
+		go test -tags=e2e -count=1 -timeout=35m \
+			-run='TestE2E_Azure/[^/]+/$(PERF_SCENARIO_FILTER)' \
+			./backends/azure/; \
+		status=$$?; \
+		echo; \
+		if [ $$status -eq 0 ] && [ ! -s "$$hist" ]; then \
+			echo "perf-placement-azure: test passed but wrote no history at e2e/$$hist" >&2; \
+			status=1; \
+		fi; \
+		if [ -s "$$hist" ]; then \
+			go run ./cmd/perfreport --format table "$$hist" || \
+				{ rc=$$?; [ $$status -eq 0 ] && status=$$rc; }; \
+			echo; \
+			echo "history:  e2e/$$hist  (jq-friendly JSON Lines)"; \
+			echo "compare:  make perf-table   (merges mock + azure history)"; \
+		fi; \
+		exit $$status
+
+# perf-axes-mock runs the mock backend UNPINNED so every live axis (auth ×
+# delay) varies and each row carries the full named-axis set
+# (axes={auth,delay}). The reporter then renders auth and delay as their
+# own columns, so you can pivot/compare on any single dimension — e.g.
+# `--filter delay=ff` to compare entra vs sas at one placement. This is the
+# "produce JSON, compare whatever" path; placement runs pin auth and only
+# vary delay. Subset with PERF_AXES_DELAY=<csv> and PERF_AXES_SCENARIO. The
+# `[^/]+/[^/]+/` run filter assumes exactly two live axis layers (auth and
+# delay), so keep both varying.
+PERF_AXES_DELAY ?= nn,ff
+PERF_AXES_SCENARIO ?= Parallel_ConnReusedEcho
+perf-axes-mock: SHELL := /bin/bash
+perf-axes-mock: .SHELLFLAGS := -u -o pipefail -c
+perf-axes-mock: build ## Sweep mock UNPINNED over auth x delay; render named-axis columns (PERF_AXES_DELAY=<csv> PERF_AXES_SCENARIO=<name>)
+	@cd e2e && \
+		rid="$(perf_run_id)"; \
+		hist="$(PERF_HISTORY_DIR)/mock-$$rid.jsonl"; \
+		absdir="$(PERF_HISTORY_DIR)"; case "$$absdir" in /*) ;; *) absdir="$$PWD/$$absdir";; esac; \
+		PERF_MATRIX_RUN_ID="$$rid" \
+		PERF_MATRIX_HISTORY_DIR="$$absdir" \
+		PERF_MATRIX_BACKEND=mock \
+		PERF_MATRIX_GIT_SHA="$$(git rev-parse --short HEAD 2>/dev/null)" \
+		E2E_DELAY=$(PERF_AXES_DELAY) go test -tags=e2e -count=1 -timeout=20m \
+			-run='TestE2E_Mock/[^/]+/[^/]+/$(PERF_AXES_SCENARIO)' \
+			./backends/mock/; \
+		status=$$?; \
+		echo; \
+		if [ $$status -eq 0 ] && [ ! -s "$$hist" ]; then \
+			echo "perf-axes-mock: test passed but wrote no history at e2e/$$hist" >&2; \
+			status=1; \
+		fi; \
+		if [ -s "$$hist" ]; then \
+			go run ./cmd/perfreport --format table "$$hist" || \
+				{ rc=$$?; [ $$status -eq 0 ] && status=$$rc; }; \
+			echo; \
+			echo "history:  e2e/$$hist  (jq-friendly JSON Lines)"; \
+			echo "pivot:    go run ./cmd/perfreport --filter delay=ff --mode PortForward $$hist"; \
+		fi; \
+		exit $$status
+
+# perf-table and perf-grid re-render the accumulated history in
+# PERF_HISTORY_DIR without re-running anything — cheap, so iterating on
+# views costs nothing. They MERGE every run present and collapse to the
+# newest row per cell, so once both perf-placement and perf-placement-azure
+# have run, the table shows mock and azure side by side (backend column).
+# METRIC selects the grid cell metric (all=composite cold/warm/est); MODE
+# narrows to one transport (empty = all modes, the default for table/compare;
+# the grid, which needs a single mode, falls back to PortForward when MODE is
+# unset); SCENARIO/BACKEND narrow the merged history down to the single
+# scenario/backend a grid needs.
+METRIC ?= all
+MODE ?=
+SCENARIO ?=
+BACKEND ?=
+
+perf-table: SHELL := /bin/bash
+perf-table: .SHELLFLAGS := -u -o pipefail -c
+perf-table: ## Re-render the merged run history as the flat matrix table (SCENARIO=<name> BACKEND=mock|azure)
+	@cd e2e && shopt -s nullglob && \
+		files=($(PERF_HISTORY_DIR)/*.jsonl); \
+		[ $${#files[@]} -gt 0 ] || { echo "no history in e2e/$(PERF_HISTORY_DIR); run a perf target first" >&2; exit 1; }; \
+		go run ./cmd/perfreport --format table $(if $(SCENARIO),--scenario $(SCENARIO),) $(if $(BACKEND),--backend $(BACKEND),) "$${files[@]}"
+
+perf-grid: SHELL := /bin/bash
+perf-grid: .SHELLFLAGS := -u -o pipefail -c
+perf-grid: ## Re-render a single mock backend as a 3x3 grid (METRIC=all|est|warm|cold MODE=PortForward|SOCKS5 SCENARIO=<name> BACKEND=mock)
+	@cd e2e && shopt -s nullglob && \
+		files=($(PERF_HISTORY_DIR)/*.jsonl); \
+		[ $${#files[@]} -gt 0 ] || { echo "no history in e2e/$(PERF_HISTORY_DIR); run a perf target first" >&2; exit 1; }; \
+		go run ./cmd/perfreport --format grid --metric $(METRIC) --mode $(or $(MODE),PortForward) $(if $(SCENARIO),--scenario $(SCENARIO),) $(if $(BACKEND),--backend $(BACKEND),) "$${files[@]}"
+
+# All perf views read the same store: every perf (and functional) e2e run
+# appends a timestamped per-run file under perf-artifacts/history (always-on
+# emission), so runs accumulate instead of overwriting. perf-history lists
+# what's there; perf-compare diffs two runs (BASE/CAND default to the two
+# newest, so re-run a scenario before and after a change then just
+# `make perf-compare`). BASE/CAND accept a run id, an unambiguous id prefix,
+# or the words latest/previous.
+#
+# To compare along a different dimension instead of runs, set DIM to an axis
+# name (e.g. auth, delay) or backend/scenario/mode, and give BASE/CAND the two
+# values (e.g. `make perf-compare DIM=auth BASE=sas CAND=entra`). Non-run
+# comparisons match within a single run, so BASE/CAND=previous/latest only make
+# sense for the default DIM=run.
+BASE ?= previous
+CAND ?= latest
+DIM ?= run
+
+perf-history: SHELL := /bin/bash
+perf-history: .SHELLFLAGS := -u -o pipefail -c
+perf-history: ## List every run captured in perf-artifacts/history (one row per cell per run)
+	@cd e2e && shopt -s nullglob && \
+		files=($(PERF_HISTORY_DIR)/*.jsonl); \
+		[ $${#files[@]} -gt 0 ] || { echo "no history in e2e/$(PERF_HISTORY_DIR); run any e2e/perf target first" >&2; exit 1; }; \
+		go run ./cmd/perfreport --all-runs $(if $(SCENARIO),--scenario $(SCENARIO),) $(if $(BACKEND),--backend $(BACKEND),) "$${files[@]}"
+
+perf-compare: SHELL := /bin/bash
+perf-compare: .SHELLFLAGS := -u -o pipefail -c
+perf-compare: ## Diff two runs (BASE=previous CAND=latest); or DIM=auth|delay|backend|... BASE=x CAND=y to compare within a run
+	@cd e2e && shopt -s nullglob && \
+		files=($(PERF_HISTORY_DIR)/*.jsonl); \
+		[ $${#files[@]} -gt 0 ] || { echo "no history in e2e/$(PERF_HISTORY_DIR); run any e2e/perf target first" >&2; exit 1; }; \
+		go run ./cmd/perfreport --compare "$(BASE)..$(CAND)" $(if $(filter-out run,$(DIM)),--compare-by $(DIM),) $(if $(SCENARIO),--scenario $(SCENARIO),) $(if $(MODE),--mode $(MODE),) $(if $(BACKEND),--backend $(BACKEND),) "$${files[@]}"
+
+perf-clean-history: SHELL := /bin/bash
+perf-clean-history: .SHELLFLAGS := -u -o pipefail -c
+perf-clean-history: ## Delete the accumulated per-run history files
+	@cd e2e && rm -f $(PERF_HISTORY_DIR)/*.jsonl
+
+# perf-gate is the CI tripwire: diff the two newest runs and exit non-zero
+# only if a warm/cold p50 cell regressed by more than FAIL_OVER percent AND
+# more than FAIL_MIN_ABS (so a big percent on a tiny baseline can't flake
+# it). A single run present (no baseline yet) is a skip, not a failure.
+FAIL_OVER ?= 30
+FAIL_MIN_ABS ?= 20ms
+perf-gate: SHELL := /bin/bash
+perf-gate: .SHELLFLAGS := -u -o pipefail -c
+perf-gate: ## Fail only on a gross perf regression between the two newest runs (FAIL_OVER=<pct> FAIL_MIN_ABS=<dur> BACKEND=mock|azure)
+	@cd e2e && shopt -s nullglob && \
+		files=($(PERF_HISTORY_DIR)/*.jsonl); \
+		[ $${#files[@]} -gt 0 ] || { echo "no history in e2e/$(PERF_HISTORY_DIR); run any e2e/perf target first" >&2; exit 1; }; \
+		go run ./cmd/perfreport --compare "$(BASE)..$(CAND)" --fail-over $(FAIL_OVER) --fail-min-abs $(FAIL_MIN_ABS) \
+			$(if $(SCENARIO),--scenario $(SCENARIO),) $(if $(MODE),--mode $(MODE),) $(if $(BACKEND),--backend $(BACKEND),) "$${files[@]}"
 
 help: ## Show this help
 	@grep -E '^[a-zA-Z0-9_-]+:.*?## .*$$' $(MAKEFILE_LIST) | \

--- a/e2e/backends/mock/README.md
+++ b/e2e/backends/mock/README.md
@@ -25,9 +25,9 @@ Azure backend:
 ```bash
 make e2e-mock                         # both auth methods × default profile
 make e2e-mock-fast                    # both auth methods × zero profile (fastest)
-make e2e-mock-matrix                  # both auth methods × every registered profile
+make e2e-mock-matrix                  # both auth methods × curated functional delay set (zero + default)
 E2E_DELAY=zero make e2e-mock          # zero profile, no synthetic relay delay
-E2E_DELAY=all make e2e-mock           # fan out over every registered profile
+E2E_DELAY=all make e2e-mock           # fan out over the curated functional delay set (zero + default)
 E2E_DELAY=zero,default make e2e-mock  # explicit profile subset
 E2E_AUTH=entra make e2e-mock          # pin the entra auth method
 ```
@@ -37,6 +37,141 @@ scenarios under `TestE2E_Mock/<auth>/<profile>/<scenario>` (auth outermost).
 Per-profile latency thresholds scale with the profile's predicted cost, and the
 entra cold-start budget widens only when the profile models a token-acquisition
 cost. An unrecognised name fails the test loudly and prints the known names.
+
+`E2E_DELAY=all` runs only the curated functional delay set (`zero` + `default`).
+The relay-placement profiles form the full sender×listener grid — nine cells
+named `<sender><listener>` with single-letter distance codes (`n`ear/`m`id/`f`ar,
+sender first), e.g. `nf` = sender near, listener far. They model sender/listener
+distance from the relay and are resolvable by name — e.g. `E2E_DELAY=nn,nf,fn,ff`
+— but are intentionally excluded from `all` so a perf sweep does not expand the
+functional suite. Sweep the whole grid via `make perf-placement`, whose rows
+land in the always-on per-run history file (tagged with `PERF_MATRIX_BACKEND`)
+and render with `go run ./cmd/perfreport`.
+
+The reporter is decoupled from execution: every run appends a timestamped file
+to one store, `perf-artifacts/history/<backend>-<run id>.jsonl`, and `make
+perf-table` / `make perf-grid` re-render the merged history without re-running.
+Because the reporter merges every file it is given and collapses to the newest
+row per cell, running `make perf-placement` (mock) and `make
+perf-placement-azure` produces one comparison table with a `backend` column. The
+3×3 grid view needs a single backend, scenario, and mode — narrow the merged
+history with `make perf-grid BACKEND=mock SCENARIO=<name>`.
+
+### Named axes — compare any dimension
+
+Each row records its matrix cell as **named axis dimensions** (e.g.
+`axes: {"auth":"sas","delay":"nn"}`) resolved from the backend's `Axes()`,
+not just a flat string. The reporter renders one column per axis and accepts
+repeatable `--filter key=value` (where `key` is any axis name, or the virtual
+`backend`/`scenario`/`mode`), so you can pivot on a single dimension:
+
+```sh
+make perf-axes-mock                       # run mock UNPINNED: auth × delay both vary
+# the footer prints the exact history file it wrote, e.g.
+go run ./cmd/perfreport --filter delay=ff --mode PortForward \
+  perf-artifacts/history/mock-<run id>.jsonl   # compare entra vs sas at one placement
+```
+
+A run that _pins_ an axis (e.g. `make perf-placement` pins `E2E_AUTH=sas`)
+omits that axis from its rows; merging such a run with an unpinned one yields
+rows with differing axis key sets, and the reporter prints a warning because a
+`--filter` on the missing key would silently skip them. To compare across an
+axis, leave it unpinned so every row carries it.
+
+### Comparing runs — before/after a change
+
+Emission is **always-on** and there is a single store: every e2e/perf run
+appends a timestamped per-run file under `perf-artifacts/history/`, named
+`<backend>-<run id>.jsonl`. Every view (`perf-table`, `perf-grid`,
+`perf-history`, `perf-compare`) reads that one directory. Each row carries a
+`run` id — a sortable UTC timestamp plus a short random suffix — so repeated
+runs of the same cell accumulate as history instead of overwriting or
+colliding. Set `PERF_MATRIX_RUN_ID` to pin the id (e.g. sharded runs share one,
+and the generation targets set it so their footer can render the exact file they
+just wrote); the default is generated per run. Setting `PERF_MATRIX_JSONL=<path>`
+additionally exports that one run to an explicit file — an opt-in escape hatch
+(e.g. CI shard upload), not part of the default workflow.
+
+```sh
+make perf-placement                 # run once (baseline)
+# …make a change…
+make perf-placement                 # run again (candidate)
+make perf-history                   # list the runs captured so far
+make perf-compare                   # diff the two newest: BASE=previous CAND=latest
+```
+
+`make perf-compare` matches cells across two runs and prints baseline,
+candidate, and the percent delta for `warm_p50`, `cold_p50`, and `est`
+(negative = faster). `BASE`/`CAND` accept a run id, an unambiguous id prefix,
+or the words `latest`/`previous`; `SCENARIO`/`MODE`/`BACKEND` narrow the
+comparison. A cell present in only one run renders as a dash so missing
+coverage is visible rather than silently dropped — note that comparisons match
+on the full cell `(backend, axes, scenario, mode)`, so both runs must pin the
+same axes for a row to line up. Back-to-back runs of identical code show the
+measurement-noise floor (typically a few percent); a real regression has to
+beat that to be meaningful. By default the plain table collapses a merged
+history to the newest run per cell; pass `--all-runs` to see every run with a
+`run` column. `make perf-clean-history` clears the accumulated files.
+
+### Comparing any dimension — entra vs sas, near vs far, mock vs azure
+
+The same delta view pivots on **any** dimension, not just runs. Set `DIM` to a
+named axis (`auth`, `delay`, …), `backend`, `scenario`, `mode`, or the legacy
+flat `axis`, and give `BASE`/`CAND` the two values to compare:
+
+```sh
+make perf-compare DIM=auth  BASE=sas CAND=entra   # entra vs sas, same run
+make perf-compare DIM=delay BASE=nn  CAND=ff      # near vs far placement
+```
+
+The compared dimension drops out of the identity columns and becomes the
+`base`/`cand`/`Δ%` split; every other dimension still lines the rows up. Unlike
+run comparison, a non-run compare matches **within a single run** (the run id
+stays part of a cell's identity), so it is apples-to-apples — when the history
+holds several runs you get one comparison row per run, surfaced by a `run`
+column. Because of that same-run rule, comparing `backend=mock..azure` only
+works when both backends were measured under one run id; mock and azure
+captured as separate runs have no overlapping cell and the tool says so rather
+than printing meaningless dashes. Filtering on the compared dimension (e.g.
+`--filter auth=sas` while comparing `auth`) is rejected, since it would delete
+one side of the comparison. The underlying flags are `--compare-by <dim>` with
+`--compare base..cand`.
+
+### Validation tiers — where perf fits next to correctness
+
+Perf is a **measurement lens on the e2e suite**, not a separate suite: the perf
+scenarios are `t.Run` subtests inside `TestE2E_Mock` / `TestE2E_Azure`, and
+every e2e/perf run emits history (emission is always-on). That gives four
+distinct uses, in increasing cost:
+
+1. **Correctness (PR-gating).** `ci.yml` + `e2e.yml` already run the functional
+   suite — connection setup, SHA-256 byte parity, auth, fallback, and the
+   mock-resembles-azure log-shape parity gate. Perf numbers are produced as a
+   side effect but **nothing is gated on them**. This is the only tier that
+   blocks a merge.
+2. **Opt-in PR perf** (`perf-pr.yml`). Add the `perf` label to a PR (or use the
+   Actions "Run workflow" button) to sweep the mock placement grid and render
+   the matrix into the job summary, with the history uploaded as an artifact.
+   Always green — it informs, it never blocks. Runs read-only with no cloud
+   credentials.
+3. **Nightly gross-regression gate** (`perf-nightly.yml`). A cron job sweeps the
+   mock grid, restores the previous nightly's history artifact as a baseline,
+   and runs `make perf-gate` (default `FAIL_OVER=30`, i.e. fail only on a
+   warm/cold p50 cell that regressed by **both** >30% **and** >20ms). Mock-only:
+   the real Azure relay's rendezvous spikes (~3–6s) swamp any threshold. The
+   baseline is re-uploaded only on success, so a regressing night never
+   overwrites the known-good reference.
+4. **Developer-local before/after.** `make perf-placement` twice around a change,
+   then `make perf-compare` (or `make perf-gate FAIL_OVER=<pct>` to get the same
+   pass/fail verdict the nightly uses).
+
+`make perf-gate` is the shared tripwire for tiers 3 and 4: it diffs the two
+newest runs and exits non-zero only on a gross regression, treats a tiny
+absolute delta as noise (`FAIL_MIN_ABS`, default `20ms`), and **skips** (exit 0)
+when only one run is present so a bootstrap night is not a failure. It requires
+the two newest runs to be the same scenario shape (both produced by
+`make perf-placement`); a partial cell-set difference is a warning, but zero
+overlap is a hard error so the gate can never silently pass on nothing.
 
 ## What it is
 

--- a/e2e/backends/mock/env_test.go
+++ b/e2e/backends/mock/env_test.go
@@ -53,7 +53,11 @@ func authNamesFromEnv(t testing.TB) []string {
 //
 //   - unset / empty -> the single "default" profile (the wire-faithful
 //     profile the e2e timing thresholds are calibrated against).
-//   - "all"         -> every registered profile, in sorted order.
+//   - "all"         -> the functional matrix set (zero, default), in
+//     sorted order. This is deliberately the curated functional set,
+//     not every resolvable profile: placement profiles (near/mid/far/…)
+//     are resolvable by name for perf sweeps but excluded here so the
+//     full functional run is not silently expanded.
 //   - "a,b,c"       -> the listed profiles, in the given order, deduped.
 //
 // Every name is validated against the mockrelay registry; an empty
@@ -65,7 +69,7 @@ func delayProfileNamesFromEnv(t testing.TB) []string {
 	case "":
 		return []string{"default"}
 	case "all":
-		return server.ProfileNames()
+		return server.FunctionalMatrixProfileNames()
 	}
 	seen := make(map[string]struct{})
 	var names []string

--- a/e2e/cmd/perfreport/main.go
+++ b/e2e/cmd/perfreport/main.go
@@ -1,0 +1,1259 @@
+// Command perfreport renders the aztunnel performance matrix from a
+// JSON Lines artifact produced by the e2e harness (PERF_MATRIX_JSONL).
+//
+// Decoupling reporting from execution lets the same artifact drive
+// several views and lets sharded runs be concatenated then rendered
+// once. The artifact — not a shared Go type — is the contract, so this
+// command owns its own copy of the record schema rather than importing
+// the harness internals.
+//
+// Usage:
+//
+//	perfreport [flags] [artifact.jsonl]   # or read JSONL from stdin
+//
+// Flags:
+//
+//	--format table|grid|auto
+//	                        table (default) reproduces the flat matrix
+//	                        (with a backend column); grid pivots the
+//	                        placement axis into a 3x3; auto renders the
+//	                        grid when the (filtered) records hold a single
+//	                        backend+scenario+mode, else the table.
+//	--metric all|est|warm|cold
+//	                        grid cell metric (default all → composite
+//	                        cold/warm/est; est = cold_p50 − warm_p50).
+//	--scenario <name>       restrict to one scenario (grid needs exactly one).
+//	--mode <name>           restrict to one mode (grid needs exactly one).
+//	--backend <name>        restrict to one backend, e.g. mock|azure (grid
+//	                        needs exactly one; pass several artifacts to
+//	                        compare backends side by side in the table).
+//
+// Multiple artifact files are merged (the table then shows one row per
+// backend×axis×scenario×mode), so a mock run and an azure run render as a
+// single comparison table: perfreport mock.jsonl azure.jsonl
+package main
+
+import (
+	"bufio"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"sort"
+	"strings"
+	"text/tabwriter"
+	"time"
+)
+
+// wantSchema is the only artifact schema this reporter understands; a
+// row tagged with anything else is rejected so an incompatible producer
+// fails loudly instead of rendering misaligned data.
+const wantSchema = "perfmatrix/v1"
+
+// record mirrors the harness's perfMatrixRecord (perfmatrix/v1). It is
+// duplicated on purpose: the JSONL artifact is the boundary, so the
+// reporter does not import the e2e scenarios package.
+type record struct {
+	Type      string            `json:"type"`
+	Schema    string            `json:"schema"`
+	Run       string            `json:"run,omitempty"`
+	Backend   string            `json:"backend"`
+	Axis      string            `json:"axis"`
+	Axes      map[string]string `json:"axes,omitempty"`
+	Scenario  string            `json:"scenario"`
+	Mode      string            `json:"mode"`
+	ColdP50Ns *int64            `json:"cold_p50_ns"`
+	WarmP50Ns *int64            `json:"warm_p50_ns"`
+	WarmP95Ns *int64            `json:"warm_p95_ns"`
+	ColdN     int               `json:"cold_n"`
+	WarmN     int               `json:"warm_n"`
+	SuccessN  int               `json:"success_n"`
+	AttemptN  int               `json:"attempt_n"`
+	WallNs    int64             `json:"wall_ns"`
+}
+
+// runMeta is the "run" header record (one per source file). The reporter
+// retains these so a merged table can show its provenance — which backend
+// / build / time each set of rows came from — and warn when the merged
+// sources span different builds (a stale-artifact footgun, since the
+// per-backend producers only overwrite their own file).
+type runMeta struct {
+	Type        string `json:"type"`
+	Run         string `json:"run"`
+	Backend     string `json:"backend"`
+	GeneratedAt string `json:"generated_at"`
+	GitSHA      string `json:"git_sha"`
+	E2EAuth     string `json:"e2e_auth"`
+	E2EDelay    string `json:"e2e_delay"`
+}
+
+func main() {
+	format := flag.String("format", "table", "output format: table|grid|auto")
+	metric := flag.String("metric", "all", "grid cell metric: all|est|warm|cold")
+	scenario := flag.String("scenario", "", "restrict to one scenario")
+	mode := flag.String("mode", "", "restrict to one mode")
+	backend := flag.String("backend", "", "restrict to one backend (mock|azure)")
+	var filters filterFlags
+	flag.Var(&filters, "filter", "restrict to rows matching key=value (repeatable; key may be any axis name or backend/scenario/mode/run)")
+	compare := flag.String("compare", "", "compare two values: baseline..candidate (run ids/prefixes or latest/previous for runs; exact values for other dimensions)")
+	compareBy := flag.String("compare-by", "run", "dimension to compare across: run|backend|scenario|mode|axis|<named axis key>")
+	allRuns := flag.Bool("all-runs", false, "show every run per cell instead of collapsing to the latest")
+	failOver := flag.Float64("fail-over", 0, "with --compare: exit non-zero if any warm/cold p50 cell regresses by more than this percent (0 disables gating)")
+	failMinAbs := flag.String("fail-min-abs", "20ms", "with --fail-over: a regression must also exceed this absolute p50 delta (a Go duration) before the gate trips, so tiny baselines can't flake it")
+	flag.Parse()
+
+	recs, runs, err := load(flag.Args())
+	if err != nil {
+		fail(err)
+	}
+	fm, err := filters.toMap()
+	if err != nil {
+		fail(err)
+	}
+	// The dedicated --scenario/--mode/--backend flags are sugar for the
+	// equivalent --filter entries, so everything narrows through one path.
+	addFilter(fm, "scenario", *scenario)
+	addFilter(fm, "mode", *mode)
+	addFilter(fm, "backend", *backend)
+	recs = applyFilters(recs, fm)
+	renderProvenance(os.Stdout, relevantRuns(runs, recs))
+
+	if *compare != "" {
+		base, cand, ok := strings.Cut(*compare, "..")
+		if !ok || base == "" || cand == "" {
+			fail(fmt.Errorf("--compare wants baseline..candidate, got %q", *compare))
+		}
+		// Filtering on the compared dimension would remove one side of the
+		// comparison before it runs, so reject the contradiction up front.
+		if _, ok := fm[*compareBy]; ok {
+			fail(fmt.Errorf("cannot filter on the compared dimension %q while --compare-by %q is set", *compareBy, *compareBy))
+		}
+		gs, err := renderCompare(os.Stdout, recs, *compareBy, base, cand)
+		if err != nil {
+			// A gate run with nothing to compare yet (e.g. the first ever
+			// nightly, before a baseline exists) is a skip, not a failure.
+			if *failOver > 0 && errors.Is(err, errNotEnoughRuns) {
+				fmt.Fprintf(os.Stderr, "perf-gate: %v — nothing to compare yet (skipping)\n", err)
+				return
+			}
+			fail(err)
+		}
+		if *failOver > 0 {
+			applyGate(gs, *failOver, *failMinAbs)
+		}
+		return
+	}
+	if *failOver > 0 {
+		fail(errors.New("--fail-over requires --compare (the gate compares a baseline to a candidate)"))
+	}
+
+	// By default collapse to the newest run per cell so a merged history
+	// shows one current number per cell; --all-runs keeps every run (the
+	// table then grows a run column). Either way, note when history exists.
+	nRuns := len(distinctRuns(recs))
+	if !*allRuns {
+		recs = latestPerCell(recs)
+	}
+	if nRuns > 1 {
+		if *allRuns {
+			fmt.Fprintf(os.Stderr, "note: %d runs present; showing all (use --compare a..b for deltas)\n", nRuns)
+		} else {
+			fmt.Fprintf(os.Stderr, "note: %d runs present; showing latest per cell (use --all-runs or --compare a..b)\n", nRuns)
+		}
+	}
+
+	switch *format {
+	case "table":
+		if err := renderTable(os.Stdout, recs); err != nil {
+			fail(err)
+		}
+	case "grid":
+		if err := renderGrid(os.Stdout, recs, *metric); err != nil {
+			fail(err)
+		}
+	case "auto":
+		// Grid needs exactly one scenario and one mode; when the artifact
+		// holds more than that (e.g. a full-scenario sweep), fall back to
+		// the table, which renders any number of rows.
+		if singleCell(recs) {
+			if err := renderGrid(os.Stdout, recs, *metric); err != nil {
+				fail(err)
+			}
+		} else if err := renderTable(os.Stdout, recs); err != nil {
+			fail(err)
+		}
+	default:
+		fail(fmt.Errorf("unknown --format %q (want table|grid|auto)", *format))
+	}
+}
+
+// singleCell reports whether the records collapse to one backend, one
+// scenario, and one mode — the precondition for a grid render.
+func singleCell(recs []record) bool {
+	backends, scenarios, modes := map[string]bool{}, map[string]bool{}, map[string]bool{}
+	for _, r := range recs {
+		backends[r.Backend] = true
+		scenarios[r.Scenario] = true
+		modes[r.Mode] = true
+	}
+	return len(backends) == 1 && len(scenarios) == 1 && len(modes) == 1
+}
+
+func fail(err error) {
+	fmt.Fprintln(os.Stderr, "perfreport:", err)
+	os.Exit(1)
+}
+
+// load reads JSONL from the named files (or stdin when none are given),
+// skipping blank lines, collecting "run" header records, and rejecting
+// duplicate (backend, axis, scenario, mode, run) keys so a stale or
+// double-appended artifact fails loudly instead of silently picking one
+// row. The run id is part of the dedup key, so distinct runs of the same
+// cell coexist (that is how multi-run history and before/after comparison
+// work); only a repeated cell *within the same run* is an error. It
+// returns the data rows and the run-header records (the latter drive the
+// provenance line).
+func load(paths []string) ([]record, []runMeta, error) {
+	var readers []io.Reader
+	var closers []io.Closer
+	if len(paths) == 0 {
+		readers = append(readers, os.Stdin)
+	}
+	for _, p := range paths {
+		f, err := os.Open(p)
+		if err != nil {
+			return nil, nil, err
+		}
+		readers = append(readers, f)
+		closers = append(closers, f)
+	}
+	defer func() {
+		for _, c := range closers {
+			_ = c.Close()
+		}
+	}()
+
+	var recs []record
+	var runs []runMeta
+	seen := map[string]bool{}
+	seenRun := map[string]bool{}
+	for _, r := range readers {
+		sc := bufio.NewScanner(r)
+		sc.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+		for sc.Scan() {
+			line := strings.TrimSpace(sc.Text())
+			if line == "" {
+				continue
+			}
+			var rec record
+			if err := json.Unmarshal([]byte(line), &rec); err != nil {
+				return nil, nil, fmt.Errorf("malformed JSONL line: %v", err)
+			}
+			// Retain the run header for provenance; skip any other
+			// non-row meta type. Everything else is a data row and must
+			// carry the v1 schema so a malformed or pre-contract line
+			// fails loudly rather than being rendered as if it were valid.
+			if rec.Type == "run" {
+				var rm runMeta
+				if err := json.Unmarshal([]byte(line), &rm); err != nil {
+					return nil, nil, fmt.Errorf("malformed run record: %v", err)
+				}
+				// A single run sharded across processes writes one run
+				// header per shard (same backend + run id). Keep only the
+				// first so provenance lists each run once, not once per
+				// shard, when artifacts are concatenated. Only dedup on a
+				// real run id; an empty id (legacy/hand-written artifact)
+				// can't be proven a shard, so keep every such header.
+				if rm.Run != "" {
+					rk := rm.Backend + "\x00" + rm.Run
+					if seenRun[rk] {
+						continue
+					}
+					seenRun[rk] = true
+				}
+				runs = append(runs, rm)
+				continue
+			}
+			if rec.Type != "" && rec.Type != "row" {
+				continue
+			}
+			if rec.Schema != wantSchema {
+				return nil, nil, fmt.Errorf("row record has schema %q, want %q "+
+					"(missing or produced by an incompatible harness version)", rec.Schema, wantSchema)
+			}
+			key := cellKey(rec) + "\x00" + rec.Run
+			if seen[key] {
+				return nil, nil, fmt.Errorf("duplicate row for backend=%q axis=%q scenario=%q mode=%q run=%q "+
+					"(stale or double-appended artifact?)", rec.Backend, displayAxes(rec), rec.Scenario, rec.Mode, rec.Run)
+			}
+			seen[key] = true
+			recs = append(recs, rec)
+		}
+		if err := sc.Err(); err != nil {
+			return nil, nil, err
+		}
+	}
+	if len(recs) == 0 {
+		return nil, nil, errors.New("no rows in artifact")
+	}
+	return recs, runs, nil
+}
+
+// relevantRuns returns the run headers whose backend actually appears in
+// recs, so a --backend-filtered render shows only the matching source(s).
+func relevantRuns(runs []runMeta, recs []record) []runMeta {
+	present := map[string]bool{}
+	for _, r := range recs {
+		present[r.Backend] = true
+	}
+	var out []runMeta
+	for _, rm := range runs {
+		if present[rm.Backend] {
+			out = append(out, rm)
+		}
+	}
+	return out
+}
+
+// renderProvenance prints a one-line summary of the source runs (backend,
+// build, time) and a non-fatal warning when the merged sources span more
+// than one build — making the stale-artifact footgun visible without
+// changing the merge-by-default UX. No output when there are no run
+// headers (e.g. a pre-provenance artifact).
+func renderProvenance(w io.Writer, runs []runMeta) {
+	if len(runs) == 0 {
+		return
+	}
+	sort.SliceStable(runs, func(i, j int) bool { return runs[i].Backend < runs[j].Backend })
+	shas := map[string]bool{}
+	var parts []string
+	for _, r := range runs {
+		sha := r.GitSHA
+		if sha == "" {
+			sha = "?"
+		}
+		shas[r.GitSHA] = true
+		label := dash(r.Backend) + "@" + sha
+		if r.GeneratedAt != "" {
+			label += " " + r.GeneratedAt
+		}
+		parts = append(parts, label)
+	}
+	_, _ = fmt.Fprintln(w, "sources: "+strings.Join(parts, "  |  "))
+	if len(shas) > 1 {
+		_, _ = fmt.Fprintln(w, "warning: merged artifacts span multiple builds (git shas differ) — comparison may mix versions")
+	}
+	_, _ = fmt.Fprintln(w)
+}
+
+// filterFlags collects repeatable --filter key=value pairs.
+type filterFlags []string
+
+func (f *filterFlags) String() string { return strings.Join(*f, ",") }
+func (f *filterFlags) Set(v string) error {
+	*f = append(*f, v)
+	return nil
+}
+
+func (f filterFlags) toMap() (map[string]string, error) {
+	m := map[string]string{}
+	for _, kv := range f {
+		k, v, ok := strings.Cut(kv, "=")
+		if !ok || k == "" {
+			return nil, fmt.Errorf("bad --filter %q (want key=value)", kv)
+		}
+		m[k] = v
+	}
+	return m, nil
+}
+
+func addFilter(m map[string]string, key, val string) {
+	if val != "" {
+		m[key] = val
+	}
+}
+
+// applyFilters keeps rows matching every key=value constraint. backend,
+// scenario, and mode are virtual keys; any other key is matched against
+// the row's named axes (a row missing that axis never matches).
+func applyFilters(recs []record, filters map[string]string) []record {
+	if len(filters) == 0 {
+		return recs
+	}
+	var out []record
+	for _, r := range recs {
+		if matchesFilters(r, filters) {
+			out = append(out, r)
+		}
+	}
+	return out
+}
+
+func matchesFilters(r record, filters map[string]string) bool {
+	for k, v := range filters {
+		switch k {
+		case "backend":
+			if r.Backend != v {
+				return false
+			}
+		case "scenario":
+			if r.Scenario != v {
+				return false
+			}
+		case "mode":
+			if r.Mode != v {
+				return false
+			}
+		case "run":
+			if r.Run != v {
+				return false
+			}
+		default:
+			if av, ok := r.Axes[k]; !ok || av != v {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+// axisColumns is the sorted union of named-axis keys across recs, or nil
+// when no row carries named axes (a legacy artifact renders the single
+// flat "axis" column instead).
+func axisColumns(recs []record) []string {
+	set := map[string]bool{}
+	for _, r := range recs {
+		for k := range r.Axes {
+			set[k] = true
+		}
+	}
+	if len(set) == 0 {
+		return nil
+	}
+	cols := make([]string, 0, len(set))
+	for k := range set {
+		cols = append(cols, k)
+	}
+	sort.Strings(cols)
+	return cols
+}
+
+// canonicalAxes is a deterministic identity for a row's axis cell, used
+// for sort and dedup. It serializes the named axes when present, else
+// falls back to the flat axis string so legacy artifacts keep distinct
+// keys.
+func canonicalAxes(r record) string { return canonicalAxesExcept(r, "") }
+
+// displayAxes is the human-facing axis label for messages (gate failures,
+// duplicate-row errors). It prefers the flat Axis path the harness always
+// emits (e.g. "entra/far") so the named-axis separator used by
+// canonicalAxes (the non-printable \x1f) never leaks into user-visible
+// text; it falls back to canonicalAxes only for a record with no flat Axis.
+func displayAxes(r record) string {
+	if r.Axis != "" {
+		return r.Axis
+	}
+	return canonicalAxes(r)
+}
+
+// canonicalAxesExcept is canonicalAxes with one dimension dropped, used by
+// the compare-by-dimension path to build a residual identity that excludes
+// the dimension under comparison. skip=="" reproduces canonicalAxes
+// exactly. For a legacy row (no named axes) the flat Axis stands in for the
+// whole axis dimension, so skip=="axis" drops it.
+func canonicalAxesExcept(r record, skip string) string {
+	if len(r.Axes) == 0 {
+		if skip == "axis" {
+			return ""
+		}
+		return r.Axis
+	}
+	keys := make([]string, 0, len(r.Axes))
+	for k := range r.Axes {
+		if k == skip {
+			continue
+		}
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	var b strings.Builder
+	for i, k := range keys {
+		if i > 0 {
+			b.WriteByte('\x1f')
+		}
+		b.WriteString(k)
+		b.WriteByte('=')
+		b.WriteString(r.Axes[k])
+	}
+	return b.String()
+}
+
+// cellKey identifies a matrix cell independent of which run produced it:
+// (backend, axes, scenario, mode). Two runs of the same cell share a
+// cellKey, which is how before/after comparison and latest-per-cell
+// collapsing match rows across runs.
+func cellKey(r record) string {
+	return r.Backend + "\x00" + canonicalAxes(r) + "\x00" + r.Scenario + "\x00" + r.Mode
+}
+
+// distinctRuns returns the sorted-descending set of run ids present, so
+// the newest run sorts first (run ids are lexically sortable timestamps).
+func distinctRuns(recs []record) []string {
+	set := map[string]bool{}
+	for _, r := range recs {
+		set[r.Run] = true
+	}
+	out := make([]string, 0, len(set))
+	for id := range set {
+		out = append(out, id)
+	}
+	sort.Sort(sort.Reverse(sort.StringSlice(out)))
+	return out
+}
+
+// latestPerCell keeps, for each cell, only the row from the newest run, so
+// the default table shows one current number per cell even when several
+// runs are merged. It returns the collapsed rows.
+func latestPerCell(recs []record) []record {
+	best := map[string]record{}
+	for _, r := range recs {
+		k := cellKey(r)
+		if cur, ok := best[k]; !ok || r.Run > cur.Run {
+			best[k] = r
+		}
+	}
+	out := make([]record, 0, len(best))
+	for _, r := range best {
+		out = append(out, r)
+	}
+	return out
+}
+
+// dimValue extracts the value of the comparison dimension from a row. The
+// bool is false when the row does not carry the dimension at all (an axis
+// key it lacks, or a legacy-only "axis" on a named-axis row), so such rows
+// are excluded from the comparison rather than matched as empty.
+func dimValue(r record, dim string) (string, bool) {
+	switch dim {
+	case "run":
+		return r.Run, true
+	case "backend":
+		return r.Backend, true
+	case "scenario":
+		return r.Scenario, true
+	case "mode":
+		return r.Mode, true
+	case "axis":
+		if len(r.Axes) == 0 {
+			return r.Axis, r.Axis != ""
+		}
+		return "", false
+	default:
+		v, ok := r.Axes[dim]
+		return v, ok
+	}
+}
+
+// isAxisDim reports whether dim names a key in the named Axes map rather
+// than one of the fixed identity fields or the legacy flat axis.
+func isAxisDim(dim string) bool {
+	switch dim {
+	case "run", "backend", "scenario", "mode", "axis":
+		return false
+	default:
+		return true
+	}
+}
+
+// residualKey identifies a row by every identity dimension EXCEPT the one
+// under comparison, so two rows differing only in that dimension (e.g.
+// auth=sas vs auth=entra of the same run/scenario/mode) collapse to one
+// comparison cell. Run is part of the residual for non-run dimensions, so
+// comparisons stay apples-to-apples within a single run.
+func residualKey(r record, dim string) string {
+	backend, scenario, mode, run := r.Backend, r.Scenario, r.Mode, r.Run
+	switch dim {
+	case "backend":
+		backend = ""
+	case "scenario":
+		scenario = ""
+	case "mode":
+		mode = ""
+	case "run":
+		run = ""
+	}
+	return backend + "\x00" + canonicalAxesExcept(r, dim) + "\x00" + scenario + "\x00" + mode + "\x00" + run
+}
+
+// distinctDimValues returns the sorted-ascending set of non-empty values a
+// dimension takes across recs (empty values are not selectable).
+func distinctDimValues(recs []record, dim string) []string {
+	set := map[string]bool{}
+	for _, r := range recs {
+		if v, ok := dimValue(r, dim); ok && v != "" {
+			set[v] = true
+		}
+	}
+	out := make([]string, 0, len(set))
+	for v := range set {
+		out = append(out, v)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// resolveDimValue maps a selector to a concrete value of the dimension. The
+// run dimension keeps its latest/previous/prefix semantics; every other
+// dimension requires an exact match against the values actually present.
+func resolveDimValue(dim, sel string, recs []record) (string, error) {
+	if dim == "run" {
+		return resolveRun(sel, distinctRuns(recs))
+	}
+	values := distinctDimValues(recs, dim)
+	if len(values) == 0 {
+		return "", fmt.Errorf("no rows carry dimension %q", dim)
+	}
+	for _, v := range values {
+		if v == sel {
+			return v, nil
+		}
+	}
+	return "", fmt.Errorf("no %s value matches %q (available: %s)", dim, sel, strings.Join(values, ", "))
+}
+
+// errNotEnoughRuns marks the "fewer than two runs to compare" condition so
+// a gate (--fail-over) can treat it as a skip rather than a failure.
+var errNotEnoughRuns = errors.New("not enough runs to compare")
+
+// resolveRun maps a run selector to a concrete run id. "latest" and
+// "previous" pick the 1st and 2nd newest runs; otherwise the value must
+// equal a run id or be an unambiguous prefix of exactly one.
+func resolveRun(sel string, runs []string) (string, error) {
+	switch sel {
+	case "latest":
+		if len(runs) == 0 {
+			return "", fmt.Errorf("%w: no runs present", errNotEnoughRuns)
+		}
+		return runs[0], nil
+	case "previous":
+		if len(runs) < 2 {
+			return "", fmt.Errorf("%w: need at least 2 runs for %q (have %d)", errNotEnoughRuns, sel, len(runs))
+		}
+		return runs[1], nil
+	}
+	var match string
+	var n int
+	for _, id := range runs {
+		if id == sel {
+			return id, nil
+		}
+		if strings.HasPrefix(id, sel) {
+			match = id
+			n++
+		}
+	}
+	switch n {
+	case 1:
+		return match, nil
+	case 0:
+		return "", fmt.Errorf("no run matches %q", sel)
+	default:
+		return "", fmt.Errorf("run selector %q is ambiguous (%d matches)", sel, n)
+	}
+}
+
+func sortRecs(recs []record) {
+	sort.SliceStable(recs, func(i, j int) bool {
+		if recs[i].Backend != recs[j].Backend {
+			return recs[i].Backend < recs[j].Backend
+		}
+		if a, b := canonicalAxes(recs[i]), canonicalAxes(recs[j]); a != b {
+			return a < b
+		}
+		if recs[i].Scenario != recs[j].Scenario {
+			return recs[i].Scenario < recs[j].Scenario
+		}
+		if recs[i].Mode != recs[j].Mode {
+			return recs[i].Mode < recs[j].Mode
+		}
+		// Newest run first so an --all-runs table reads top-down in time.
+		return recs[i].Run > recs[j].Run
+	})
+}
+
+func renderTable(w io.Writer, recs []record) error {
+	sortRecs(recs)
+	cols := axisColumns(recs)
+	warnMixedAxisKeys(w, recs, cols)
+	showRun := len(distinctRuns(recs)) >= 2
+	_, _ = fmt.Fprintln(w, "PERF MATRIX (client-side RTT; est = cold_p50 − warm_p50 ≈ establishment cost)")
+	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
+
+	header := []string{"backend"}
+	if len(cols) == 0 {
+		header = append(header, "axis")
+	} else {
+		header = append(header, cols...)
+	}
+	if showRun {
+		header = append(header, "run")
+	}
+	header = append(header, "scenario", "mode", "cold_p50", "warm_p50", "warm_p95", "est", "cold_n", "warm_n", "success", "wall")
+	_, _ = fmt.Fprintln(tw, strings.Join(header, "\t"))
+
+	for _, r := range recs {
+		cells := []string{dash(r.Backend)}
+		if len(cols) == 0 {
+			cells = append(cells, dash(r.Axis))
+		} else {
+			for _, k := range cols {
+				cells = append(cells, dash(r.Axes[k]))
+			}
+		}
+		if showRun {
+			cells = append(cells, dash(r.Run))
+		}
+		cells = append(cells,
+			r.Scenario, dash(r.Mode),
+			durOrDash(r.ColdP50Ns), durOrDash(r.WarmP50Ns), durOrDash(r.WarmP95Ns),
+			estCell(r),
+			fmt.Sprintf("%d", r.ColdN), fmt.Sprintf("%d", r.WarmN),
+			fmt.Sprintf("%d/%d", r.SuccessN, r.AttemptN), dur(r.WallNs),
+		)
+		_, _ = fmt.Fprintln(tw, strings.Join(cells, "\t"))
+	}
+	return tw.Flush()
+}
+
+// regression is one positive warm/cold p50 delta for a single cell, used
+// by the --fail-over gate. pct is the percent slowdown; absNs the absolute
+// p50 increase in nanoseconds.
+type regression struct {
+	label string
+	pct   float64
+	absNs int64
+}
+
+// gateStats summarises a comparison for the --fail-over gate: how many
+// cells paired on both sides, which baseline cells the candidate dropped,
+// and every warm/cold p50 regression observed.
+type gateStats struct {
+	paired        int
+	missingInCand []string
+	regressions   []regression
+}
+
+// regressionPct returns the percent and absolute slowdown of cand over
+// base, and ok=true only when both are present, base is positive, and cand
+// is actually slower (an improvement or unchanged value is not a
+// regression and never gates).
+func regressionPct(base, cand *int64) (pct float64, absNs int64, ok bool) {
+	if base == nil || cand == nil || *base <= 0 {
+		return 0, 0, false
+	}
+	d := *cand - *base
+	if d <= 0 {
+		return 0, 0, false
+	}
+	return float64(d) / float64(*base) * 100, d, true
+}
+
+// cellLabel is a short human key for a comparison cell, used in gate
+// messages so a failure names the offending scenario/mode/axis.
+func cellLabel(r record) string {
+	ax := displayAxes(r)
+	if ax == "" {
+		ax = "-"
+	}
+	return fmt.Sprintf("%s/%s/%s/%s", dash(r.Backend), ax, r.Scenario, dash(r.Mode))
+}
+
+// renderCompare matches cells across two values of a dimension (runs by
+// default; or a named axis like auth/delay, or backend/scenario/mode) and
+// prints baseline, candidate, and the delta for the three headline
+// metrics. The compared dimension is dropped from the identity columns.
+// Cells present on only one side are listed (with dashes) so missing
+// coverage is visible. For non-run dimensions the run id stays part of a
+// cell's identity, so a multi-run history yields one comparison row per
+// run (surfaced via a run column). It returns gateStats for the
+// --fail-over gate; the stats are meaningful only when no error is
+// returned.
+func renderCompare(w io.Writer, recs []record, dim, baseSel, candSel string) (gateStats, error) {
+	var gs gateStats
+	base, err := resolveDimValue(dim, baseSel, recs)
+	if err != nil {
+		return gs, fmt.Errorf("baseline %q: %w", baseSel, err)
+	}
+	cand, err := resolveDimValue(dim, candSel, recs)
+	if err != nil {
+		return gs, fmt.Errorf("candidate %q: %w", candSel, err)
+	}
+	if base == cand {
+		return gs, fmt.Errorf("baseline and candidate resolve to the same %s %q", dim, base)
+	}
+
+	baseByCell := map[string]record{}
+	candByCell := map[string]record{}
+	cellOrder := []record{}
+	seen := map[string]bool{}
+	excluded := 0
+	for _, r := range recs {
+		v, ok := dimValue(r, dim)
+		if !ok {
+			excluded++
+			continue
+		}
+		if v != base && v != cand {
+			continue
+		}
+		k := residualKey(r, dim)
+		if v == base {
+			baseByCell[k] = r
+		} else {
+			candByCell[k] = r
+		}
+		if !seen[k] {
+			seen[k] = true
+			cellOrder = append(cellOrder, r)
+		}
+	}
+
+	for k, br := range baseByCell {
+		if _, ok := candByCell[k]; ok {
+			gs.paired++
+		} else {
+			gs.missingInCand = append(gs.missingInCand, cellLabel(br))
+		}
+	}
+	if gs.paired == 0 && dim != "run" {
+		return gs, fmt.Errorf("no cells matched on both sides of %s %q..%q; non-run comparisons require rows to share every other dimension including run id (e.g. mock and azure are separate runs) — narrow with filters or compare runs instead", dim, base, cand)
+	}
+	if excluded > 0 {
+		_, _ = fmt.Fprintf(w, "warning: %d rows lack dimension %q and were excluded from the comparison\n", excluded, dim)
+	}
+
+	sortRecs(cellOrder)
+	cols := axisColumns(cellOrder)
+	namedAxes := len(cols) > 0
+	if isAxisDim(dim) {
+		cols = removeStr(cols, dim)
+	}
+	showBackend := dim != "backend"
+	showScenario := dim != "scenario"
+	showMode := dim != "mode"
+	showRun := dim != "run" && len(distinctRuns(cellOrder)) > 1
+
+	_, _ = fmt.Fprintf(w, "PERF COMPARE  %s: baseline=%s  candidate=%s  (Δ%% = (candidate−baseline)/baseline; negative is faster)\n", dim, base, cand)
+	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
+	var header []string
+	if showBackend {
+		header = append(header, "backend")
+	}
+	if namedAxes {
+		header = append(header, cols...)
+	} else if dim != "axis" {
+		header = append(header, "axis")
+	}
+	if showRun {
+		header = append(header, "run")
+	}
+	if showScenario {
+		header = append(header, "scenario")
+	}
+	if showMode {
+		header = append(header, "mode")
+	}
+	header = append(header,
+		"warm_base", "warm_cand", "warm_Δ%",
+		"cold_base", "cold_cand", "cold_Δ%",
+		"est_base", "est_cand", "est_Δ%")
+	_, _ = fmt.Fprintln(tw, strings.Join(header, "\t"))
+
+	for _, c := range cellOrder {
+		k := residualKey(c, dim)
+		b, bok := baseByCell[k]
+		n, nok := candByCell[k]
+		var cells []string
+		if showBackend {
+			cells = append(cells, dash(c.Backend))
+		}
+		if namedAxes {
+			for _, key := range cols {
+				cells = append(cells, dash(c.Axes[key]))
+			}
+		} else if dim != "axis" {
+			cells = append(cells, dash(c.Axis))
+		}
+		if showRun {
+			cells = append(cells, dash(c.Run))
+		}
+		if showScenario {
+			cells = append(cells, c.Scenario)
+		}
+		if showMode {
+			cells = append(cells, dash(c.Mode))
+		}
+		cells = append(cells, compareTriplet(ptrIf(bok, b.WarmP50Ns), ptrIf(nok, n.WarmP50Ns))...)
+		cells = append(cells, compareTriplet(ptrIf(bok, b.ColdP50Ns), ptrIf(nok, n.ColdP50Ns))...)
+		cells = append(cells, compareTriplet(estNs(b, bok), estNs(n, nok))...)
+		_, _ = fmt.Fprintln(tw, strings.Join(cells, "\t"))
+
+		// Collect warm/cold p50 regressions for the gate. est is derived
+		// (cold − warm) and amplifies noise, so it is reported but never
+		// gated. Only paired cells contribute.
+		if bok && nok {
+			if pct, abs, ok := regressionPct(b.WarmP50Ns, n.WarmP50Ns); ok {
+				gs.regressions = append(gs.regressions, regression{cellLabel(c) + " warm_p50", pct, abs})
+			}
+			if pct, abs, ok := regressionPct(b.ColdP50Ns, n.ColdP50Ns); ok {
+				gs.regressions = append(gs.regressions, regression{cellLabel(c) + " cold_p50", pct, abs})
+			}
+		}
+	}
+	if err := tw.Flush(); err != nil {
+		return gs, err
+	}
+	return gs, nil
+}
+
+// gateVerdict is the pure decision behind applyGate: it returns the worst
+// warm/cold p50 regression that breaches BOTH the percent threshold and
+// the absolute floor (nil when none do), or an error when the comparison
+// paired no cells (the gate must never silently pass on nothing).
+func gateVerdict(gs gateStats, failOverPct float64, floor time.Duration) (*regression, error) {
+	if gs.paired == 0 {
+		return nil, errors.New("no cells paired across baseline and candidate — nothing was compared")
+	}
+	var worst *regression
+	for i := range gs.regressions {
+		r := &gs.regressions[i]
+		if r.pct > failOverPct && time.Duration(r.absNs) > floor {
+			if worst == nil || r.pct > worst.pct {
+				worst = r
+			}
+		}
+	}
+	return worst, nil
+}
+
+// applyGate enforces the --fail-over regression gate after a comparison.
+// It exits non-zero when any paired warm/cold p50 cell regressed by more
+// than failOverPct AND by more than the failMinAbs duration floor (so a
+// large percent on a tiny baseline can't flake the gate). A comparison
+// that paired no cells is a hard failure. Cells the candidate dropped are
+// surfaced as a warning rather than a failure, because the measured
+// scenario set legitimately evolves over time on main.
+func applyGate(gs gateStats, failOverPct float64, failMinAbs string) {
+	floor, err := time.ParseDuration(failMinAbs)
+	if err != nil {
+		fail(fmt.Errorf("--fail-min-abs %q: %w", failMinAbs, err))
+	}
+	if len(gs.missingInCand) > 0 {
+		fmt.Fprintf(os.Stderr, "perf-gate: warning: %d baseline cell(s) absent from the candidate (scenario set drift?): %s\n",
+			len(gs.missingInCand), strings.Join(gs.missingInCand, ", "))
+	}
+	worst, err := gateVerdict(gs, failOverPct, floor)
+	if err != nil {
+		fail(fmt.Errorf("perf-gate: %w", err))
+	}
+	if worst != nil {
+		fmt.Fprintf(os.Stderr, "perf-gate: FAIL — %s regressed %+.1f%% (+%s), exceeding --fail-over %.1f%% / --fail-min-abs %s\n",
+			worst.label, worst.pct, time.Duration(worst.absNs).Round(time.Millisecond), failOverPct, floor)
+		os.Exit(1)
+	}
+	fmt.Fprintf(os.Stderr, "perf-gate: OK — no warm/cold p50 regression beyond %.1f%% / %s across %d paired cell(s)\n",
+		failOverPct, floor, gs.paired)
+}
+
+// removeStr returns ss without the first occurrence of v.
+func removeStr(ss []string, v string) []string {
+	out := make([]string, 0, len(ss))
+	for _, s := range ss {
+		if s == v {
+			continue
+		}
+		out = append(out, s)
+	}
+	return out
+}
+
+// ptrIf returns p only when present is true, so a cell missing on one side
+// of a comparison renders as a dash rather than borrowing the other side.
+func ptrIf(present bool, p *int64) *int64 {
+	if !present {
+		return nil
+	}
+	return p
+}
+
+// estNs is the establishment estimate (cold_p50 − warm_p50) in ns, or nil
+// when present is false or either component is unmeasured.
+func estNs(r record, present bool) *int64 {
+	if !present || r.ColdP50Ns == nil || r.WarmP50Ns == nil {
+		return nil
+	}
+	v := *r.ColdP50Ns - *r.WarmP50Ns
+	return &v
+}
+
+// compareTriplet renders base, candidate, and percent delta for one metric.
+func compareTriplet(base, cand *int64) []string {
+	bc, cc := durOrDash(base), durOrDash(cand)
+	if base == nil || cand == nil || *base == 0 {
+		return []string{bc, cc, "-"}
+	}
+	pct := float64(*cand-*base) / float64(*base) * 100
+	return []string{bc, cc, fmt.Sprintf("%+.1f%%", pct)}
+}
+
+// warnMixedAxisKeys prints one warning when the named-axis key sets differ
+// across rows (including legacy rows that carry no named axes), because a
+// pivot/filter on a key that some rows lack will silently exclude them.
+func warnMixedAxisKeys(w io.Writer, recs []record, cols []string) {
+	if len(cols) == 0 {
+		return
+	}
+	for _, r := range recs {
+		for _, k := range cols {
+			if _, ok := r.Axes[k]; !ok {
+				_, _ = fmt.Fprintf(w, "warning: rows carry differing axis dimensions (some lack %q) — filters/pivots on it will skip them\n", k)
+				return
+			}
+		}
+	}
+}
+
+// placementCodes maps the single-letter distance codes used in placement
+// axis names to display labels, in near→far order.
+var placementCodes = []struct {
+	code, label string
+}{
+	{"n", "near"},
+	{"m", "mid"},
+	{"f", "far"},
+}
+
+// renderGrid pivots the placement axis into a 3x3 of the chosen metric.
+// It requires the (filtered) records to share exactly one backend, one
+// scenario, and one mode — otherwise the grid would conflate distinct
+// measurements — and every axis to be a two-letter placement code
+// <sender><listener>.
+func renderGrid(w io.Writer, recs []record, metric string) error {
+	value, ok := metricFn(metric)
+	if !ok {
+		return fmt.Errorf("unknown --metric %q (want all|est|warm|cold)", metric)
+	}
+
+	// The grid pivots the placement axis, so first keep only rows that name
+	// a placement cell. A merged history can hold non-placement runs (a
+	// plain perf-mock row with no backend tag, an azure auth cell) that
+	// share this scenario/mode; those are skipped, not fatal. A genuinely
+	// ambiguous axis (two placement-shaped segments) is still fatal. The
+	// single-backend/scenario/mode check runs on the surviving placement
+	// rows so a stray non-placement row cannot abort the grid before it.
+	var placement []record
+	skipped := 0
+	for _, r := range recs {
+		if _, _, err := parsePlacement(r.Axis); err != nil {
+			if errors.Is(err, errNotPlacement) {
+				skipped++
+				continue
+			}
+			return err
+		}
+		placement = append(placement, r)
+	}
+	if len(placement) == 0 {
+		if len(recs) == 0 {
+			return errors.New("no rows selected for the grid (check --scenario/--mode/--filter)")
+		}
+		return fmt.Errorf("no placement grid cells among the selected rows "+
+			"(scenario=%s mode=%s); none of %d row(s) carry a two-letter "+
+			"<sender><listener> code — run 'make perf-placement' or pick a swept scenario",
+			dash(recs[0].Scenario), dash(recs[0].Mode), len(recs))
+	}
+	if err := requireSingle(placement, func(r record) string { return r.Backend }, "backend"); err != nil {
+		return err
+	}
+	if err := requireSingle(placement, func(r record) string { return r.Scenario }, "scenario"); err != nil {
+		return err
+	}
+	if err := requireSingle(placement, func(r record) string { return r.Mode }, "mode"); err != nil {
+		return err
+	}
+
+	cell := map[string]string{} // "sender,listener" -> formatted value
+	for _, r := range placement {
+		s, l, _ := parsePlacement(r.Axis) // already validated above
+		coord := s + "," + l
+		// Two rows landing on the same coordinate means placement is not
+		// the only varying dimension (e.g. a perf-placement "nf" row and an
+		// unpinned perf-axes-mock "sas/nf" row both map to n,f). Refuse
+		// rather than silently render whichever was iterated last.
+		if _, dup := cell[coord]; dup {
+			return fmt.Errorf("multiple rows map to placement cell %s%s — "+
+				"placement is not the only varying dimension; narrow with "+
+				"--filter <axis>=<value> or compare a single run", s, l)
+		}
+		cell[coord] = value(r)
+	}
+	if skipped > 0 {
+		fmt.Fprintf(os.Stderr, "note: skipped %d non-placement row(s) outside the grid\n", skipped)
+	}
+
+	cellLegend := "ms"
+	if metric == "all" {
+		cellLegend = "cell=cold/warm/est ms"
+	}
+	_, _ = fmt.Fprintf(w, "PERF MATRIX GRID  backend=%s  metric=%s  scenario=%s  mode=%s  (rows=sender, cols=listener; %s)\n",
+		dash(placement[0].Backend), metric, placement[0].Scenario, dash(placement[0].Mode), cellLegend)
+	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
+	header := "sender\\listener"
+	for _, c := range placementCodes {
+		header += "\t" + c.label
+	}
+	_, _ = fmt.Fprintln(tw, header)
+	for _, s := range placementCodes {
+		row := s.label
+		for _, l := range placementCodes {
+			v := cell[s.code+","+l.code]
+			if v == "" {
+				v = "-"
+			}
+			row += "\t" + v
+		}
+		_, _ = fmt.Fprintln(tw, row)
+	}
+	return tw.Flush()
+}
+
+// metricFn returns a formatter for the chosen grid metric. est is the
+// derived cold−warm establishment cost, computed here (never stored);
+// warm/cold are the corresponding p50s. A "-" results when the needed
+// measurement is absent.
+func metricFn(metric string) (func(record) string, bool) {
+	switch metric {
+	case "all":
+		return func(r record) string {
+			cold := msPtr(r.ColdP50Ns)
+			warm := msPtr(r.WarmP50Ns)
+			est := "-"
+			if r.ColdP50Ns != nil && r.WarmP50Ns != nil {
+				est = ms(*r.ColdP50Ns - *r.WarmP50Ns)
+			}
+			return cold + "/" + warm + "/" + est
+		}, true
+	case "est":
+		return func(r record) string {
+			if r.ColdP50Ns == nil || r.WarmP50Ns == nil {
+				return "-"
+			}
+			return ms(*r.ColdP50Ns - *r.WarmP50Ns)
+		}, true
+	case "warm":
+		return func(r record) string { return msPtr(r.WarmP50Ns) }, true
+	case "cold":
+		return func(r record) string { return msPtr(r.ColdP50Ns) }, true
+	default:
+		return nil, false
+	}
+}
+
+func requireSingle(recs []record, key func(record) string, name string) error {
+	set := map[string]bool{}
+	for _, r := range recs {
+		set[key(r)] = true
+	}
+	if len(set) == 1 {
+		return nil
+	}
+	vals := make([]string, 0, len(set))
+	for v := range set {
+		if v == "" {
+			v = "(none)"
+		}
+		vals = append(vals, v)
+	}
+	sort.Strings(vals)
+	return fmt.Errorf("grid needs exactly one %s but artifact has %d (%s); "+
+		"narrow with --%s", name, len(set), strings.Join(vals, ", "), name)
+}
+
+// parsePlacement extracts the sender/listener distance codes from a
+// placement axis. The placement code is the unique `/`-separated segment
+// shaped as two letters drawn from n/m/f — found by scanning ALL segments
+// rather than assuming a fixed position, so it stays correct if a backend
+// reorders or inserts axis dimensions around the placement one. Zero
+// matches means the axis is not a placement grid; more than one match is
+// ambiguous — both fail loudly rather than pivoting on the wrong segment.
+// errNotPlacement marks an axis that carries no placement-shaped segment,
+// so callers (e.g. the grid over a merged history) can skip such a row
+// instead of treating it as a hard error.
+var errNotPlacement = errors.New("not a placement grid cell")
+
+func parsePlacement(axis string) (sender, listener string, err error) {
+	var matches []string
+	for _, seg := range strings.Split(axis, "/") {
+		if len(seg) == 2 && isCode(seg[0]) && isCode(seg[1]) {
+			matches = append(matches, seg)
+		}
+	}
+	switch len(matches) {
+	case 1:
+		return matches[0][0:1], matches[0][1:2], nil
+	case 0:
+		return "", "", fmt.Errorf("%w: axis %q "+
+			"(want a two-letter <sender><listener> code from n/m/f)", errNotPlacement, axis)
+	default:
+		return "", "", fmt.Errorf("axis %q has multiple placement-shaped segments %v; "+
+			"cannot tell which is the placement dimension", axis, matches)
+	}
+}
+
+func isCode(b byte) bool { return b == 'n' || b == 'm' || b == 'f' }
+
+func dash(s string) string {
+	if s == "" {
+		return "-"
+	}
+	return s
+}
+
+func durOrDash(ns *int64) string {
+	if ns == nil {
+		return "-"
+	}
+	return dur(*ns)
+}
+
+func estCell(r record) string {
+	if r.ColdP50Ns == nil || r.WarmP50Ns == nil {
+		return "-"
+	}
+	return dur(*r.ColdP50Ns - *r.WarmP50Ns)
+}
+
+// dur renders a nanosecond count as a duration with the same 100µs
+// rounding the harness table uses, so reporter and inline outputs match.
+func dur(ns int64) string {
+	d := time.Duration(ns)
+	if d >= time.Millisecond {
+		return d.Round(100 * time.Microsecond).String()
+	}
+	return d.Round(time.Microsecond).String()
+}
+
+// ms renders a nanosecond count as a millisecond float with one decimal,
+// the natural unit for the placement grid.
+func ms(ns int64) string {
+	return fmt.Sprintf("%.1f", float64(ns)/float64(time.Millisecond))
+}
+
+func msPtr(ns *int64) string {
+	if ns == nil {
+		return "-"
+	}
+	return ms(*ns)
+}

--- a/e2e/cmd/perfreport/main_test.go
+++ b/e2e/cmd/perfreport/main_test.go
@@ -1,0 +1,877 @@
+package main
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func writeTemp(t *testing.T, lines ...string) string {
+	t.Helper()
+	p := filepath.Join(t.TempDir(), "a.jsonl")
+	if err := os.WriteFile(p, []byte(strings.Join(lines, "\n")+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return p
+}
+
+const (
+	rowNF    = `{"type":"row","schema":"perfmatrix/v1","backend":"mock","axis":"nf","scenario":"S","mode":"PortForward","cold_p50_ns":1191700000,"warm_p50_ns":192600000,"warm_p95_ns":193500000,"cold_n":5,"warm_n":25,"success_n":5,"attempt_n":5,"wall_ns":2155600000}`
+	rowFN    = `{"type":"row","schema":"perfmatrix/v1","backend":"mock","axis":"fn","scenario":"S","mode":"PortForward","cold_p50_ns":1104900000,"warm_p50_ns":192600000,"warm_p95_ns":193800000,"cold_n":5,"warm_n":25,"success_n":5,"attempt_n":5,"wall_ns":2069300000}`
+	rowAzure = `{"type":"row","schema":"perfmatrix/v1","backend":"azure","axis":"sas","scenario":"S","mode":"PortForward","cold_p50_ns":1450000000,"warm_p50_ns":210000000,"warm_p95_ns":215000000,"cold_n":5,"warm_n":25,"success_n":5,"attempt_n":5,"wall_ns":2500000000}`
+)
+
+func TestLoad_SkipsBlankAndNonRow(t *testing.T) {
+	p := writeTemp(t, rowNF, "", `{"type":"meta","schema":"perfmatrix/v1"}`, rowFN)
+	recs, _, err := load([]string{p})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(recs) != 2 {
+		t.Fatalf("got %d rows, want 2 (blank + meta skipped)", len(recs))
+	}
+}
+
+func TestLoad_DuplicateIsError(t *testing.T) {
+	p := writeTemp(t, rowNF, rowNF)
+	if _, _, err := load([]string{p}); err == nil || !strings.Contains(err.Error(), "duplicate") {
+		t.Fatalf("want duplicate error, got %v", err)
+	}
+}
+
+func TestLoad_MalformedIsError(t *testing.T) {
+	p := writeTemp(t, "{not json}")
+	if _, _, err := load([]string{p}); err == nil || !strings.Contains(err.Error(), "malformed") {
+		t.Fatalf("want malformed error, got %v", err)
+	}
+}
+
+func TestRenderGrid_Est(t *testing.T) {
+	recs, _, err := load([]string{writeTemp(t, rowNF, rowFN)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var b strings.Builder
+	if err := renderGrid(&b, recs, "est"); err != nil {
+		t.Fatal(err)
+	}
+	out := b.String()
+	// nf est = 1191.7-192.6 = 999.1; fn est = 1104.9-192.6 = 912.3.
+	for _, want := range []string{"999.1", "912.3", "metric=est", "mode=PortForward"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("grid output missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestRenderGrid_AmbiguousModeIsError(t *testing.T) {
+	socks := strings.Replace(rowNF, "PortForward", "SOCKS5", 1)
+	recs, _, err := load([]string{writeTemp(t, rowNF, socks)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = renderGrid(&strings.Builder{}, recs, "est")
+	if err == nil || !strings.Contains(err.Error(), "exactly one mode") {
+		t.Fatalf("want ambiguous-mode error, got %v", err)
+	}
+}
+
+func TestRenderGrid_NonPlacementAxisIsError(t *testing.T) {
+	row := strings.Replace(rowNF, `"axis":"nf"`, `"axis":"entra/far"`, 1)
+	recs, _, err := load([]string{writeTemp(t, row)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = renderGrid(&strings.Builder{}, recs, "est")
+	if err == nil || !strings.Contains(err.Error(), "placement grid cell") {
+		t.Fatalf("want placement-parse error, got %v", err)
+	}
+}
+
+func TestRenderGrid_SkipsNonPlacementRowsInMergedHistory(t *testing.T) {
+	// A non-placement run (e.g. a plain perf-mock row) can share the
+	// scenario and mode in the unified history; the grid builds from the
+	// placement rows and skips the stray one instead of erroring.
+	stray := strings.Replace(rowNF, `"axis":"nf"`, `"axis":"entra"`, 1)
+	recs, _, err := load([]string{writeTemp(t, rowNF, rowFN, stray)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var b strings.Builder
+	if err := renderGrid(&b, recs, "est"); err != nil {
+		t.Fatalf("grid should tolerate a non-placement row: %v", err)
+	}
+	out := b.String()
+	for _, want := range []string{"999.1", "912.3"} { // nf and fn cells still render
+		if !strings.Contains(out, want) {
+			t.Errorf("grid missing placement cell %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestRenderGrid_AmbiguousAxisStaysFatal(t *testing.T) {
+	// Skipping non-placement rows must NOT swallow a genuinely ambiguous
+	// axis (two placement-shaped segments), even alongside a valid row.
+	ambig := strings.Replace(rowNF, `"axis":"nf"`, `"axis":"nf/ff"`, 1)
+	recs, _, err := load([]string{writeTemp(t, rowFN, ambig)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := renderGrid(&strings.Builder{}, recs, "est"); err == nil || !strings.Contains(err.Error(), "multiple placement-shaped") {
+		t.Fatalf("ambiguous axis should stay fatal, got %v", err)
+	}
+}
+
+func TestRenderGrid_DuplicatePlacementCellIsError(t *testing.T) {
+	// A perf-placement row (axis "nf") and an unpinned perf-axes-mock row
+	// (axis "sas/nf") both map to cell n,f but differ on the auth axis;
+	// the grid must reject the ambiguity rather than silently pick one.
+	axesRow := strings.Replace(rowNF, `"axis":"nf"`, `"axis":"sas/nf"`, 1)
+	recs, _, err := load([]string{writeTemp(t, rowNF, axesRow)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := renderGrid(&strings.Builder{}, recs, "est"); err == nil || !strings.Contains(err.Error(), "placement cell") {
+		t.Fatalf("want duplicate-cell error, got %v", err)
+	}
+}
+
+func TestRenderGrid_SkipsBackendlessNonPlacementRow(t *testing.T) {
+	// A plain perf-mock row carries no backend tag and a non-placement
+	// axis; it must be skipped before the single-backend check, not abort
+	// it (the grid still renders from the real placement rows).
+	stray := strings.Replace(rowNF, `"backend":"mock","axis":"nf"`, `"backend":"","axis":""`, 1)
+	recs, _, err := load([]string{writeTemp(t, rowNF, rowFN, stray)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var b strings.Builder
+	if err := renderGrid(&b, recs, "est"); err != nil {
+		t.Fatalf("backend-less non-placement row should be skipped, got %v", err)
+	}
+	for _, want := range []string{"999.1", "912.3"} {
+		if !strings.Contains(b.String(), want) {
+			t.Errorf("grid missing placement cell %q:\n%s", want, b.String())
+		}
+	}
+}
+
+func TestParsePlacement(t *testing.T) {
+	cases := map[string]struct {
+		s, l string
+		ok   bool
+	}{
+		"nf":      {"n", "f", true},
+		"fn":      {"f", "n", true},
+		"sas/ff":  {"f", "f", true},
+		"sas/nf":  {"n", "f", true},
+		"nf/sas":  {"n", "f", true},
+		"nn":      {"n", "n", true},
+		"xy":      {"", "", false},
+		"n":       {"", "", false},
+		"near":    {"", "", false},
+		"entra/x": {"", "", false},
+		"nf/ff":   {"", "", false}, // two placement-shaped segments → ambiguous
+	}
+	for axis, want := range cases {
+		s, l, err := parsePlacement(axis)
+		if want.ok && (err != nil || s != want.s || l != want.l) {
+			t.Errorf("parsePlacement(%q) = (%q,%q,%v), want (%q,%q,nil)", axis, s, l, err, want.s, want.l)
+		}
+		if !want.ok && err == nil {
+			t.Errorf("parsePlacement(%q) = nil err, want error", axis)
+		}
+	}
+}
+
+func TestRenderGrid_CompositeAll(t *testing.T) {
+	recs, _, err := load([]string{writeTemp(t, rowNF, rowFN)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var b strings.Builder
+	if err := renderGrid(&b, recs, "all"); err != nil {
+		t.Fatal(err)
+	}
+	out := b.String()
+	// nf cell = cold/warm/est = 1191.7/192.6/999.1 in one cell.
+	for _, want := range []string{"1191.7/192.6/999.1", "1104.9/192.6/912.3", "cell=cold/warm/est", "metric=all"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("composite grid missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestMetricFn_AllNilColdIsDashEst(t *testing.T) {
+	fn, ok := metricFn("all")
+	if !ok {
+		t.Fatal("all metric not found")
+	}
+	warm := int64(192600000)
+	// cold absent: cold and est show "-", warm still renders.
+	if got := fn(record{WarmP50Ns: &warm}); got != "-/192.6/-" {
+		t.Errorf("all with nil cold = %q, want -/192.6/-", got)
+	}
+}
+
+func TestLoad_BadSchemaIsError(t *testing.T) {
+	row := strings.Replace(rowNF, "perfmatrix/v1", "perfmatrix/v2", 1)
+	p := writeTemp(t, row)
+	if _, _, err := load([]string{p}); err == nil || !strings.Contains(err.Error(), "schema") {
+		t.Fatalf("want schema error, got %v", err)
+	}
+}
+
+func TestLoad_MergesBackendFiles(t *testing.T) {
+	mock := writeTemp(t, rowNF, rowFN)
+	azure := writeTemp(t, rowAzure)
+	recs, _, err := load([]string{mock, azure})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(recs) != 3 {
+		t.Fatalf("merged %d rows, want 3 (2 mock + 1 azure)", len(recs))
+	}
+	var b strings.Builder
+	if err := renderTable(&b, recs); err != nil {
+		t.Fatal(err)
+	}
+	out := b.String()
+	for _, want := range []string{"backend", "mock", "azure"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("merged table missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestRenderGrid_MultiBackendIsError(t *testing.T) {
+	// Two placement rows on different backends must trip the single-backend
+	// check (a non-placement azure auth row would instead be skipped).
+	azureNF := strings.Replace(rowNF, `"backend":"mock"`, `"backend":"azure"`, 1)
+	recs, _, err := load([]string{writeTemp(t, rowNF, azureNF)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = renderGrid(&strings.Builder{}, recs, "est")
+	if err == nil || !strings.Contains(err.Error(), "exactly one backend") {
+		t.Fatalf("want ambiguous-backend error, got %v", err)
+	}
+}
+
+func TestRenderGrid_EmptyRecordsIsErrorNotPanic(t *testing.T) {
+	if err := renderGrid(&strings.Builder{}, nil, "est"); err == nil {
+		t.Fatal("want error for empty record set, got nil")
+	}
+}
+
+func TestSingleCell(t *testing.T) {
+	one := []record{
+		{Scenario: "A", Mode: "PortForward", Axis: "nn"},
+		{Scenario: "A", Mode: "PortForward", Axis: "ff"},
+	}
+	if !singleCell(one) {
+		t.Error("singleCell = false for one scenario+mode, want true (grid-able)")
+	}
+	twoScenarios := append(append([]record{}, one...), record{Scenario: "B", Mode: "PortForward", Axis: "nn"})
+	if singleCell(twoScenarios) {
+		t.Error("singleCell = true for two scenarios, want false (table fallback)")
+	}
+	twoModes := append(append([]record{}, one...), record{Scenario: "A", Mode: "SOCKS5", Axis: "nn"})
+	if singleCell(twoModes) {
+		t.Error("singleCell = true for two modes, want false (table fallback)")
+	}
+}
+
+func TestMetricFn_EstNilIsDash(t *testing.T) {
+	fn, ok := metricFn("est")
+	if !ok {
+		t.Fatal("est metric not found")
+	}
+	warm := int64(5)
+	// cold absent (e.g. a prewarmed-only row): est must be "-", never a bogus value.
+	if got := fn(record{WarmP50Ns: &warm}); got != "-" {
+		t.Errorf("est with nil cold = %q, want -", got)
+	}
+}
+
+const (
+	runMock  = `{"type":"run","schema":"perfmatrix/v1","backend":"mock","generated_at":"2026-06-01T10:00:00Z","git_sha":"abc1234"}`
+	runAzure = `{"type":"run","schema":"perfmatrix/v1","backend":"azure","generated_at":"2026-06-01T10:05:00Z","git_sha":"abc1234"}`
+	runStale = `{"type":"run","schema":"perfmatrix/v1","backend":"azure","generated_at":"2026-05-20T08:00:00Z","git_sha":"deadbee"}`
+)
+
+func TestLoad_CollectsRunRecords(t *testing.T) {
+	_, runs, err := load([]string{writeTemp(t, runMock, rowNF, rowFN)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(runs) != 1 || runs[0].Backend != "mock" || runs[0].GitSHA != "abc1234" {
+		t.Fatalf("got runs %+v, want one mock@abc1234", runs)
+	}
+}
+
+func TestLoad_DedupsShardedRunHeaders(t *testing.T) {
+	// A single run sharded across writers prepends one identical run
+	// header per shard (same backend + run id); load must collapse them
+	// to a single provenance entry rather than repeating the same run.
+	shard := `{"type":"run","schema":"perfmatrix/v1","backend":"mock","run":"20260601T100000Z-abc1234","generated_at":"2026-06-01T10:00:00Z","git_sha":"abc1234"}`
+	_, runs, err := load([]string{writeTemp(t, shard, rowNF, shard, rowFN)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(runs) != 1 {
+		t.Fatalf("got %d run headers, want 1 deduped", len(runs))
+	}
+}
+
+func TestRenderProvenance_SingleBuildNoWarning(t *testing.T) {
+	mock := writeTemp(t, runMock, rowNF, rowFN)
+	azure := writeTemp(t, runAzure, rowAzure)
+	recs, runs, err := load([]string{mock, azure})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var b strings.Builder
+	renderProvenance(&b, relevantRuns(runs, recs))
+	out := b.String()
+	for _, want := range []string{"sources:", "mock@abc1234", "azure@abc1234"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("provenance missing %q:\n%s", want, out)
+		}
+	}
+	if strings.Contains(out, "warning") {
+		t.Errorf("same-sha sources should not warn:\n%s", out)
+	}
+}
+
+func TestRenderProvenance_MultiBuildWarns(t *testing.T) {
+	recs, runs, err := load([]string{writeTemp(t, runMock, rowNF, rowFN), writeTemp(t, runStale, rowAzure)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var b strings.Builder
+	renderProvenance(&b, relevantRuns(runs, recs))
+	if out := b.String(); !strings.Contains(out, "warning") {
+		t.Errorf("diverging shas should warn:\n%s", out)
+	}
+}
+
+func TestRelevantRuns_FiltersByPresentBackend(t *testing.T) {
+	recs, runs, err := load([]string{writeTemp(t, runMock, rowNF), writeTemp(t, runAzure, rowAzure)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Filter rows to mock only; provenance should drop the azure source.
+	rel := relevantRuns(runs, applyFilters(recs, map[string]string{"backend": "mock"}))
+	if len(rel) != 1 || rel[0].Backend != "mock" {
+		t.Fatalf("relevantRuns = %+v, want only mock", rel)
+	}
+}
+
+const (
+	rowAuthSasNN   = `{"type":"row","schema":"perfmatrix/v1","backend":"mock","axis":"sas/nn","axes":{"auth":"sas","delay":"nn"},"scenario":"S","mode":"PortForward","cold_p50_ns":255000000,"warm_p50_ns":22000000,"warm_p95_ns":22500000,"cold_n":5,"warm_n":25,"success_n":5,"attempt_n":5,"wall_ns":366000000}`
+	rowAuthEntraNN = `{"type":"row","schema":"perfmatrix/v1","backend":"mock","axis":"entra/nn","axes":{"auth":"entra","delay":"nn"},"scenario":"S","mode":"PortForward","cold_p50_ns":256000000,"warm_p50_ns":22100000,"warm_p95_ns":23000000,"cold_n":5,"warm_n":25,"success_n":5,"attempt_n":5,"wall_ns":367000000}`
+	rowAuthSasFF   = `{"type":"row","schema":"perfmatrix/v1","backend":"mock","axis":"sas/ff","axes":{"auth":"sas","delay":"ff"},"scenario":"S","mode":"PortForward","cold_p50_ns":1950000000,"warm_p50_ns":362000000,"warm_p95_ns":363000000,"cold_n":5,"warm_n":25,"success_n":5,"attempt_n":5,"wall_ns":3770000000}`
+)
+
+func TestRenderTable_NamedAxisColumns(t *testing.T) {
+	recs, _, err := load([]string{writeTemp(t, rowAuthSasNN, rowAuthEntraNN)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var b strings.Builder
+	if err := renderTable(&b, recs); err != nil {
+		t.Fatal(err)
+	}
+	out := b.String()
+	// auth and delay must be their own header columns, not a flat "axis".
+	hdr := ""
+	for _, line := range strings.Split(out, "\n") {
+		if strings.HasPrefix(line, "backend") {
+			hdr = line
+			break
+		}
+	}
+	for _, want := range []string{"auth", "delay"} {
+		if !strings.Contains(hdr, want) {
+			t.Errorf("header %q missing column %q", hdr, want)
+		}
+	}
+	if strings.Contains(hdr, "axis ") || strings.HasSuffix(strings.TrimSpace(hdr), "axis") {
+		t.Errorf("named-axis table should not have a flat 'axis' column: %q", hdr)
+	}
+}
+
+func TestMatchesFilters_EmptyValueDoesNotMatchMissingAxis(t *testing.T) {
+	withAxis := record{Backend: "mock", Scenario: "S", Mode: "PortForward", Axes: map[string]string{"auth": "sas"}}
+	noAxis := record{Backend: "mock", Scenario: "S", Mode: "PortForward"}
+
+	// An empty-valued axis filter must not silently include rows that
+	// lack that axis (honours applyFilters' documented contract).
+	if matchesFilters(noAxis, map[string]string{"auth": ""}) {
+		t.Fatal("row missing the auth axis matched --filter auth= (empty value)")
+	}
+	if matchesFilters(noAxis, map[string]string{"auth": "sas"}) {
+		t.Fatal("row missing the auth axis matched --filter auth=sas")
+	}
+	if !matchesFilters(withAxis, map[string]string{"auth": "sas"}) {
+		t.Fatal("row with auth=sas did not match --filter auth=sas")
+	}
+}
+
+func TestApplyFilters_AxisKey(t *testing.T) {
+	recs, _, err := load([]string{writeTemp(t, rowAuthSasNN, rowAuthEntraNN, rowAuthSasFF)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := applyFilters(recs, map[string]string{"delay": "nn"})
+	if len(got) != 2 {
+		t.Fatalf("delay=nn filter got %d rows, want 2", len(got))
+	}
+	got = applyFilters(recs, map[string]string{"auth": "sas", "delay": "ff"})
+	if len(got) != 1 || got[0].Axes["delay"] != "ff" {
+		t.Fatalf("auth=sas,delay=ff filter got %#v, want one ff row", got)
+	}
+	got = applyFilters(recs, map[string]string{"backend": "mock"})
+	if len(got) != 3 {
+		t.Fatalf("backend=mock got %d, want 3 (virtual key)", len(got))
+	}
+}
+
+func TestLoad_DedupUsesNamedAxes(t *testing.T) {
+	// Same scenario+mode+backend but different named axes must NOT collide.
+	if _, _, err := load([]string{writeTemp(t, rowAuthSasNN, rowAuthEntraNN)}); err != nil {
+		t.Fatalf("distinct named axes treated as duplicate: %v", err)
+	}
+	// Identical rows DO collide.
+	if _, _, err := load([]string{writeTemp(t, rowAuthSasNN, rowAuthSasNN)}); err == nil || !strings.Contains(err.Error(), "duplicate") {
+		t.Fatalf("want duplicate error for identical named-axis rows, got %v", err)
+	}
+}
+
+func TestWarnMixedAxisKeys(t *testing.T) {
+	// rowNF/rowFN carry no named axes; mixing them with named-axis rows
+	// must surface a warning so a pivot doesn't silently drop them.
+	recs, _, err := load([]string{writeTemp(t, rowAuthSasNN, rowNF)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var b strings.Builder
+	if err := renderTable(&b, recs); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(b.String(), "differing axis dimensions") {
+		t.Errorf("expected mixed-axes warning, got:\n%s", b.String())
+	}
+}
+
+// --- multi-run / comparison ---------------------------------------------
+
+const (
+	rowRunOld = `{"type":"row","schema":"perfmatrix/v1","run":"20260601T100000.000Z-aaaa","backend":"mock","axes":{"auth":"sas","delay":"ff"},"scenario":"S","mode":"PortForward","cold_p50_ns":2000000000,"warm_p50_ns":400000000,"warm_p95_ns":410000000,"cold_n":5,"warm_n":25,"success_n":5,"attempt_n":5,"wall_ns":2100000000}`
+	rowRunNew = `{"type":"row","schema":"perfmatrix/v1","run":"20260601T120000.000Z-bbbb","backend":"mock","axes":{"auth":"sas","delay":"ff"},"scenario":"S","mode":"PortForward","cold_p50_ns":1600000000,"warm_p50_ns":380000000,"warm_p95_ns":390000000,"cold_n":5,"warm_n":25,"success_n":5,"attempt_n":5,"wall_ns":1700000000}`
+)
+
+func TestLoad_SameCellDistinctRunsCoexist(t *testing.T) {
+	recs, _, err := load([]string{writeTemp(t, rowRunOld, rowRunNew)})
+	if err != nil {
+		t.Fatalf("two runs of one cell should not collide: %v", err)
+	}
+	if len(recs) != 2 {
+		t.Fatalf("got %d rows, want 2", len(recs))
+	}
+}
+
+func TestLoad_SameRunSameCellStillDuplicate(t *testing.T) {
+	p := writeTemp(t, rowRunOld, rowRunOld)
+	if _, _, err := load([]string{p}); err == nil || !strings.Contains(err.Error(), "duplicate") {
+		t.Fatalf("want duplicate error within one run, got %v", err)
+	}
+}
+
+func TestLatestPerCell_KeepsNewestRun(t *testing.T) {
+	recs, _, err := load([]string{writeTemp(t, rowRunOld, rowRunNew)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := latestPerCell(recs)
+	if len(got) != 1 {
+		t.Fatalf("got %d rows, want 1 collapsed", len(got))
+	}
+	if got[0].Run != "20260601T120000.000Z-bbbb" {
+		t.Errorf("kept run %q, want the newer bbbb", got[0].Run)
+	}
+}
+
+func TestResolveRun(t *testing.T) {
+	runs := []string{"20260601T120000.000Z-bbbb", "20260601T100000.000Z-aaaa"} // newest first
+	cases := []struct {
+		sel     string
+		want    string
+		wantErr bool
+	}{
+		{"latest", "20260601T120000.000Z-bbbb", false},
+		{"previous", "20260601T100000.000Z-aaaa", false},
+		{"20260601T100000.000Z-aaaa", "20260601T100000.000Z-aaaa", false}, // exact
+		{"20260601T12", "20260601T120000.000Z-bbbb", false},               // unique prefix
+		{"20260601T1", "", true},                                          // ambiguous prefix
+		{"nope", "", true},                                                // no match
+	}
+	for _, tc := range cases {
+		got, err := resolveRun(tc.sel, runs)
+		if tc.wantErr {
+			if err == nil {
+				t.Errorf("%q: want error, got %q", tc.sel, got)
+			}
+			continue
+		}
+		if err != nil || got != tc.want {
+			t.Errorf("%q: got (%q,%v), want (%q,nil)", tc.sel, got, err, tc.want)
+		}
+	}
+}
+
+func TestRenderCompare_Deltas(t *testing.T) {
+	recs, _, err := load([]string{writeTemp(t, rowRunOld, rowRunNew)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var b strings.Builder
+	if _, err := renderCompare(&b, recs, "run", "previous", "latest"); err != nil {
+		t.Fatal(err)
+	}
+	out := b.String()
+	// warm: (380-400)/400 = -5.0%; cold: (1600-2000)/2000 = -20.0%;
+	// est: base 1600, cand 1220 -> (1220-1600)/1600 = -23.8%.
+	for _, want := range []string{"-5.0%", "-20.0%", "-23.8%", "baseline=20260601T100000.000Z-aaaa"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("compare output missing %q:\n%s", want, out)
+		}
+	}
+}
+
+// gateCandRegress is newer than rowRunOld and SLOWER: warm 400ms->500ms
+// (+25%, +100ms), cold 2000ms->2200ms (+10%, +200ms).
+const gateCandRegress = `{"type":"row","schema":"perfmatrix/v1","run":"20260601T140000.000Z-cccc","backend":"mock","axes":{"auth":"sas","delay":"ff"},"scenario":"S","mode":"PortForward","cold_p50_ns":2200000000,"warm_p50_ns":500000000,"warm_p95_ns":510000000,"cold_n":5,"warm_n":25,"success_n":5,"attempt_n":5,"wall_ns":2700000000}`
+
+// gateTinyBase/gateTinyCand share a cell whose warm doubles (1ms->2ms):
+// +100% but only +1ms absolute, to exercise the --fail-min-abs floor.
+const gateTinyBase = `{"type":"row","schema":"perfmatrix/v1","run":"20260601T100000.000Z-aaaa","backend":"mock","axes":{"auth":"sas","delay":"ff"},"scenario":"S","mode":"PortForward","cold_p50_ns":1000000,"warm_p50_ns":1000000,"warm_p95_ns":1100000,"cold_n":5,"warm_n":25,"success_n":5,"attempt_n":5,"wall_ns":2000000}`
+const gateTinyCand = `{"type":"row","schema":"perfmatrix/v1","run":"20260601T140000.000Z-cccc","backend":"mock","axes":{"auth":"sas","delay":"ff"},"scenario":"S","mode":"PortForward","cold_p50_ns":1000000,"warm_p50_ns":2000000,"warm_p95_ns":2100000,"cold_n":5,"warm_n":25,"success_n":5,"attempt_n":5,"wall_ns":2000000}`
+
+func gateStatsFor(t *testing.T, rows ...string) gateStats {
+	t.Helper()
+	recs, _, err := load([]string{writeTemp(t, rows...)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	gs, err := renderCompare(&strings.Builder{}, recs, "run", "previous", "latest")
+	if err != nil {
+		t.Fatalf("renderCompare: %v", err)
+	}
+	return gs
+}
+
+func TestGate_CollectsWarmAndColdRegressions(t *testing.T) {
+	gs := gateStatsFor(t, rowRunOld, gateCandRegress)
+	if gs.paired != 1 {
+		t.Fatalf("paired = %d, want 1", gs.paired)
+	}
+	if len(gs.regressions) != 2 {
+		t.Fatalf("regressions = %d, want 2 (warm+cold):\n%+v", len(gs.regressions), gs.regressions)
+	}
+	var warm, cold *regression
+	for i := range gs.regressions {
+		switch {
+		case strings.HasSuffix(gs.regressions[i].label, "warm_p50"):
+			warm = &gs.regressions[i]
+		case strings.HasSuffix(gs.regressions[i].label, "cold_p50"):
+			cold = &gs.regressions[i]
+		}
+	}
+	if warm == nil || cold == nil {
+		t.Fatalf("missing warm/cold regression: %+v", gs.regressions)
+	}
+	if got := warm.pct; got < 24.9 || got > 25.1 {
+		t.Errorf("warm pct = %.2f, want ~25", got)
+	}
+	if warm.absNs != 100000000 {
+		t.Errorf("warm absNs = %d, want 100000000", warm.absNs)
+	}
+}
+
+func TestGateVerdict_TripsAboveThreshold(t *testing.T) {
+	gs := gateStatsFor(t, rowRunOld, gateCandRegress)
+	// warm +25% > 20% and +100ms > 50ms floor; cold +10% does not.
+	worst, err := gateVerdict(gs, 20, 50*time.Millisecond)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if worst == nil {
+		t.Fatal("want a tripping regression, got nil")
+	}
+	if !strings.HasSuffix(worst.label, "warm_p50") {
+		t.Errorf("worst = %q, want the warm_p50 cell", worst.label)
+	}
+}
+
+func TestGateVerdict_PassesWithinThreshold(t *testing.T) {
+	gs := gateStatsFor(t, rowRunOld, gateCandRegress)
+	// Both warm (+25%) and cold (+10%) are under a 30% gate.
+	worst, err := gateVerdict(gs, 30, 50*time.Millisecond)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if worst != nil {
+		t.Errorf("want pass, got tripping cell %q (%.1f%%)", worst.label, worst.pct)
+	}
+}
+
+func TestGateVerdict_AbsFloorSuppressesTinyBaseline(t *testing.T) {
+	gs := gateStatsFor(t, gateTinyBase, gateTinyCand)
+	// warm doubled (+100%) but only +1ms; a 50ms floor must suppress it.
+	worst, err := gateVerdict(gs, 20, 50*time.Millisecond)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if worst != nil {
+		t.Errorf("want floor to suppress, got tripping cell %q (+%dns)", worst.label, worst.absNs)
+	}
+}
+
+func TestGateVerdict_IgnoresImprovement(t *testing.T) {
+	gs := gateStatsFor(t, rowRunOld, rowRunNew) // candidate is faster
+	if len(gs.regressions) != 0 {
+		t.Errorf("an improvement produced regressions: %+v", gs.regressions)
+	}
+	worst, err := gateVerdict(gs, 1, time.Nanosecond)
+	if err != nil || worst != nil {
+		t.Errorf("want clean pass, got worst=%v err=%v", worst, err)
+	}
+}
+
+func TestGateVerdict_NoPairedCellsIsError(t *testing.T) {
+	if _, err := gateVerdict(gateStats{}, 20, 50*time.Millisecond); err == nil {
+		t.Fatal("want error when nothing paired, got nil")
+	}
+}
+
+func TestGate_DroppedCandidateCellIsTrackedNotPaired(t *testing.T) {
+	candOther := strings.Replace(gateCandRegress, `"scenario":"S"`, `"scenario":"OtherScenario"`, 1)
+	gs := gateStatsFor(t, rowRunOld, candOther)
+	if gs.paired != 0 {
+		t.Errorf("paired = %d, want 0 (scenario differs)", gs.paired)
+	}
+	if len(gs.missingInCand) != 1 {
+		t.Errorf("missingInCand = %v, want one entry", gs.missingInCand)
+	}
+	if _, err := gateVerdict(gs, 20, 50*time.Millisecond); err == nil {
+		t.Error("want gateVerdict error when nothing paired")
+	}
+}
+
+func TestGate_SingleRunIsNotEnoughRuns(t *testing.T) {
+	recs, _, err := load([]string{writeTemp(t, rowRunOld)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = renderCompare(&strings.Builder{}, recs, "run", "previous", "latest")
+	if !errors.Is(err, errNotEnoughRuns) {
+		t.Fatalf("want errNotEnoughRuns, got %v", err)
+	}
+}
+
+func TestRenderCompare_MissingCellIsDash(t *testing.T) {
+	// candidate run lacks the cell present in baseline.
+	candOther := strings.Replace(rowRunNew, `"S"`, `"OtherScenario"`, 1)
+	recs, _, err := load([]string{writeTemp(t, rowRunOld, candOther)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var b strings.Builder
+	if _, err := renderCompare(&b, recs, "run", "previous", "latest"); err != nil {
+		t.Fatal(err)
+	}
+	// Each cell appears on exactly one side, so every delta is a dash.
+	if !strings.Contains(b.String(), "-\t") && !strings.Contains(b.String(), " - ") {
+		t.Errorf("expected dashes for one-sided cells:\n%s", b.String())
+	}
+}
+
+func TestRenderTable_RunColumnWhenMultipleRuns(t *testing.T) {
+	recs, _, err := load([]string{writeTemp(t, rowRunOld, rowRunNew)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var b strings.Builder
+	if err := renderTable(&b, recs); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(b.String(), "run") || !strings.Contains(b.String(), "aaaa") {
+		t.Errorf("expected a run column listing both runs:\n%s", b.String())
+	}
+}
+
+func TestApplyFilters_RunKey(t *testing.T) {
+	recs, _, err := load([]string{writeTemp(t, rowRunOld, rowRunNew)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := applyFilters(recs, map[string]string{"run": "20260601T120000.000Z-bbbb"})
+	if len(got) != 1 || got[0].Run != "20260601T120000.000Z-bbbb" {
+		t.Errorf("run filter kept %d rows: %+v", len(got), got)
+	}
+}
+
+// Fixtures for compare-by-dimension: two runs, each carrying both auth
+// values at delay=nn, plus a legacy flat-axis row with no named axes.
+const (
+	rowR1SasNN   = `{"type":"row","schema":"perfmatrix/v1","run":"20260601T100000.000Z-aaaa","backend":"mock","axes":{"auth":"sas","delay":"nn"},"scenario":"S","mode":"PortForward","cold_p50_ns":250000000,"warm_p50_ns":22000000,"warm_p95_ns":23000000,"cold_n":5,"warm_n":25,"success_n":5,"attempt_n":5,"wall_ns":360000000}`
+	rowR1EntraNN = `{"type":"row","schema":"perfmatrix/v1","run":"20260601T100000.000Z-aaaa","backend":"mock","axes":{"auth":"entra","delay":"nn"},"scenario":"S","mode":"PortForward","cold_p50_ns":340000000,"warm_p50_ns":22000000,"warm_p95_ns":23000000,"cold_n":5,"warm_n":25,"success_n":5,"attempt_n":5,"wall_ns":450000000}`
+	rowR2SasNN   = `{"type":"row","schema":"perfmatrix/v1","run":"20260601T110000.000Z-bbbb","backend":"mock","axes":{"auth":"sas","delay":"nn"},"scenario":"S","mode":"PortForward","cold_p50_ns":255000000,"warm_p50_ns":22000000,"warm_p95_ns":23000000,"cold_n":5,"warm_n":25,"success_n":5,"attempt_n":5,"wall_ns":366000000}`
+	rowR2EntraNN = `{"type":"row","schema":"perfmatrix/v1","run":"20260601T110000.000Z-bbbb","backend":"mock","axes":{"auth":"entra","delay":"nn"},"scenario":"S","mode":"PortForward","cold_p50_ns":360000000,"warm_p50_ns":22000000,"warm_p95_ns":23000000,"cold_n":5,"warm_n":25,"success_n":5,"attempt_n":5,"wall_ns":470000000}`
+	rowLegacyNF  = `{"type":"row","schema":"perfmatrix/v1","run":"20260601T100000.000Z-aaaa","backend":"mock","axis":"nf","scenario":"S","mode":"PortForward","cold_p50_ns":300000000,"warm_p50_ns":22000000,"warm_p95_ns":23000000,"cold_n":5,"warm_n":25,"success_n":5,"attempt_n":5,"wall_ns":360000000}`
+	rowLegacyFN  = `{"type":"row","schema":"perfmatrix/v1","run":"20260601T100000.000Z-aaaa","backend":"mock","axis":"fn","scenario":"S","mode":"PortForward","cold_p50_ns":330000000,"warm_p50_ns":22000000,"warm_p95_ns":23000000,"cold_n":5,"warm_n":25,"success_n":5,"attempt_n":5,"wall_ns":360000000}`
+)
+
+func TestRenderCompare_ByAxis_DeltaAndColumns(t *testing.T) {
+	recs, _, err := load([]string{writeTemp(t, rowR1SasNN, rowR1EntraNN)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var b strings.Builder
+	if _, err := renderCompare(&b, recs, "auth", "sas", "entra"); err != nil {
+		t.Fatal(err)
+	}
+	out := b.String()
+	// cold: (340-250)/250 = +36.0%.
+	if !strings.Contains(out, "+36.0%") {
+		t.Errorf("missing cold delta +36.0%%:\n%s", out)
+	}
+	if !strings.Contains(out, "auth: baseline=sas  candidate=entra") {
+		t.Errorf("header should name the compared dimension:\n%s", out)
+	}
+	hdr := headerLine(out)
+	// The compared axis is dropped; the other axis remains a column.
+	if !strings.Contains(hdr, "delay") {
+		t.Errorf("expected residual 'delay' column:\n%s", hdr)
+	}
+	if strings.Contains(hdr, "auth") {
+		t.Errorf("compared axis 'auth' must not be an identity column:\n%s", hdr)
+	}
+}
+
+func TestRenderCompare_ByAxis_MultiRunShowsRunColumn(t *testing.T) {
+	recs, _, err := load([]string{writeTemp(t, rowR1SasNN, rowR1EntraNN, rowR2SasNN, rowR2EntraNN)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var b strings.Builder
+	if _, err := renderCompare(&b, recs, "auth", "sas", "entra"); err != nil {
+		t.Fatal(err)
+	}
+	out := b.String()
+	hdr := headerLine(out)
+	if !strings.Contains(hdr, "run") {
+		t.Errorf("multi-run axis compare should add a run column:\n%s", hdr)
+	}
+	// One comparison row per run; both run ids present.
+	for _, want := range []string{"aaaa", "bbbb"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("expected run %q in output:\n%s", want, out)
+		}
+	}
+}
+
+func TestRenderCompare_ByLegacyAxis(t *testing.T) {
+	recs, _, err := load([]string{writeTemp(t, rowLegacyNF, rowLegacyFN)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var b strings.Builder
+	if _, err := renderCompare(&b, recs, "axis", "nf", "fn"); err != nil {
+		t.Fatal(err)
+	}
+	out := b.String()
+	// cold: (330-300)/300 = +10.0%.
+	if !strings.Contains(out, "+10.0%") {
+		t.Errorf("missing cold delta +10.0%%:\n%s", out)
+	}
+	if !strings.Contains(out, "axis: baseline=nf  candidate=fn") {
+		t.Errorf("header should name the legacy axis dimension:\n%s", out)
+	}
+}
+
+func TestRenderCompare_NoOverlapNonRunErrors(t *testing.T) {
+	// mock and azure live in separate runs, so a backend compare has no
+	// residual that exists on both sides.
+	recs, _, err := load([]string{writeTemp(t, rowR1SasNN, rowAzureRun)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var b strings.Builder
+	_, err = renderCompare(&b, recs, "backend", "mock", "azure")
+	if err == nil || !strings.Contains(err.Error(), "no cells matched on both sides") {
+		t.Errorf("expected no-overlap error, got %v", err)
+	}
+}
+
+func TestRenderCompare_UnknownValueListsAvailable(t *testing.T) {
+	recs, _, err := load([]string{writeTemp(t, rowR1SasNN, rowR1EntraNN)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var b strings.Builder
+	_, err = renderCompare(&b, recs, "auth", "sas", "ntlm")
+	if err == nil || !strings.Contains(err.Error(), "available: entra, sas") {
+		t.Errorf("expected available-values error, got %v", err)
+	}
+}
+
+func TestRenderCompare_ExcludesRowsLackingDim(t *testing.T) {
+	// A named-axis row carries no flat axis, so an --compare-by axis run
+	// should skip it and warn rather than match it as empty.
+	recs, _, err := load([]string{writeTemp(t, rowLegacyNF, rowLegacyFN, rowR1SasNN)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var b strings.Builder
+	if _, err := renderCompare(&b, recs, "axis", "nf", "fn"); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(b.String(), `lack dimension "axis"`) {
+		t.Errorf("expected an excluded-rows warning:\n%s", b.String())
+	}
+}
+
+func TestResolveDimValue(t *testing.T) {
+	recs, _, err := load([]string{writeTemp(t, rowR1SasNN, rowR1EntraNN)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if v, err := resolveDimValue("auth", "entra", recs); err != nil || v != "entra" {
+		t.Errorf("exact match: got (%q,%v)", v, err)
+	}
+	if _, err := resolveDimValue("auth", "nope", recs); err == nil {
+		t.Error("expected error for missing value")
+	}
+	if _, err := resolveDimValue("frob", "x", recs); err == nil {
+		t.Error("expected error for dimension no row carries")
+	}
+}
+
+// headerLine returns the first line beginning with "backend" (the table
+// header) from a rendered comparison.
+func headerLine(out string) string {
+	for _, line := range strings.Split(out, "\n") {
+		if strings.HasPrefix(line, "backend") {
+			return line
+		}
+	}
+	return ""
+}
+
+const rowAzureRun = `{"type":"row","schema":"perfmatrix/v1","run":"20260601T120000.000Z-cccc","backend":"azure","axes":{"auth":"sas","delay":"nn"},"scenario":"S","mode":"PortForward","cold_p50_ns":1450000000,"warm_p50_ns":210000000,"warm_p95_ns":215000000,"cold_n":5,"warm_n":25,"success_n":5,"attempt_n":5,"wall_ns":2500000000}`

--- a/e2e/scenarios/matrix.go
+++ b/e2e/scenarios/matrix.go
@@ -1,0 +1,471 @@
+package scenarios
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+	"text/tabwriter"
+	"time"
+)
+
+// perfMatrixRow is one rendered line in the human-readable performance
+// matrix: a single scenario's representative client-side timings,
+// distilled from the same data that produces its `workload-summary`
+// log line. The matrix exists so a human can scan placement / shape /
+// mode trade-offs at a glance instead of parsing key=val log soup.
+type perfMatrixRow struct {
+	axis     string            // axis-cell path, e.g. "sas" or "entra/far" (flat; for the human table)
+	axes     map[string]string // named axis dimensions, e.g. {"auth":"entra","delay":"far"}
+	scenario string            // leaf scenario label, e.g. "Parallel_ConnReusedEcho"
+	mode     string            // PortForward | SOCKS5 | Connect | -
+	coldP50  time.Duration
+	warmP50  time.Duration
+	warmP95  time.Duration
+	coldN    int
+	warmN    int
+	successN int
+	attemptN int
+	wall     time.Duration
+}
+
+// perfMatrix collects rows across all scenarios in a run and renders
+// them once at the end. Guarded by a mutex because scenarios (and the
+// conns within them) can record concurrently.
+type perfMatrix struct {
+	mu        sync.Mutex
+	rows      []perfMatrixRow
+	axisNames []string // ordered axis names for this run (from Backend.Axes()), used to label path segments
+}
+
+var perfMatrixSink perfMatrix
+
+func (m *perfMatrix) add(row perfMatrixRow) {
+	m.mu.Lock()
+	m.rows = append(m.rows, row)
+	m.mu.Unlock()
+}
+
+// setAxisNames records the ordered axis names the run is fanning over so
+// recorded rows can label their path segments (segment i is axisNames[i]).
+// Called once before any cell runs; rows read it concurrently afterward.
+func (m *perfMatrix) setAxisNames(names []string) {
+	m.mu.Lock()
+	m.axisNames = append([]string(nil), names...)
+	m.mu.Unlock()
+}
+
+func (m *perfMatrix) snapshotAxisNames() []string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return append([]string(nil), m.axisNames...)
+}
+
+// drain returns the recorded rows in a stable sort order and clears the
+// sink so a subsequent run in the same process starts fresh. The single
+// snapshot under the mutex is shared by every consumer (table render and
+// JSONL emission) so they never disagree about what ran.
+func (m *perfMatrix) drain() []perfMatrixRow {
+	m.mu.Lock()
+	rows := m.rows
+	m.rows = nil
+	m.mu.Unlock()
+
+	sort.SliceStable(rows, func(i, j int) bool {
+		if rows[i].axis != rows[j].axis {
+			return rows[i].axis < rows[j].axis
+		}
+		if rows[i].scenario != rows[j].scenario {
+			return rows[i].scenario < rows[j].scenario
+		}
+		return rows[i].mode < rows[j].mode
+	})
+	return rows
+}
+
+// renderTable formats rows as the aligned human-readable matrix. Returns
+// "" if there are no rows.
+func renderTable(rows []perfMatrixRow) string {
+	if len(rows) == 0 {
+		return ""
+	}
+	var b strings.Builder
+	b.WriteString("\nPERF MATRIX (client-side RTT; est = cold_p50 − warm_p50 ≈ establishment cost)\n")
+	tw := tabwriter.NewWriter(&b, 0, 0, 2, ' ', 0)
+	_, _ = fmt.Fprintln(tw, "axis\tscenario\tmode\tcold_p50\twarm_p50\twarm_p95\test\tcold_n\twarm_n\tsuccess\twall")
+	for _, r := range rows {
+		_, _ = fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%d\t%d\t%d/%d\t%s\n",
+			dash(r.axis), r.scenario, dash(r.mode),
+			durOrDash(r.coldP50, r.coldN),
+			durOrDash(r.warmP50, r.warmN),
+			durOrDash(r.warmP95, r.warmN),
+			estCol(r),
+			r.coldN, r.warmN, r.successN, r.attemptN, round1(r.wall),
+		)
+	}
+	_ = tw.Flush()
+	b.WriteString("END PERF MATRIX\n")
+	return b.String()
+}
+
+func estCol(r perfMatrixRow) string {
+	if r.coldN == 0 || r.warmN == 0 {
+		return "-"
+	}
+	return round1(r.coldP50 - r.warmP50).String()
+}
+
+func durOrDash(d time.Duration, n int) string {
+	if n == 0 {
+		return "-"
+	}
+	return round1(d).String()
+}
+
+func dash(s string) string {
+	if s == "" {
+		return "-"
+	}
+	return s
+}
+
+// round1 trims sub-millisecond noise so the table reads cleanly.
+func round1(d time.Duration) time.Duration {
+	if d >= time.Millisecond {
+		return d.Round(100 * time.Microsecond)
+	}
+	return d.Round(time.Microsecond)
+}
+
+// recordPerfMatrixRow distils a finished round into one matrix row.
+// scenarioPath is t.Name(); coldRTT/warmAll are the same samples the
+// workload-summary line aggregates; successN/attemptN are the connection
+// success counts (rendered "n/m").
+func recordPerfMatrixRow(scenarioPath string, coldRTT, warmAll []time.Duration, successN, attemptN int, wall time.Duration) {
+	names := perfMatrixSink.snapshotAxisNames()
+	axisVals, leaf := splitScenarioPath(scenarioPath, len(names))
+	scenario, mode := splitMode(leaf)
+	axis := strings.Join(axisVals, "/")
+	var axes map[string]string
+	if len(axisVals) > 0 {
+		axes = make(map[string]string, len(axisVals))
+		for i, v := range axisVals {
+			key := fmt.Sprintf("axis%d", i)
+			if i < len(names) && names[i] != "" {
+				key = names[i]
+			}
+			axes[key] = v
+		}
+	}
+	perfMatrixSink.add(perfMatrixRow{
+		axis:     axis,
+		axes:     axes,
+		scenario: scenario,
+		mode:     mode,
+		coldP50:  repr(coldRTT, 0.50),
+		warmP50:  repr(warmAll, 0.50),
+		warmP95:  repr(warmAll, 0.95),
+		coldN:    len(coldRTT),
+		warmN:    len(warmAll),
+		successN: successN,
+		attemptN: attemptN,
+		wall:     wall,
+	})
+}
+
+// perfMatrixSchema is the artifact schema tag carried by every emitted
+// record. Bump it on any breaking field change so consumers can branch.
+const perfMatrixSchema = "perfmatrix/v1"
+
+// perfMatrixRecord is the JSON Lines shape of one matrix row — the
+// decoupling boundary between test execution (which emits) and reporting
+// (which renders). It carries only raw measurements; derived columns
+// such as est are recomputed by the reporter, never stored. Duration
+// fields are integer nanoseconds and are pointers so an unmeasured
+// metric (cold_n==0 or warm_n==0) serializes as null rather than a
+// misleading zero. Keep this in sync with the reader-side struct in
+// cmd/perfreport, which owns its own copy on purpose: the artifact, not
+// a shared Go type, is the contract.
+type perfMatrixRecord struct {
+	Type      string            `json:"type"` // always "row"; a "run" meta record (see perfMatrixRunRecord) precedes the rows
+	Schema    string            `json:"schema"`
+	Run       string            `json:"run,omitempty"`     // run id: groups all rows emitted by one test invocation (see newRunID)
+	Backend   string            `json:"backend,omitempty"` // mock | azure — set via PERF_MATRIX_BACKEND so a merged file is per-backend distinguishable
+	Axis      string            `json:"axis"`
+	Axes      map[string]string `json:"axes,omitempty"` // named axis dimensions, e.g. {"auth":"sas","delay":"nn"}
+	Scenario  string            `json:"scenario"`
+	Mode      string            `json:"mode,omitempty"`
+	ColdP50Ns *int64            `json:"cold_p50_ns"`
+	WarmP50Ns *int64            `json:"warm_p50_ns"`
+	WarmP95Ns *int64            `json:"warm_p95_ns"`
+	ColdN     int               `json:"cold_n"`
+	WarmN     int               `json:"warm_n"`
+	SuccessN  int               `json:"success_n"`
+	AttemptN  int               `json:"attempt_n"`
+	WallNs    int64             `json:"wall_ns"`
+}
+
+// perfMatrixRunRecord is the leading "run" meta record that makes an
+// archived artifact self-describing: when a CI-stored file is read in
+// isolation, these fields answer "which build, which backend config,
+// when?" without the surrounding test log. Consumers that only care
+// about measurements skip every record whose type != "row". git_sha is
+// supplied by the orchestrator via PERF_MATRIX_GIT_SHA (the test process
+// does not shell out to git); auth/delay come from the same env the
+// harness already reads.
+type perfMatrixRunRecord struct {
+	Type        string `json:"type"` // always "run"
+	Schema      string `json:"schema"`
+	Run         string `json:"run"` // run id stamped on the header and every row of this invocation
+	Backend     string `json:"backend,omitempty"`
+	GeneratedAt string `json:"generated_at"`
+	GitSHA      string `json:"git_sha,omitempty"`
+	E2EAuth     string `json:"e2e_auth,omitempty"`
+	E2EDelay    string `json:"e2e_delay,omitempty"`
+}
+
+// perfMatrixBackend names the backend that produced these rows (mock or
+// azure), taken from PERF_MATRIX_BACKEND. The harness itself is
+// backend-agnostic — the entrypoint's Makefile target sets this — so a
+// merged artifact can distinguish, and the reporter can group by, rows
+// from different backends.
+func perfMatrixBackend() string { return os.Getenv("PERF_MATRIX_BACKEND") }
+
+func newRunRecord(runID string) perfMatrixRunRecord {
+	return perfMatrixRunRecord{
+		Type:        "run",
+		Schema:      perfMatrixSchema,
+		Run:         runID,
+		Backend:     perfMatrixBackend(),
+		GeneratedAt: time.Now().UTC().Format(time.RFC3339),
+		GitSHA:      os.Getenv("PERF_MATRIX_GIT_SHA"),
+		E2EAuth:     os.Getenv("E2E_AUTH"),
+		E2EDelay:    os.Getenv("E2E_DELAY"),
+	}
+}
+
+// newRunID returns a collision-resistant, lexically-sortable run id:
+// PERF_MATRIX_RUN_ID overrides (so a sharded run can share one id and
+// merge its rows), else a UTC millisecond timestamp plus an 8-hex random
+// suffix. The fixed-width timestamp prefix makes plain string compare a
+// valid newest-first ordering; the random suffix prevents same-ms
+// collisions across processes. Falls back to the bare timestamp if the
+// system RNG is unavailable.
+func newRunID() string {
+	if v := os.Getenv("PERF_MATRIX_RUN_ID"); v != "" {
+		return v
+	}
+	ts := time.Now().UTC().Format("20060102T150405.000Z")
+	var b [4]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return ts
+	}
+	return ts + "-" + hex.EncodeToString(b[:])
+}
+
+// historyDir is where always-on per-run history files accumulate:
+// PERF_MATRIX_HISTORY_DIR overrides, else <go.work root>/e2e/perf-artifacts/history
+// (so every module's tests land in one shared place), else a cwd-relative
+// fallback when the workspace root can't be located.
+func historyDir() string {
+	if v := os.Getenv("PERF_MATRIX_HISTORY_DIR"); v != "" {
+		return v
+	}
+	if root := workspaceRoot(); root != "" {
+		return filepath.Join(root, "e2e", "perf-artifacts", "history")
+	}
+	return filepath.Join("perf-artifacts", "history")
+}
+
+// workspaceRoot walks up from the cwd to the directory containing go.work,
+// returning "" if none is found.
+func workspaceRoot() string {
+	dir, err := os.Getwd()
+	if err != nil {
+		return ""
+	}
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.work")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return ""
+		}
+		dir = parent
+	}
+}
+
+// historyPath names a run's history file <backend-or-"e2e">-<runID>.jsonl
+// under historyDir, so a directory listing is grouped by backend and
+// ordered by run id.
+func historyPath(runID string) string {
+	backend := perfMatrixBackend()
+	if backend == "" {
+		backend = "e2e"
+	}
+	return filepath.Join(historyDir(), backend+"-"+runID+".jsonl")
+}
+
+// nsIf returns a pointer to d's nanoseconds when n>0, else nil — so an
+// unmeasured metric serializes as JSON null instead of a bogus zero.
+func nsIf(d time.Duration, n int) *int64 {
+	if n == 0 {
+		return nil
+	}
+	v := d.Nanoseconds()
+	return &v
+}
+
+func (r perfMatrixRow) record() perfMatrixRecord {
+	return perfMatrixRecord{
+		Type:      "row",
+		Schema:    perfMatrixSchema,
+		Backend:   perfMatrixBackend(),
+		Axis:      r.axis,
+		Axes:      r.axes,
+		Scenario:  r.scenario,
+		Mode:      r.mode,
+		ColdP50Ns: nsIf(r.coldP50, r.coldN),
+		WarmP50Ns: nsIf(r.warmP50, r.warmN),
+		WarmP95Ns: nsIf(r.warmP95, r.warmN),
+		ColdN:     r.coldN,
+		WarmN:     r.warmN,
+		SuccessN:  r.successN,
+		AttemptN:  r.attemptN,
+		WallNs:    r.wall.Nanoseconds(),
+	}
+}
+
+// writeJSONL appends a leading "run" meta record followed by one JSON
+// object per row to path, stamping runID on the header and every row. It
+// MkdirAll's the parent dir, then opens O_APPEND so a single run sharded
+// across processes (disjoint cells, shared PERF_MATRIX_RUN_ID) merges by
+// concatenation. Distinct runs carry distinct run ids, so the reporter
+// keeps them apart (and still rejects a doubled single run, which collides
+// on run id + cell). Each record is marshaled then written with its
+// trailing newline in a single Write so a record is never split across a
+// partial append.
+func writeJSONL(path, runID string, rows []perfMatrixRow) error {
+	if dir := filepath.Dir(path); dir != "" {
+		if err := os.MkdirAll(dir, 0o750); err != nil { //nolint:gosec // path is an operator-controlled perf-artifact location (PERF_MATRIX_HISTORY_DIR/PERF_MATRIX_JSONL), not external input
+			return err
+		}
+	}
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600) //nolint:gosec // path is an operator-controlled perf-artifact location (PERF_MATRIX_HISTORY_DIR/PERF_MATRIX_JSONL), not external input
+	if err != nil {
+		return err
+	}
+	writeRecord := func(v any) error {
+		line, err := json.Marshal(v)
+		if err != nil {
+			return err
+		}
+		return writeFull(f, append(line, '\n'))
+	}
+	if err := writeRecord(newRunRecord(runID)); err != nil {
+		_ = f.Close()
+		return err
+	}
+	for _, r := range rows {
+		rec := r.record()
+		rec.Run = runID
+		if err := writeRecord(rec); err != nil {
+			_ = f.Close()
+			return err
+		}
+	}
+	return f.Close()
+}
+
+// finishPerfMatrix drains the sink once and, from that single snapshot,
+// logs the human table and emits the JSONL artifact(s). Emission is
+// always-on: every run appends a timestamped per-run file to the history
+// dir (best-effort — a failure is logged, never fatal, so a functional
+// `make test` is never broken by an unwritable artifact dir). When
+// PERF_MATRIX_JSONL is additionally set, that explicit path is also
+// written and a failure there IS fatal, since the caller asked for it by
+// name.
+func finishPerfMatrix(t logf) {
+	rows := perfMatrixSink.drain()
+	if table := renderTable(rows); table != "" {
+		t.Logf("%s", table)
+	}
+	if len(rows) == 0 {
+		return
+	}
+	runID := newRunID()
+	if path := os.Getenv("PERF_MATRIX_JSONL"); path != "" {
+		if err := writeJSONL(path, runID, rows); err != nil {
+			t.Errorf("perf matrix: writing JSONL artifact to %q: %v", path, err)
+		}
+	}
+	hpath := historyPath(runID)
+	if err := writeJSONL(hpath, runID, rows); err != nil {
+		t.Logf("perf matrix: best-effort history write to %q failed: %v", hpath, err)
+	}
+}
+
+// logf is the slice of *testing.T finishPerfMatrix needs, kept narrow so
+// the function is unit-testable without a real T.
+type logf interface {
+	Logf(format string, args ...any)
+	Errorf(format string, args ...any)
+}
+
+// repr reduces a sample to its representative latency at percentile p
+// (0.50 → median, 0.95 → p95). A percentile is well-defined for any
+// non-empty sample, so even a small run reports a true percentile that
+// matches the *_p50 / *_p95 column (and the regression gate) names
+// rather than silently switching to the mean; the *_n columns convey
+// how many samples back it. Zero for an empty sample.
+func repr(ds []time.Duration, p float64) time.Duration {
+	if len(ds) == 0 {
+		return 0
+	}
+	sorted := make([]time.Duration, len(ds))
+	copy(sorted, ds)
+	sort.Slice(sorted, func(i, j int) bool { return sorted[i] < sorted[j] })
+	return pct(sorted, p)
+}
+
+// splitScenarioPath separates the axis-cell values from the leaf scenario
+// in a sub-test path. The first segment is always the entry-point test
+// (e.g. "TestE2E_Mock") and is dropped. The next nAxes segments are the
+// axis values (in Backend.Axes() order); everything after that joins into
+// the leaf, so a scenario that nests its own t.Run sub-paths can't be
+// mistaken for an axis. nAxes comes authoritatively from Backend.Axes(), so
+// nAxes==0 means a fully-pinned backend with no axes: zero middle segments
+// are axis values and the whole remainder is the leaf.
+func splitScenarioPath(name string, nAxes int) (axisVals []string, leaf string) {
+	segs := strings.Split(name, "/")
+	if len(segs) <= 1 {
+		return nil, name
+	}
+	segs = segs[1:] // drop the entry-point test name
+	if nAxes < 0 {
+		nAxes = 0
+	}
+	if nAxes > len(segs)-1 {
+		nAxes = len(segs) - 1
+	}
+	return segs[:nAxes], strings.Join(segs[nAxes:], "/")
+}
+
+// splitMode peels a _PortForward / _SOCKS5 / _Connect token out of a
+// scenario leaf so the mode becomes its own column, tolerating the
+// token appearing mid-name (e.g. "..._SOCKS5_MultiTarget").
+func splitMode(leaf string) (scenario, mode string) {
+	for _, m := range []string{"PortForward", "SOCKS5", "Connect"} {
+		tok := "_" + m
+		if i := strings.Index(leaf, tok); i >= 0 {
+			return leaf[:i] + leaf[i+len(tok):], m
+		}
+	}
+	return leaf, ""
+}

--- a/e2e/scenarios/matrix_named_axes_test.go
+++ b/e2e/scenarios/matrix_named_axes_test.go
@@ -1,0 +1,93 @@
+package scenarios
+
+import (
+	"reflect"
+	"testing"
+	"time"
+)
+
+func TestSplitScenarioPath_NamedAxisCount(t *testing.T) {
+	cases := []struct {
+		name     string
+		path     string
+		nAxes    int
+		wantVals []string
+		wantLeaf string
+	}{
+		{
+			name:     "two axes",
+			path:     "TestE2E_Mock/sas/nn/Parallel_ConnReusedEcho_PortForward",
+			nAxes:    2,
+			wantVals: []string{"sas", "nn"},
+			wantLeaf: "Parallel_ConnReusedEcho_PortForward",
+		},
+		{
+			name:     "one axis (pinned auth) collapses",
+			path:     "TestE2E_Mock/nn/Parallel_ConnReusedEcho_PortForward",
+			nAxes:    1,
+			wantVals: []string{"nn"},
+			wantLeaf: "Parallel_ConnReusedEcho_PortForward",
+		},
+		{
+			name:     "no axes (fully pinned)",
+			path:     "TestE2E_Mock/Parallel_ConnReusedEcho_PortForward",
+			nAxes:    0,
+			wantVals: []string{},
+			wantLeaf: "Parallel_ConnReusedEcho_PortForward",
+		},
+		{
+			// A scenario that nests its own sub-test must not have that
+			// sub-path mistaken for an axis: only nAxes segments are axes.
+			name:     "inner subtest stays in the leaf",
+			path:     "TestE2E_Mock/sas/nn/Parallel_ConnReusedEcho/inner",
+			nAxes:    2,
+			wantVals: []string{"sas", "nn"},
+			wantLeaf: "Parallel_ConnReusedEcho/inner",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			vals, leaf := splitScenarioPath(tc.path, tc.nAxes)
+			if !reflect.DeepEqual(vals, tc.wantVals) {
+				t.Errorf("axisVals = %#v, want %#v", vals, tc.wantVals)
+			}
+			if leaf != tc.wantLeaf {
+				t.Errorf("leaf = %q, want %q", leaf, tc.wantLeaf)
+			}
+		})
+	}
+}
+
+func TestRecordPerfMatrixRow_NamedAxes(t *testing.T) {
+	perfMatrixSink.drain() // clear any prior rows
+	perfMatrixSink.setAxisNames([]string{"auth", "delay"})
+	t.Cleanup(func() {
+		perfMatrixSink.drain()
+		perfMatrixSink.setAxisNames(nil)
+	})
+
+	recordPerfMatrixRow(
+		"TestE2E_Mock/entra/ff/Parallel_ConnReusedEcho_SOCKS5",
+		[]time.Duration{time.Second}, []time.Duration{time.Millisecond},
+		3, 3, 2*time.Second,
+	)
+	rows := perfMatrixSink.drain()
+	if len(rows) != 1 {
+		t.Fatalf("got %d rows, want 1", len(rows))
+	}
+	r := rows[0]
+	wantAxes := map[string]string{"auth": "entra", "delay": "ff"}
+	if !reflect.DeepEqual(r.axes, wantAxes) {
+		t.Errorf("axes = %#v, want %#v", r.axes, wantAxes)
+	}
+	if r.axis != "entra/ff" {
+		t.Errorf("flat axis = %q, want entra/ff", r.axis)
+	}
+	if r.scenario != "Parallel_ConnReusedEcho" || r.mode != "SOCKS5" {
+		t.Errorf("scenario/mode = %q/%q, want Parallel_ConnReusedEcho/SOCKS5", r.scenario, r.mode)
+	}
+	rec := r.record()
+	if rec.Axes["auth"] != "entra" || rec.Axes["delay"] != "ff" {
+		t.Errorf("record Axes = %#v, want auth=entra delay=ff", rec.Axes)
+	}
+}

--- a/e2e/scenarios/matrix_run_test.go
+++ b/e2e/scenarios/matrix_run_test.go
@@ -1,0 +1,147 @@
+package scenarios
+
+import (
+	"bufio"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestNewRunID(t *testing.T) {
+	t.Setenv("PERF_MATRIX_RUN_ID", "pinned-run-7")
+	if got := newRunID(); got != "pinned-run-7" {
+		t.Fatalf("override: got %q, want pinned-run-7", got)
+	}
+
+	t.Setenv("PERF_MATRIX_RUN_ID", "")
+	a, b := newRunID(), newRunID()
+	if a == b {
+		t.Fatalf("two generated ids collided: %q", a)
+	}
+	for _, id := range []string{a, b} {
+		ts, suffix, ok := strings.Cut(id, "-")
+		if !ok || len(suffix) != 8 {
+			t.Fatalf("id %q is not <ts>-<8hex>", id)
+		}
+		if !strings.HasSuffix(ts, "Z") || !strings.Contains(ts, "T") {
+			t.Fatalf("id %q lacks a sortable UTC timestamp prefix", id)
+		}
+	}
+}
+
+func TestWriteJSONL_StampsRunOnHeaderAndRows(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "nested", "out.jsonl") // also exercises MkdirAll
+	rows := []perfMatrixRow{
+		{axis: "nn", scenario: "S", mode: "PortForward", coldP50: 1, coldN: 1, successN: 1, attemptN: 1},
+	}
+	if err := writeJSONL(path, "run-XYZ", rows); err != nil {
+		t.Fatalf("writeJSONL: %v", err)
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer f.Close()
+
+	var header struct {
+		Type string `json:"type"`
+		Run  string `json:"run"`
+	}
+	var rowRun string
+	sc := bufio.NewScanner(f)
+	for i := 0; sc.Scan(); i++ {
+		line := strings.TrimSpace(sc.Text())
+		if line == "" {
+			continue
+		}
+		if i == 0 {
+			if err := json.Unmarshal([]byte(line), &header); err != nil {
+				t.Fatalf("header unmarshal: %v", err)
+			}
+			continue
+		}
+		var row struct {
+			Type string `json:"type"`
+			Run  string `json:"run"`
+		}
+		if err := json.Unmarshal([]byte(line), &row); err != nil {
+			t.Fatalf("row unmarshal: %v", err)
+		}
+		rowRun = row.Run
+	}
+	if header.Type != "run" || header.Run != "run-XYZ" {
+		t.Errorf("header = %+v, want type=run run=run-XYZ", header)
+	}
+	if rowRun != "run-XYZ" {
+		t.Errorf("row run = %q, want run-XYZ", rowRun)
+	}
+}
+
+func TestHistoryDir_HonorsOverride(t *testing.T) {
+	t.Setenv("PERF_MATRIX_HISTORY_DIR", "/tmp/custom-hist")
+	if got := historyDir(); got != "/tmp/custom-hist" {
+		t.Fatalf("got %q, want /tmp/custom-hist", got)
+	}
+}
+
+func TestHistoryPath_BackendAndRunInName(t *testing.T) {
+	t.Setenv("PERF_MATRIX_HISTORY_DIR", "/tmp/h")
+	t.Setenv("PERF_MATRIX_BACKEND", "mock")
+	if got, want := historyPath("run-9"), filepath.Join("/tmp/h", "mock-run-9.jsonl"); got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+	t.Setenv("PERF_MATRIX_BACKEND", "")
+	if got, want := historyPath("run-9"), filepath.Join("/tmp/h", "e2e-run-9.jsonl"); got != want {
+		t.Fatalf("unset backend: got %q, want %q", got, want)
+	}
+}
+
+// recLogf records how finishPerfMatrix reported, so we can pin the
+// best-effort-history vs fatal-explicit contract.
+type recLogf struct{ logfN, errorfN int }
+
+func (r *recLogf) Logf(string, ...any)   { r.logfN++ }
+func (r *recLogf) Errorf(string, ...any) { r.errorfN++ }
+
+// unwritablePath returns a path whose parent is a regular file, so any
+// MkdirAll/Open beneath it fails regardless of uid (root bypasses mode
+// bits, so 0o500 dirs are not reliable).
+func unwritablePath(t *testing.T) string {
+	t.Helper()
+	f := filepath.Join(t.TempDir(), "blocker")
+	if err := os.WriteFile(f, []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return filepath.Join(f, "sub", "out.jsonl")
+}
+
+func TestFinishPerfMatrix_HistoryWriteIsBestEffort(t *testing.T) {
+	perfMatrixSink.drain()
+	t.Cleanup(func() { perfMatrixSink.drain() })
+	t.Setenv("PERF_MATRIX_JSONL", "")
+	t.Setenv("PERF_MATRIX_HISTORY_DIR", filepath.Dir(unwritablePath(t))) // unwritable
+
+	perfMatrixSink.add(perfMatrixRow{scenario: "S", mode: "PortForward", coldP50: 1, coldN: 1, successN: 1, attemptN: 1})
+	var rec recLogf
+	finishPerfMatrix(&rec)
+	if rec.errorfN != 0 {
+		t.Fatalf("history write failure must not Errorf (would flake functional `make test`); got %d", rec.errorfN)
+	}
+}
+
+func TestFinishPerfMatrix_ExplicitWriteIsFatal(t *testing.T) {
+	perfMatrixSink.drain()
+	t.Cleanup(func() { perfMatrixSink.drain() })
+	t.Setenv("PERF_MATRIX_JSONL", unwritablePath(t)) // unwritable -> fatal
+	t.Setenv("PERF_MATRIX_HISTORY_DIR", t.TempDir()) // writable -> best-effort succeeds
+
+	perfMatrixSink.add(perfMatrixRow{scenario: "S", mode: "PortForward", coldP50: 1, coldN: 1, successN: 1, attemptN: 1})
+	var rec recLogf
+	finishPerfMatrix(&rec)
+	if rec.errorfN != 1 {
+		t.Fatalf("explicit PERF_MATRIX_JSONL write failure must Errorf exactly once, got %d", rec.errorfN)
+	}
+}

--- a/e2e/scenarios/performance.go
+++ b/e2e/scenarios/performance.go
@@ -507,10 +507,11 @@ func dialSender(senderAddr, target string, mode SenderMode, timeout time.Duratio
 // requests are discarded from the reported stats.
 //
 //	cold-path scenarios (ConnPerRequest, ConnReused):
-//	  WarmupRequests = 0 — first request times count as ttfw/ttc
+//	  WarmupRequests = 0 — the first request's round-trip is reported
+//	  as cold_rtt (includes connection establishment)
 //	steady-state scenarios (ConnPrewarmed):
 //	  WarmupRequests = 1 — first request is discarded; the rest are
-//	  reported as warm_min/mean/p50/p95/p99/max
+//	  reported as warm_rtt_min/mean/p50/p95/p99/max
 type WorkloadShape struct {
 	TotalConns      int
 	Concurrency     int
@@ -625,8 +626,13 @@ type connResult struct {
 }
 
 type firstReqTiming struct {
-	TTFW time.Duration // dial → first write complete (request transmitted to local sender; NOT the conventional "time to first byte received")
-	TTC  time.Duration // dial → first read complete (full request → response round-trip including dial)
+	// ColdRTT is the cold-path round-trip: open → first response
+	// received on a fresh connection. It spans the full
+	// request → target → response round-trip and, because the
+	// connection is new, includes connection establishment. With a
+	// tiny payload against an instant echo target, "first response"
+	// coincides with "round-trip complete", so this is an honest RTT.
+	ColdRTT time.Duration
 }
 
 func runRound(t *testing.T, tun *Tunnel, addrs []string, threshold time.Duration, w WorkloadShape) {
@@ -654,15 +660,15 @@ func runRound(t *testing.T, tun *Tunnel, addrs []string, threshold time.Duration
 			switch {
 			case w.WarmupRequests > 0 && len(r.Warm) > 0:
 				wmin, wmax, wmean := minMaxMean(r.Warm)
-				t.Logf("conn[%d] warm_n=%d warm_min=%v warm_mean=%v warm_max=%v",
+				t.Logf("conn[%d] warm_n=%d warm_rtt_min=%v warm_rtt_mean=%v warm_rtt_max=%v",
 					i, len(r.Warm), wmin, wmean, wmax)
 			case len(r.Warm) > 0:
 				wmin, wmax, wmean := minMaxMean(r.Warm)
-				t.Logf("conn[%d] first_req_ttfw=%v first_req_ttc=%v warm_n=%d warm_min=%v warm_mean=%v warm_max=%v",
-					i, r.FirstReq.TTFW, r.FirstReq.TTC, len(r.Warm), wmin, wmean, wmax)
+				t.Logf("conn[%d] cold_rtt=%v warm_n=%d warm_rtt_min=%v warm_rtt_mean=%v warm_rtt_max=%v",
+					i, r.FirstReq.ColdRTT, len(r.Warm), wmin, wmean, wmax)
 			default:
-				t.Logf("conn[%d] ttfw=%v ttc=%v",
-					i, r.FirstReq.TTFW, r.FirstReq.TTC)
+				t.Logf("conn[%d] cold_rtt=%v",
+					i, r.FirstReq.ColdRTT)
 			}
 		}(i)
 	}
@@ -670,15 +676,14 @@ func runRound(t *testing.T, tun *Tunnel, addrs []string, threshold time.Duration
 	wall := time.Since(start)
 
 	var failures int
-	var coldTTFW, coldTTC, warmAll []time.Duration
+	var coldRTT, warmAll []time.Duration
 	for _, r := range results {
 		if r.Err != nil {
 			failures++
 			continue
 		}
 		if w.WarmupRequests == 0 {
-			coldTTFW = append(coldTTFW, r.FirstReq.TTFW)
-			coldTTC = append(coldTTC, r.FirstReq.TTC)
+			coldRTT = append(coldRTT, r.FirstReq.ColdRTT)
 		}
 		warmAll = append(warmAll, r.Warm...)
 	}
@@ -695,24 +700,24 @@ func runRound(t *testing.T, tun *Tunnel, addrs []string, threshold time.Duration
 	// `TestE2E_Azure/entra/Parallel_ConnPrewarmedEcho_SOCKS5`).
 	parts = append(parts, "workload-summary", fmt.Sprintf("scenario=%s", t.Name()))
 
-	if len(coldTTFW) > 0 {
-		parts = append(parts,
-			fmtDist("ttfw", coldTTFW),
-			fmtDist("ttc", coldTTC),
-		)
+	if len(coldRTT) > 0 {
+		parts = append(parts, fmtDist("cold_rtt", coldRTT))
 	}
 	if len(warmAll) > 0 {
-		parts = append(parts, fmtDist("warm", warmAll))
+		parts = append(parts, fmtDist("warm_rtt", warmAll))
 	}
 	parts = append(parts,
 		fmt.Sprintf("wall=%v", wall),
 		fmt.Sprintf("budget=%v", budget),
-		fmt.Sprintf("cold_n=%d", len(coldTTFW)),
+		fmt.Sprintf("cold_n=%d", len(coldRTT)),
 		fmt.Sprintf("warm_n=%d", len(warmAll)),
 		fmt.Sprintf("num_targets=%d", len(addrs)),
 		fmt.Sprintf("success=%d/%d", w.TotalConns-failures, w.TotalConns),
 	)
 	t.Logf("%s", strings.Join(parts, " "))
+
+	recordPerfMatrixRow(t.Name(), coldRTT, warmAll,
+		w.TotalConns-failures, w.TotalConns, wall)
 
 	// Go's net deadlines are best-effort: an I/O op can return a few
 	// hundred milliseconds after its deadline under scheduler / OS
@@ -856,9 +861,6 @@ func runOneConn(senderAddr, target string, w WorkloadShape, roundDeadline time.T
 			res.Err = fmt.Errorf("write[%d]: %w", i, err)
 			return res
 		}
-		if i == 0 && w.WarmupRequests == 0 {
-			res.FirstReq.TTFW = time.Since(dialStart)
-		}
 		if _, err = io.ReadFull(conn, buf); err != nil {
 			res.Err = fmt.Errorf("read[%d]: %w", i, err)
 			return res
@@ -870,7 +872,7 @@ func runOneConn(senderAddr, target string, w WorkloadShape, roundDeadline time.T
 		elapsed := time.Since(reqStart)
 		switch {
 		case i == 0 && w.WarmupRequests == 0:
-			res.FirstReq.TTC = time.Since(dialStart)
+			res.FirstReq.ColdRTT = time.Since(dialStart)
 		case i >= w.WarmupRequests:
 			res.Warm = append(res.Warm, elapsed)
 		}

--- a/e2e/scenarios/scenarios.go
+++ b/e2e/scenarios/scenarios.go
@@ -31,7 +31,16 @@ import (
 // #01/#02/... suffixes.
 func RunAllScenarios(t *testing.T, b Backend) {
 	t.Helper()
-	forEachCell(t, b.Axes(), func(t *testing.T, cell map[string]string) {
+	axes := b.Axes()
+	names := make([]string, len(axes))
+	for i, a := range axes {
+		names[i] = a.Name()
+	}
+	perfMatrixSink.setAxisNames(names)
+	t.Cleanup(func() {
+		finishPerfMatrix(t)
+	})
+	forEachCell(t, axes, func(t *testing.T, cell map[string]string) {
 		cellBackend := b.Cell(cell)
 		RunCoreScenarios(t, cellBackend)
 		RunTopologyScenarios(t, cellBackend)

--- a/mockrelay/server/delay_profile.go
+++ b/mockrelay/server/delay_profile.go
@@ -129,6 +129,55 @@ var DelayProfileDefault = DelayProfile{
 	TokenAcquire:      450 * time.Millisecond,
 }
 
+// Relay-placement profiles model where the sender and listener sit
+// relative to the relay by varying only the per-lane one-way transit
+// (SLatency/LLatency). The placement-independent costs — fresh DNS
+// resolution, SAS validation, and matchmake — are held at the
+// DelayProfileDefault values so the cold-vs-warm spread the perf matrix
+// renders (est ≈ establishment cost) isolates distance alone.
+// TokenAcquire is zero because these profiles are exercised on the SAS
+// path (no AAD round trip); pin E2E_AUTH=sas when sweeping them.
+//
+// The placement axis is the full sender×listener grid: each client sits
+// at one of three distances from the relay — near (5 ms), mid (35 ms),
+// or far (90 ms) one-way lane transit — giving nine cells. Cells are
+// named <sender><listener> with single-letter distance codes (n/m/f),
+// sender first: e.g. "nf" = sender near, listener far; "fn" = sender
+// far, listener near. The three diagonal cells (nn/mm/ff) are symmetric;
+// the six off-diagonal cells are asymmetric. Because the listener lane
+// carries one extra rendezvous hop (the accept frame), a cell and its
+// transpose are NOT equal in establishment cost — e.g. "nf" predicts a
+// higher rendezvous than "fn" at identical total distance, a difference
+// the matrix surfaces directly. Steady-state echo depends only on the
+// total path (SLatency+LLatency), so transposed cells share a warm RTT.
+//
+// All nine keep PredictedBridgeEcho under the perf harness's flat 500 ms
+// warm-request model (ff is the largest at 2*(90+90)=360 ms), so no
+// roundBudget change is needed. They are deliberately excluded from the
+// functional matrix set (see FunctionalMatrixProfileNames): they are
+// resolvable by name for perf sweeps but do not expand the
+// E2E_DELAY=all functional run.
+const (
+	placementNear = 5 * time.Millisecond
+	placementMid  = 35 * time.Millisecond
+	placementFar  = 90 * time.Millisecond
+)
+
+// placementProfile builds a grid cell from a sender/listener lane
+// transit, holding the placement-independent costs (DNS, SAS validation,
+// matchmake) at the DelayProfileDefault values so the cold-vs-warm spread
+// the perf matrix renders isolates distance alone. TokenAcquire is zero:
+// these cells are swept on the SAS path (pin E2E_AUTH=sas).
+func placementProfile(sender, listener time.Duration) DelayProfile {
+	return DelayProfile{
+		SLatency:          sender,
+		LLatency:          listener,
+		DNSLookup:         DelayProfileDefault.DNSLookup,
+		AuthInternal:      DelayProfileDefault.AuthInternal,
+		MatchMakeInternal: DelayProfileDefault.MatchMakeInternal,
+	}
+}
+
 // registry is the single source of truth mapping canonical profile
 // names to DelayProfiles. Selection sites — the E2E_DELAY env toggle,
 // docs, and any future CLI or test-matrix axis — resolve through
@@ -137,10 +186,41 @@ var DelayProfileDefault = DelayProfile{
 // every consumer picks up automatically. Keep keys lowercase and
 // hyphen-free so they read cleanly as env-var values and sub-test
 // path segments.
+//
+// Membership here makes a profile *resolvable by name*; it does NOT by
+// itself enroll the profile in the E2E_DELAY=all functional matrix —
+// that set is curated separately (FunctionalMatrixProfileNames) so
+// placement profiles can be swept by perf targets without inflating the
+// full functional run.
 var registry = map[string]DelayProfile{
 	"zero":    DelayProfileZero,
 	"default": DelayProfileDefault,
+	"nn":      placementProfile(placementNear, placementNear),
+	"nm":      placementProfile(placementNear, placementMid),
+	"nf":      placementProfile(placementNear, placementFar),
+	"mn":      placementProfile(placementMid, placementNear),
+	"mm":      placementProfile(placementMid, placementMid),
+	"mf":      placementProfile(placementMid, placementFar),
+	"fn":      placementProfile(placementFar, placementNear),
+	"fm":      placementProfile(placementFar, placementMid),
+	"ff":      placementProfile(placementFar, placementFar),
 }
+
+// PlacementGridProfileNames returns the nine sender×listener placement
+// cell names in row-major order (sender outer, listener inner: nn, nm,
+// nf, mn, …, ff). Perf placement sweeps default to this set; it is a
+// superset relationship with neither the functional matrix nor the
+// timing-fidelity profiles.
+func PlacementGridProfileNames() []string {
+	return []string{"nn", "nm", "nf", "mn", "mm", "mf", "fn", "fm", "ff"}
+}
+
+// functionalMatrix is the curated set of profile names the full mock
+// e2e suite fans over when E2E_DELAY=all. It is intentionally narrow —
+// the zero (test-speed) and default (wire-faithful) timing-fidelity
+// profiles — so adding a resolvable placement profile to registry does
+// not silently multiply the functional run's cell count or runtime.
+var functionalMatrix = []string{"zero", "default"}
 
 // ProfileByName returns the named profile from the registry. The error
 // names the unknown profile and lists the known names (sorted) so a
@@ -155,14 +235,27 @@ func ProfileByName(name string) (DelayProfile, error) {
 	return p, nil
 }
 
-// ProfileNames returns the registered profile names in sorted order.
-// Drives stable error messages and lets docs or a test-matrix axis
-// enumerate the profiles from the single registry source of truth.
+// ProfileNames returns every resolvable profile name in sorted order.
+// Drives stable error messages and lets docs or a CLI enumerate the
+// profiles from the single registry source of truth. Note this is the
+// full resolvable set, not the functional matrix set — use
+// FunctionalMatrixProfileNames for the E2E_DELAY=all enumeration.
 func ProfileNames() []string {
 	names := make([]string, 0, len(registry))
 	for n := range registry {
 		names = append(names, n)
 	}
+	sort.Strings(names)
+	return names
+}
+
+// FunctionalMatrixProfileNames returns the curated set of profile names
+// the full mock e2e suite runs when E2E_DELAY=all, in sorted order. It
+// is the timing-fidelity pair (zero, default) only; placement profiles
+// are resolvable by ProfileByName but deliberately omitted so a perf
+// sweep does not expand the functional matrix.
+func FunctionalMatrixProfileNames() []string {
+	names := append([]string(nil), functionalMatrix...)
 	sort.Strings(names)
 	return names
 }

--- a/mockrelay/server/delay_profile_test.go
+++ b/mockrelay/server/delay_profile_test.go
@@ -466,6 +466,35 @@ func TestProfileRegistry_KnownNames(t *testing.T) {
 	}
 }
 
+// TestFunctionalMatrixProfileNames asserts the curated functional
+// matrix set stays narrow (the timing-fidelity pair zero/default) and
+// that placement profiles, while resolvable by ProfileByName, are
+// deliberately excluded from it — so a perf-only placement sweep does
+// not silently expand the E2E_DELAY=all functional run.
+func TestFunctionalMatrixProfileNames(t *testing.T) {
+	got := FunctionalMatrixProfileNames()
+	want := []string{"default", "zero"}
+	if !slices.Equal(got, want) {
+		t.Fatalf("FunctionalMatrixProfileNames() = %v, want %v", got, want)
+	}
+
+	all := ProfileNames()
+	for _, name := range got {
+		if !slices.Contains(all, name) {
+			t.Errorf("functional profile %q is not resolvable (missing from ProfileNames %v)", name, all)
+		}
+	}
+
+	for _, placement := range PlacementGridProfileNames() {
+		if _, err := ProfileByName(placement); err != nil {
+			t.Errorf("placement profile %q should be resolvable: %v", placement, err)
+		}
+		if slices.Contains(got, placement) {
+			t.Errorf("placement profile %q must NOT be in the functional matrix set %v", placement, got)
+		}
+	}
+}
+
 // TestProfileByName_UnknownIsLoud asserts an unregistered name yields
 // an error naming the bad input and listing the known profiles, so a
 // typo at a selection site fails loudly rather than silently picking


### PR DESCRIPTION
Reworks the e2e performance tooling into a single measurement lens over the existing e2e suite, with persistent history, arbitrary-dimension comparison, and a CI regression gate.

The perf scenarios run as subtests of the mock/azure suites and emit a human-readable **PERF MATRIX** using honest round-trip vocabulary. Execution is decoupled from reporting: every run appends rows to an always-on per-run history file under `e2e/perf-artifacts/history/`, and `perfreport` re-renders the merged store without re-running anything. A 3×3 relay sender/listener **placement axis** joins the existing delay registry, and the reporter pivots on any dimension — compare runs before/after a change, or `auth=sas..entra`, `delay=nn..ff`, `mock..azure` within a single run.

`perfreport --fail-over <pct> --fail-min-abs <dur>` turns that into a gate: it diffs the two newest runs and fails only when a `warm_p50` or `cold_p50` cell regressed by **both** more than the percent threshold **and** more than the absolute floor. The derived `est` metric is reported but never gated, improvements never trip, a single run is a skip, partial cell-set drift is a warning, and zero overlap is a hard error. `make perf-gate` wraps it.

Two workflows put it to work: **`perf-pr.yml`** runs the mock sweep opt-in (`perf` label or manual dispatch), read-only and non-gating, rendering the matrix into the job summary; **`perf-nightly.yml`** carries the previous nightly baseline forward as an artifact, gates tonight's mock run against it, and re-uploads the pruned history only on success so a regressing night never overwrites the known-good baseline. The four validation tiers are documented in `e2e/backends/mock/README.md`.

Mock-only gating is deliberate: the real Azure relay's rendezvous spikes (~3–6s) swamp any threshold, so Azure perf is measured but never gated. Scheduled workflows only fire from the default branch, so the nightly tier arms on merge, and neither workflow runs on ordinary PRs.