### PR TITLE
Diagnose and tolerate relay rendezvous spikes

### DIFF
--- a/docs/internals/sequences/port-forward.md
+++ b/docs/internals/sequences/port-forward.md
@@ -199,8 +199,16 @@ but are loopback in this topology, so each is ≈ 0 ms.
 | Lane `l` one-way (Phase 0, 3, 4, 5 101)    | `LLatency`                                     |
 | Per-handler DNS lookup (Phase 0, 2, 4)     | `DNSLookup`                                    |
 | SAS-token validation (Phase 0 and Phase 2) | `AuthInternal`                                 |
+| Entra-token validation (Phase 0, Phase 2)  | `EntraValidate`                                |
 | Accept-message dispatch (Phase 3)          | `MatchMakeInternal`                            |
 | Phase 6 bridge forwarding                  | `SLatency + LLatency` (pipelined, per message) |
+
+The relay charges exactly one token-validation cost per token-bearing
+leg, chosen by the inbound token's shape: `EntraValidate` for an Entra
+(JWT) bearer token, `AuthInternal` for a SAS token. `EntraValidate`
+models the per-request "warm tax" the real Azure Relay control plane
+pays validating an Entra token on every connect, distinct from the
+one-off client-side acquisition cost (`TokenAcquire`).
 
 Pass `mockrelay/server.DelayProfileDefault` via
 `server.WithDelayProfile(...)` to make the mock pay wire-faithful

--- a/docs/internals/sequences/socks5.md
+++ b/docs/internals/sequences/socks5.md
@@ -216,8 +216,13 @@ the rendezvous.
 | Lane `l` one-way (Phase 0, 3, 4, 5 101)    | `LLatency`                                     |
 | Per-handler DNS lookup (Phase 0, 2, 4)     | `DNSLookup`                                    |
 | SAS-token validation (Phase 0 and Phase 2) | `AuthInternal`                                 |
+| Entra-token validation (Phase 0, Phase 2)  | `EntraValidate`                                |
 | Accept-message dispatch (Phase 3)          | `MatchMakeInternal`                            |
 | Phase 6 and Phase 7 bridge forwarding      | `SLatency + LLatency` (pipelined, per message) |
+
+The relay charges one token-validation cost per token-bearing leg,
+selected by the inbound token's shape: `EntraValidate` for an Entra
+(JWT) bearer token, `AuthInternal` for a SAS token.
 
 Phase 6 (envelope / target dial / REP) and Phase 7 (payload) ride
 the established bridge, which is delay-modelled as a pipelined

--- a/e2e/backends/azure/backend_test.go
+++ b/e2e/backends/azure/backend_test.go
@@ -134,6 +134,39 @@ func (*azureBackend) ConnectLatencyThreshold() time.Duration {
 	return 3 * time.Second
 }
 
+// ConnectLatencyPolicy returns the tolerant quantile gate for the
+// steady-state ConnectLatency_Serial scenario against real Azure Relay.
+//
+// Steady-state rendezvous is ~0.4 s (SAS) / ~0.75 s (Entra), but an
+// isolated ~1-in-10-to-40 dial spikes to 3-7 s in the relay control
+// plane (proven from full sender+listener logs: zero client retries,
+// the listener idle in ws.Read for the whole stall). That tail is not
+// aztunnel's to fix, so the gate tolerates a sparse spike tail while
+// still catching a broad regression:
+//
+//   - NormalP50 = 1.5 s: comfortably above both auth cells' steady
+//     state, well below the seconds-scale regressions we expect; a
+//     broad shift lifts the median into it.
+//   - SoftTail = 3 s: the old per-sample ceiling, now applied to the
+//     soft-tail sample (top ~10% discarded) instead of every sample.
+//   - SpikeCeiling = 6 s: per-dial deadline budget (deadline =
+//     SpikeCeiling + connectSlack ≈ 11 s) so a tolerated 3-7 s spike is
+//     measured, not killed by an i/o timeout.
+//   - Iterations = 20: enough that the soft-tail statistic discards 2
+//     spikes (ceil(10%)) yet the run stays well inside the job budget.
+//
+// Returned regardless of authName: both auth cells share the same
+// control-plane rendezvous path; per-auth cold-start cost is gated
+// separately via ColdStartLatencyThreshold.
+func (*azureBackend) ConnectLatencyPolicy() scenarios.ConnectLatencyPolicy {
+	return scenarios.ConnectLatencyPolicy{
+		Iterations:   20,
+		NormalP50:    1500 * time.Millisecond,
+		SoftTail:     3 * time.Second,
+		SpikeCeiling: 6 * time.Second,
+	}
+}
+
 // ColdStartLatencyThreshold returns the per-backend ceiling for the
 // first connection through a freshly-started sender. The first
 // dial pays one-time costs the steady-state threshold excludes —

--- a/e2e/backends/mock/README.md
+++ b/e2e/backends/mock/README.md
@@ -15,8 +15,12 @@ Azure backend:
 - **Auth method** (`E2E_AUTH`): unset runs both `sas` and `entra`; pin one with
   `E2E_AUTH=sas` or `E2E_AUTH=entra`. The `entra` cell drives a real
   `EntraTokenProvider` (backed by a fake credential) so the production token
-  cache is exercised end-to-end, and pays a one-off cold token-acquisition cost
-  on the first dial.
+  cache is exercised end-to-end, pays a one-off cold token-acquisition cost on
+  the first dial, and — because the fake credential now mints a JWT-shaped token
+  — also pays the mock relay's per-request Entra validation cost
+  (`EntraValidate`) on every connect, modelling the recurring server-side "warm
+  tax" the real Azure Relay charges under Entra. The `sas` cell pays only the
+  cheap local SAS validation (`AuthInternal`).
 - **Delay profile** (`E2E_DELAY`): unset uses the wire-faithful `default`
   profile so timing thresholds calibrated against Azure also fire here. The
   profile also owns the entra cold-acquisition cost (`TokenAcquire`), so the

--- a/e2e/backends/mock/backend.go
+++ b/e2e/backends/mock/backend.go
@@ -228,21 +228,23 @@ func (b *MockBackend) Cell(values map[string]string) scenarios.Backend {
 const mockLatencyFloor = 3 * time.Second
 
 // mockLatencyBudget derives the per-connection latency ceiling for a
-// pinned profile. It is affine in the profile's predicted cost — one
-// cold rendezvous plus one bridge echo, the shape the ConnectLatency
-// scenarios measure (dial -> 1-byte echo) — so a slow profile gets a
-// proportionally larger budget that still trips on a real regression,
-// rather than a flat constant that would mask seconds-scale slowdowns.
-// The 3 s floor preserves the historical budget for the zero/default
-// profiles (both predict well under it).
+// pinned profile and auth method. It is affine in the profile's
+// predicted cost — one cold rendezvous (on the given auth path, so the
+// Entra leg pays EntraValidate instead of AuthInternal) plus one bridge
+// echo, the shape the ConnectLatency scenarios measure (dial -> 1-byte
+// echo) — so a slow profile gets a proportionally larger budget that
+// still trips on a real regression, rather than a flat constant that
+// would mask seconds-scale slowdowns. The 3 s floor preserves the
+// historical budget for the zero/default profiles (both predict well
+// under it).
 //
 // Note: the workload scenarios' warm-request budget (roundBudget in
 // e2e/scenarios/performance.go) is a flat 500 ms per request and is
 // NOT derived from the profile; a profile whose PredictedBridgeEcho
 // exceeds that would need roundBudget made delay-aware. Both currently
 // registered profiles (zero, default) are well within it.
-func mockLatencyBudget(p server.DelayProfile) time.Duration {
-	predicted := p.PredictedRendezvous() + p.PredictedBridgeEcho()
+func mockLatencyBudget(p server.DelayProfile, entra bool) time.Duration {
+	predicted := p.PredictedRendezvousFor(entra) + p.PredictedBridgeEcho()
 	budget := predicted*3/2 + 2*time.Second
 	if budget < mockLatencyFloor {
 		budget = mockLatencyFloor
@@ -256,7 +258,7 @@ func mockLatencyBudget(p server.DelayProfile) time.Duration {
 // mockLatencyBudget). A directly-constructed zero-profile backend
 // yields the 3 s floor — the historical value.
 func (b *MockBackend) ConnectLatencyThreshold() time.Duration {
-	return mockLatencyBudget(b.DelayProfile)
+	return mockLatencyBudget(b.DelayProfile, b.authName == AuthEntra)
 }
 
 // ConnectLatencyPolicy returns a strict, spike-free quantile gate for
@@ -270,7 +272,7 @@ func (b *MockBackend) ConnectLatencyThreshold() time.Duration {
 // past the budget trips the gate. Iterations is kept at 10 since extra
 // samples buy nothing against a deterministic backend.
 func (b *MockBackend) ConnectLatencyPolicy() scenarios.ConnectLatencyPolicy {
-	budget := mockLatencyBudget(b.DelayProfile)
+	budget := mockLatencyBudget(b.DelayProfile, b.authName == AuthEntra)
 	return scenarios.ConnectLatencyPolicy{
 		Iterations:   10,
 		NormalP50:    budget,
@@ -289,7 +291,7 @@ func (b *MockBackend) ConnectLatencyPolicy() scenarios.ConnectLatencyPolicy {
 // is 0, so entra and sas share the same (floored) cold-start budget,
 // keeping "zero means instant everywhere" intact.
 func (b *MockBackend) ColdStartLatencyThreshold() time.Duration {
-	budget := mockLatencyBudget(b.DelayProfile)
+	budget := mockLatencyBudget(b.DelayProfile, b.authName == AuthEntra)
 	if b.authName == AuthEntra {
 		budget += entraColdStartHeadroom(b.DelayProfile)
 	}

--- a/e2e/backends/mock/backend.go
+++ b/e2e/backends/mock/backend.go
@@ -259,6 +259,26 @@ func (b *MockBackend) ConnectLatencyThreshold() time.Duration {
 	return mockLatencyBudget(b.DelayProfile)
 }
 
+// ConnectLatencyPolicy returns a strict, spike-free quantile gate for
+// the mock backend. The in-process mock is deterministic — every dial
+// pays the same modelled rendezvous delay with negligible jitter — so
+// it must NOT inherit Azure's spike tolerance, which would mask a real
+// regression in mock-exercised code. All three thresholds collapse to
+// the single deterministic budget (mockLatencyBudget): the upper-median
+// and soft-tail samples both sit at ~the modelled latency, comfortably
+// under the budget, and any regression that lifts the bulk of samples
+// past the budget trips the gate. Iterations is kept at 10 since extra
+// samples buy nothing against a deterministic backend.
+func (b *MockBackend) ConnectLatencyPolicy() scenarios.ConnectLatencyPolicy {
+	budget := mockLatencyBudget(b.DelayProfile)
+	return scenarios.ConnectLatencyPolicy{
+		Iterations:   10,
+		NormalP50:    budget,
+		SoftTail:     budget,
+		SpikeCeiling: budget,
+	}
+}
+
 // ColdStartLatencyThreshold returns the per-backend ceiling for the
 // first connection through a freshly-started sender. The warm budget is
 // mockLatencyBudget (every dial pays the same rendezvous delay). The

--- a/e2e/backends/mock/entracred.go
+++ b/e2e/backends/mock/entracred.go
@@ -23,17 +23,19 @@ import (
 // actually works — break EntraTokenProvider's caching and `calls` jumps
 // from 1 to N.
 //
-// The token string it returns is a genuine SAS token signed with the
-// mock relay's default key, because mockrelay/server.validateSAS only
-// accepts SharedAccessSignature-shaped tokens. The mock does not compare
-// the token audience (sr) against the request URI, so a single fixed
-// resource URI signs a token valid for every entity. This is a
+// The token string it returns is a fake Entra (OAuth2 JWT) bearer token
+// minted by server.MintFakeBearerToken: an HS256 compact JWS signed with
+// the mock relay's default key. The mock relay sniffs the token shape and
+// runs it down the Entra validation path (server.validateBearer), charging
+// the per-request EntraValidate cost — so the mock now models the Entra
+// "warm tax" the real Azure Relay control plane pays on every
+// token-bearing leg, not just the client-side acquisition. This is still a
 // deliberate fidelity trade: we model Entra *client acquisition timing +
-// caching + metrics*, NOT Entra cryptography, OAuth scopes, audience
-// binding, or server-side RBAC (none of which the mock server can
-// validate). The trade is only safe because production EntraTokenProvider
-// never parses the returned token string — it trusts AccessToken.ExpiresOn
-// directly (internal/relay/auth.go) — so a SAS-shaped string is opaque to
+// caching + metrics* and the *relay-side per-request validation cost*, NOT
+// real Entra cryptography (RS256/AAD keys), OAuth scopes, audience binding,
+// or RBAC. The trade is safe because production EntraTokenProvider never
+// parses the returned token string — it trusts AccessToken.ExpiresOn
+// directly (internal/relay/auth.go) — so a JWT-shaped string is opaque to
 // it. Revisit if EntraTokenProvider ever starts parsing the token body.
 type fakeEntraCredential struct {
 	// delay is the synthetic per-acquisition latency, modelling the
@@ -56,16 +58,12 @@ func (c *fakeEntraCredential) GetToken(ctx context.Context, _ policy.TokenReques
 			return azcore.AccessToken{}, ctx.Err()
 		}
 	}
-	// Sign a SAS token the mock relay will accept. The audience is a
-	// fixed placeholder — validateSAS does not bind sr to the request
-	// URI — and outlives the test so the cache treats it as fresh.
+	// Mint a fake Entra JWT the mock relay will validate down its Entra
+	// path (charging EntraValidate). It is signed with the relay's
+	// default key and outlives the test so the client cache treats it as
+	// fresh.
 	const tokenLifetime = time.Hour
-	tok, err := relay.GenerateSASToken(
-		"https://mock-entra.invalid/fake",
-		server.DefaultSASKeyName,
-		server.DefaultSASKey,
-		tokenLifetime,
-	)
+	tok, err := server.MintFakeBearerToken(server.DefaultSASKey, tokenLifetime)
 	if err != nil {
 		return azcore.AccessToken{}, err
 	}

--- a/e2e/scenarios/backend.go
+++ b/e2e/scenarios/backend.go
@@ -139,8 +139,13 @@ type Backend interface {
 
 	// ConnectLatencyThreshold is the per-backend ceiling for a single
 	// fresh-connection round-trip (Dial → 1-byte write → 1-byte echo
-	// read → Close). The Performance suite's serial-connect scenarios
-	// assert each iteration completes inside this budget.
+	// read → Close). It feeds the echo-workload scenarios' per-round
+	// budget (roundBudget) and the per-connection dial/I-O deadlines
+	// clamped to it. The steady-state ConnectLatency_Serial scenarios
+	// do NOT use this value at all — neither as an assertion nor as a
+	// deadline: their gate is the quantile policy from
+	// ConnectLatencyPolicy (see below) and their per-dial deadline is
+	// that policy's SpikeCeiling.
 	//
 	// The threshold is read on the cell-pinned backend (after Cell()),
 	// so implementations may vary it per axis value (e.g. tighter for
@@ -156,11 +161,8 @@ type Backend interface {
 	// backend that wanted to split those costs into separate budgets
 	// would need a richer interface.
 	//
-	// The Performance suite's ConnectLatency_Serial scenarios drive
-	// this threshold against the steady-state path — they discard one
-	// untimed warm-up dial before measuring. Cold-start cost is
-	// regression-protected separately via ColdStartLatencyThreshold
-	// and ConnectLatency_ColdStart_* scenarios.
+	// Cold-start cost is regression-protected separately via
+	// ColdStartLatencyThreshold and ConnectLatency_ColdStart_*.
 	ConnectLatencyThreshold() time.Duration
 
 	// ConnectLatencyPolicy parameterises the steady-state

--- a/e2e/scenarios/backend.go
+++ b/e2e/scenarios/backend.go
@@ -52,6 +52,52 @@ type Axis interface {
 	Values() []string
 }
 
+// ConnectLatencyPolicy parameterises the steady-state
+// ConnectLatency_Serial assertion. The scenario runs Iterations timed
+// dials, then judges the batch on robust quantiles rather than any
+// single sample, so the rare and unfixable Azure Relay rendezvous tail
+// (isolated multi-second spikes, proven to originate in the relay
+// control plane and not in aztunnel) does not flake the suite while a
+// genuine, broad regression still trips it:
+//
+//   - the upper-median sample must be below NormalP50. A regression in
+//     aztunnel's steady-state overhead lifts every sample and moves the
+//     median; an isolated spike does not.
+//   - the soft-tail sample (the largest after discarding the sparse top
+//     ~10% of samples) must be below SoftTail. This tolerates a small
+//     number of independent spikes while still catching a degradation
+//     broad enough to lift the bulk of the tail.
+//
+// There is deliberately no "max sample" or "tolerated spike count"
+// assertion: a hard count cap reintroduces the statistical cliff it is
+// meant to remove (its trip probability grows with Iterations). The
+// only hard failure on a single slow dial is a genuine hang, bounded by
+// the per-dial deadline of SpikeCeiling + connectSlack.
+//
+// A strict, spike-free backend (the in-process mock) sets NormalP50,
+// SoftTail and SpikeCeiling to the same deterministic budget so any
+// real regression trips the gate; a tolerant backend (real Azure Relay)
+// sets NormalP50 well above steady state, SoftTail at the old
+// per-sample ceiling, and SpikeCeiling generously above both.
+type ConnectLatencyPolicy struct {
+	// Iterations is the number of timed dials the serial scenario
+	// performs (in addition to one untimed warm-up).
+	Iterations int
+
+	// NormalP50 is the upper bound on the upper-median sample.
+	NormalP50 time.Duration
+
+	// SoftTail is the upper bound on the soft-tail sample (largest
+	// after discarding the sparse top ~10%).
+	SoftTail time.Duration
+
+	// SpikeCeiling bounds a single dial: the per-dial socket deadline
+	// is SpikeCeiling + connectSlack. It is decoupled from the
+	// assertion thresholds so a tolerated spike is measured rather than
+	// killed by an i/o timeout.
+	SpikeCeiling time.Duration
+}
+
 // Backend is the abstraction e2e scenarios run against. Each
 // implementation knows how to bring up a topology that satisfies
 // SetupOptions and to tear it down cleanly via t.Cleanup.
@@ -116,6 +162,14 @@ type Backend interface {
 	// regression-protected separately via ColdStartLatencyThreshold
 	// and ConnectLatency_ColdStart_* scenarios.
 	ConnectLatencyThreshold() time.Duration
+
+	// ConnectLatencyPolicy parameterises the steady-state
+	// ConnectLatency_Serial assertion for this backend. It is read on
+	// the cell-pinned backend so an Azure implementation may tune the
+	// quantile gate per axis value when data justifies it. See
+	// ConnectLatencyPolicy (the struct) for the meaning of each field
+	// and the rationale for a quantile gate over a per-sample ceiling.
+	ConnectLatencyPolicy() ConnectLatencyPolicy
 
 	// ColdStartLatencyThreshold is the per-backend ceiling for the
 	// very first connection through a freshly-started sender — the

--- a/e2e/scenarios/connectlatency_eval_test.go
+++ b/e2e/scenarios/connectlatency_eval_test.go
@@ -1,0 +1,171 @@
+package scenarios
+
+import (
+	"testing"
+	"time"
+)
+
+// ms is a brevity helper for building duration sample sets.
+func ms(v int) time.Duration { return time.Duration(v) * time.Millisecond }
+
+// repeat returns a slice of n samples all equal to d.
+func repeat(d time.Duration, n int) []time.Duration {
+	out := make([]time.Duration, n)
+	for i := range out {
+		out[i] = d
+	}
+	return out
+}
+
+// azurePolicy mirrors the tolerant production gate so the unit tests
+// exercise the same thresholds CI uses. Kept local to avoid importing
+// the azure backend (which carries a build tag and Azure deps).
+var azurePolicy = ConnectLatencyPolicy{
+	Iterations:   20,
+	NormalP50:    1500 * time.Millisecond,
+	SoftTail:     3 * time.Second,
+	SpikeCeiling: 6 * time.Second,
+}
+
+func TestEvaluateConnectLatency(t *testing.T) {
+	// A 20-sample steady-state batch (~400 ms) used as the base for
+	// spike-injection cases.
+	steady20 := repeat(ms(400), 20)
+
+	withSpikes := func(base []time.Duration, spikes ...time.Duration) []time.Duration {
+		out := append([]time.Duration(nil), base...)
+		copy(out, spikes) // overwrite the first len(spikes) samples
+		return out
+	}
+
+	tests := []struct {
+		name    string
+		samples []time.Duration
+		policy  ConnectLatencyPolicy
+		wantOK  bool
+	}{
+		{
+			name:    "empty input fails",
+			samples: nil,
+			policy:  azurePolicy,
+			wantOK:  false,
+		},
+		{
+			name:    "all fast passes",
+			samples: steady20,
+			policy:  azurePolicy,
+			wantOK:  true,
+		},
+		{
+			name:    "one spike tolerated",
+			samples: withSpikes(steady20, ms(5000)),
+			policy:  azurePolicy,
+			wantOK:  true,
+		},
+		{
+			name:    "two spikes tolerated (ceil 10% of 20)",
+			samples: withSpikes(steady20, ms(5000), ms(6000)),
+			policy:  azurePolicy,
+			wantOK:  true,
+		},
+		{
+			name:    "three spikes trip the soft-tail",
+			samples: withSpikes(steady20, ms(5000), ms(5000), ms(5000)),
+			policy:  azurePolicy,
+			wantOK:  false,
+		},
+		{
+			name:    "uniform 2s regression trips the median",
+			samples: repeat(ms(2000), 20),
+			policy:  azurePolicy,
+			wantOK:  false,
+		},
+		{
+			name:    "ten-ten split trips the median (upper-median is slow)",
+			samples: append(repeat(ms(400), 10), repeat(ms(2000), 10)...),
+			policy:  azurePolicy,
+			wantOK:  false,
+		},
+		{
+			name:    "broad mid-tail rise below 3s old ceiling still trips median",
+			samples: repeat(ms(1800), 20),
+			policy:  azurePolicy,
+			wantOK:  false,
+		},
+		{
+			name:    "median exactly at threshold fails (>= is failure)",
+			samples: repeat(ms(1500), 20),
+			policy:  azurePolicy,
+			wantOK:  false,
+		},
+		{
+			name:    "soft-tail exactly at threshold fails",
+			samples: withSpikes(steady20, ms(3000), ms(3000), ms(3000)),
+			policy:  azurePolicy,
+			wantOK:  false,
+		},
+		{
+			name:    "single sample below median threshold passes",
+			samples: repeat(ms(400), 1),
+			policy:  azurePolicy,
+			wantOK:  true,
+		},
+		{
+			name:    "single slow sample fails (upper-median is that sample)",
+			samples: repeat(ms(5000), 1),
+			policy:  azurePolicy,
+			wantOK:  false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ok, reason := evaluateConnectLatency(tc.samples, tc.policy)
+			if ok != tc.wantOK {
+				t.Fatalf("evaluateConnectLatency ok=%v want %v (reason=%q)", ok, tc.wantOK, reason)
+			}
+			if !ok && reason == "" {
+				t.Errorf("failing evaluation returned empty reason")
+			}
+			if ok && reason != "" {
+				t.Errorf("passing evaluation returned non-empty reason %q", reason)
+			}
+		})
+	}
+}
+
+func TestUpperMedian(t *testing.T) {
+	// Even length: upper of the two central samples.
+	if got := upperMedian([]time.Duration{ms(1), ms(2), ms(3), ms(4)}); got != ms(3) {
+		t.Errorf("even-length upperMedian = %v, want %v", got, ms(3))
+	}
+	// Odd length: the central sample.
+	if got := upperMedian([]time.Duration{ms(1), ms(2), ms(3)}); got != ms(2) {
+		t.Errorf("odd-length upperMedian = %v, want %v", got, ms(2))
+	}
+}
+
+func TestTolerableSpikes(t *testing.T) {
+	cases := map[int]int{1: 1, 9: 1, 10: 1, 11: 2, 20: 2, 21: 3, 30: 3}
+	for n, want := range cases {
+		if got := tolerableSpikes(n); got != want {
+			t.Errorf("tolerableSpikes(%d) = %d, want %d", n, got, want)
+		}
+	}
+}
+
+func TestSoftTailSample(t *testing.T) {
+	sorted := []time.Duration{ms(1), ms(2), ms(3), ms(4), ms(5)}
+	// tolerate 0 => largest.
+	if got := softTailSample(sorted, 0); got != ms(5) {
+		t.Errorf("softTailSample tolerate=0 = %v, want %v", got, ms(5))
+	}
+	// tolerate 2 => discard top 2, largest remaining is sorted[2].
+	if got := softTailSample(sorted, 2); got != ms(3) {
+		t.Errorf("softTailSample tolerate=2 = %v, want %v", got, ms(3))
+	}
+	// tolerate >= len => clamps to the smallest sample, no panic.
+	if got := softTailSample(sorted, 10); got != ms(1) {
+		t.Errorf("softTailSample tolerate=10 = %v, want %v", got, ms(1))
+	}
+}

--- a/e2e/scenarios/performance.go
+++ b/e2e/scenarios/performance.go
@@ -19,8 +19,10 @@ import (
 // connection-setup and short-session work as testing.T so CI fails
 // when wall time exceeds the per-backend threshold.
 //
-// Two scenarios assert per-iteration time against
-// ConnectLatencyThreshold; ShortSession_Serial is observation-only.
+// Two scenarios assert connect time against the backend's
+// ConnectLatencyPolicy (ConnectLatency_Serial) / ColdStartLatency-
+// Threshold (ConnectLatency_ColdStart); ShortSession_Serial is
+// observation-only.
 // The 12 parameterized echo-workload scenarios that follow
 // (Serial|Parallel × ConnPerRequest|ConnReused|ConnPrewarmed ×
 // _PortForward|_SOCKS5), plus the single _MultiTarget variant that
@@ -48,7 +50,7 @@ func RunPerformanceScenarios(t *testing.T, b Backend) {
 
 // performanceCases is the metadata-only registry of performance
 // scenarios. All entries are AnyBackend: per-backend thresholds are
-// applied inside each scenario via b.ConnectLatencyThreshold(),
+// applied inside each scenario via b.ConnectLatencyPolicy(),
 // b.RoundBudget(), etc., so the same scenario can run against both
 // without false alarms.
 //
@@ -79,31 +81,21 @@ func performanceCases() []scenarioCase {
 	}
 }
 
-// ScenarioConnectLatency_Serial_PortForward opens 10 serial
-// port-forward connections, each performing one 1-byte echo
-// round-trip, and asserts every iteration completes inside
-// b.ConnectLatencyThreshold(). One additional untimed warm-up
-// dial precedes the measured loop so per-process cold-start
-// costs (notably the EntraTokenProvider's first credential
-// fetch — ~2-3 s observed against Entra ID) don't bleed into
-// the first measured iteration. The scenario logs the warm-up
-// elapsed for visibility and a per-iteration elapsed so a
-// failure makes the offending iteration obvious.
+// ScenarioConnectLatency_Serial_PortForward opens a backend-defined
+// number of serial port-forward connections (ConnectLatencyPolicy.
+// Iterations), each performing one 1-byte echo round-trip, and asserts
+// the batch against the backend's quantile gate (upper-median <
+// NormalP50 AND soft-tail < SoftTail; see ConnectLatencyPolicy). One
+// additional untimed warm-up dial precedes the measured loop so
+// per-process cold-start costs (notably the EntraTokenProvider's first
+// credential fetch — ~2-3 s observed against Entra ID) don't bleed into
+// the measured samples. The scenario logs the warm-up elapsed and a
+// per-iteration elapsed plus the distribution so a failure is
+// diagnosable from CI output alone.
 //
-// Measured iteration count is fixed at 10 (plus 1 warm-up).
-// Walltime bounds at the current 3 s thresholds:
-//   - Happy path: 11 × ~1 s rendezvous ≈ 11 s per scenario.
-//   - Threshold-only violation (operational success, elapsed too
-//     high): bounded by 11 × (threshold + connectSlack) ≈ 88 s
-//     per scenario, since runSerialConnectLatency uses
-//     t.Errorf + continue on threshold violations and a
-//     successful iteration can use up to threshold+connectSlack
-//     of budget before the deadline fires.
-//   - Operational error (dial/echo/close failure): fails fast at
-//     ≈ threshold + connectSlack ≈ 8 s via t.Fatalf.
-//
-// All three bounds keep the scenario well inside both the
-// per-test default timeout and the e2e job's 60 m envelope.
+// Walltime is bounded by Iterations × (SpikeCeiling + connectSlack) in
+// the worst case (every dial stalls to its deadline), well inside the
+// e2e job's 60 m envelope; the happy path is Iterations × ~steady-state.
 func ScenarioConnectLatency_Serial_PortForward(t *testing.T, b Backend) {
 	t.Helper()
 	AssertNoLeaks(t)
@@ -181,49 +173,46 @@ func ScenarioShortSession_Serial(t *testing.T, b Backend) {
 // runSerialConnectLatency is the shared implementation of the two
 // ConnectLatency_Serial variants. Each measured iteration: dial
 // (port-forward TCP or SOCKS5 CONNECT) → write 1 byte → read
-// 1 byte echoed back → close. Asserts elapsed < threshold per
-// measured iteration.
+// 1 byte echoed back → close. It collects every iteration's elapsed
+// time and asserts the batch against the backend's
+// ConnectLatencyPolicy quantile gate (see evaluateConnectLatency and
+// the ConnectLatencyPolicy doc) rather than checking each sample
+// against a single ceiling.
 //
-// A single warm-up dial precedes the measured loop. Its elapsed
-// is logged but neither threshold-asserted nor counted in the
-// measured iteration count. The warm-up absorbs per-process
-// cold-start costs that the steady-state scenario isn't trying
-// to characterize — most prominently the EntraTokenProvider's
-// first credential fetch, which observably adds ~2-3 s to the
-// first connection and exceeds the 3 s threshold on most runs
-// against Entra ID. Without the warm-up, ConnectLatency_Serial
-// flakes on Entra cells while reporting healthy steady-state
-// latency on every subsequent iteration.
+// The quantile gate exists because the dominant failure mode against
+// real Azure Relay is an isolated multi-second rendezvous spike that
+// originates in the relay control plane, not in aztunnel (proven from
+// full sender+listener logs: zero client-side retries, the listener
+// sits idle in ws.Read for the whole stall, then accepts normally).
+// A per-sample ceiling turns that unfixable tail into a flake; a
+// per-sample ceiling with a tolerated-spike count reintroduces the
+// same cliff at a higher count. The upper-median + soft-tail gate
+// tolerates the sparse tail while still tripping on a broad regression
+// (which an old "max < 3 s" check missed entirely below 3 s).
 //
-// Failure-mode handling is deliberately split:
+// A single warm-up dial precedes the measured loop. Its elapsed is
+// logged but neither asserted nor counted. The warm-up absorbs
+// per-process cold-start costs the steady-state scenario isn't trying
+// to characterize — most prominently the EntraTokenProvider's first
+// credential fetch, which observably adds ~2-3 s to the first
+// connection. Cold-start cost is regression-protected separately via
+// ConnectLatency_ColdStart_*.
 //
-//   - Operational errors (dial/write/read/echo-mismatch/close) →
-//     t.Fatalf. These mean the harness is fundamentally broken
-//     (no rendezvous, target unreachable, socket draining
-//     timeout, etc.). Continuing past them wastes CI walltime
-//     because every subsequent iteration is likely to hit the
-//     same (threshold + connectSlack) ~ 8 s timeout — at 10
-//     iterations × 2 scenarios × 2 Azure auth cells that's a
-//     320 s failure-path burn against the 60 m e2e workflow
-//     envelope. Fail fast.
-//   - Threshold violations (operational success, elapsed >=
-//     threshold) → t.Errorf + continue. These produce a
-//     measured elapsed time on every iteration, so continuing is
-//     cheap (each iteration completed normally inside the budget
-//     window) and lets a flaky CI run surface every offending
-//     iteration in one report. CI still fails the suite either
-//     way.
+// Operational errors (dial/write/read/echo-mismatch/close) → t.Fatalf:
+// they mean the harness is fundamentally broken and every subsequent
+// iteration would burn the same deadline. The per-dial deadline is
+// anchored to policy.SpikeCeiling + connectSlack (not the assertion
+// thresholds) so a tolerated spike is measured rather than killed by
+// an i/o timeout.
 //
 // dialWithRetry / dialSOCKS5WithRetry are intentionally not used —
 // the retry helpers exist to swallow first-dial transient races on
-// brand-new tunnels, but the Performance scenarios open exactly
-// one topology, perform one untimed warm-up dial, and then dial
-// it 10 times in sequence. By the first measured iteration the
-// relay is fully warm; failing on a real dial error here is what
-// we want to measure.
+// brand-new tunnels, but by the first measured iteration the relay is
+// fully warm (one untimed warm-up dial precedes the loop); failing on
+// a real dial error here is what we want to measure.
 func runSerialConnectLatency(t *testing.T, b Backend, mode SenderMode) {
 	t.Helper()
-	threshold := b.ConnectLatencyThreshold()
+	policy := b.ConnectLatencyPolicy()
 	echo := StartPlainEcho(t)
 	opts := SetupOptions{
 		NumListeners:   1,
@@ -236,27 +225,97 @@ func runSerialConnectLatency(t *testing.T, b Backend, mode SenderMode) {
 	tun := b.Setup(t, opts)
 	dumpConnectLatencyLogsOnFail(t, tun)
 
-	const iterations = 10
 	payload := []byte{0x42}
 	buf := make([]byte, 1)
 
-	warmupElapsed, err := timeOneConnect(tun.SenderAddr, echo.Addr(), mode, payload, buf, threshold)
+	// The per-dial deadline is anchored to SpikeCeiling, not to the
+	// assertion thresholds, so a tolerated rendezvous spike is measured
+	// and folded into the quantiles rather than killed by an i/o
+	// timeout (which would be an unrecoverable t.Fatalf below).
+	deadlineBudget := policy.SpikeCeiling
+
+	warmupElapsed, err := timeOneConnect(tun.SenderAddr, echo.Addr(), mode, payload, buf, deadlineBudget)
 	if err != nil {
 		t.Fatalf("warmup: %v (elapsed=%v)", err, warmupElapsed)
 	}
-	t.Logf("ConnectLatency_Serial_%v warmup: %v (untimed, threshold %v)", mode, warmupElapsed, threshold)
+	t.Logf("ConnectLatency_Serial_%v warmup: %v (untimed)", mode, warmupElapsed)
 
-	for i := 0; i < iterations; i++ {
-		elapsed, err := timeOneConnect(tun.SenderAddr, echo.Addr(), mode, payload, buf, threshold)
+	samples := make([]time.Duration, 0, policy.Iterations)
+	for i := 0; i < policy.Iterations; i++ {
+		elapsed, err := timeOneConnect(tun.SenderAddr, echo.Addr(), mode, payload, buf, deadlineBudget)
 		if err != nil {
 			t.Fatalf("iter %d: %v (elapsed=%v)", i, err, elapsed)
 		}
-		if elapsed >= threshold {
-			t.Errorf("iter %d: connect latency %v >= threshold %v", i, elapsed, threshold)
-			continue
-		}
-		t.Logf("ConnectLatency_Serial_%v iter %d: %v (< %v)", mode, i, elapsed, threshold)
+		samples = append(samples, elapsed)
+		t.Logf("ConnectLatency_Serial_%v iter %d: %v", mode, i, elapsed)
 	}
+
+	t.Logf("ConnectLatency_Serial_%v distribution: %s (policy normalP50=%v softTail=%v over %d iters)",
+		mode, fmtDist("connect", samples), policy.NormalP50, policy.SoftTail, policy.Iterations)
+
+	if ok, reason := evaluateConnectLatency(samples, policy); !ok {
+		t.Errorf("ConnectLatency_Serial_%v: %s", mode, reason)
+	}
+}
+
+// evaluateConnectLatency judges a batch of connect-latency samples
+// against a policy's quantile gate. It returns ok=false with a
+// human-readable reason naming the first failing arm. See
+// ConnectLatencyPolicy for the rationale behind the two-arm gate and
+// the deliberate absence of a per-sample / spike-count cap.
+//
+// The gate is intentionally tolerant of a sparse tail of independent
+// spikes (the soft-tail statistic discards the top ceil(10%) of
+// samples) but strict about a broad shift (the upper-median moves the
+// moment the bulk of samples regress).
+func evaluateConnectLatency(samples []time.Duration, p ConnectLatencyPolicy) (ok bool, reason string) {
+	if len(samples) == 0 {
+		return false, "no connect-latency samples collected"
+	}
+	sorted := make([]time.Duration, len(samples))
+	copy(sorted, samples)
+	sort.Slice(sorted, func(i, j int) bool { return sorted[i] < sorted[j] })
+
+	p50 := upperMedian(sorted)
+	if p50 >= p.NormalP50 {
+		return false, fmt.Sprintf("median connect latency %v >= normal threshold %v (broad regression across %d samples; %s)",
+			p50, p.NormalP50, len(sorted), fmtDist("connect", sorted))
+	}
+
+	tolerate := tolerableSpikes(len(sorted))
+	softTail := softTailSample(sorted, tolerate)
+	if softTail >= p.SoftTail {
+		return false, fmt.Sprintf("soft-tail connect latency %v >= soft-tail threshold %v (tail degradation beyond the %d tolerated spike(s) across %d samples; %s)",
+			softTail, p.SoftTail, tolerate, len(sorted), fmtDist("connect", sorted))
+	}
+	return true, ""
+}
+
+// upperMedian returns the upper of the two central samples for an
+// even-length sorted slice, or the central sample for an odd length:
+// sorted[len/2]. Choosing the upper central value makes the median
+// assertion conservative — a regression that lifts half the samples
+// still trips it.
+func upperMedian(sorted []time.Duration) time.Duration {
+	return sorted[len(sorted)/2]
+}
+
+// tolerableSpikes is the number of top samples the soft-tail statistic
+// discards: ceil(10% of n). This scales the spike tolerance with the
+// iteration count (2 spikes over 20, 1 over 10) so the gate degrades
+// gracefully instead of at a fixed cliff.
+func tolerableSpikes(n int) int {
+	return (n + 9) / 10
+}
+
+// softTailSample returns the largest sample after discarding the top
+// `tolerate` outliers: sorted[len-1-tolerate], clamped to the slice.
+func softTailSample(sorted []time.Duration, tolerate int) time.Duration {
+	idx := len(sorted) - 1 - tolerate
+	if idx < 0 {
+		idx = 0
+	}
+	return sorted[idx]
 }
 
 // dumpConnectLatencyLogsOnFail registers a t.Cleanup that prints the
@@ -367,6 +426,16 @@ func ScenarioConnectLatency_ColdStart_SOCKS5(t *testing.T, b Backend) {
 func runColdStartConnectLatency(t *testing.T, b Backend, mode SenderMode) {
 	t.Helper()
 	threshold := b.ColdStartLatencyThreshold()
+	// Decouple the per-dial deadline from the assertion threshold, the
+	// same way the serial scenario does. A cold-start dial that pays a
+	// tolerable rendezvous spike on top of the genuine cold-token cost
+	// must return a measured (over-threshold) sample so the best-of-2
+	// retry below can run; if the deadline fired at threshold+slack the
+	// spike would surface as a fatal i/o timeout and defeat the retry.
+	// SpikeCeiling is the backend's model of the largest tolerable
+	// rendezvous spike; threshold+SpikeCeiling comfortably exceeds any
+	// cold-start+spike combination while still bounding a genuine hang.
+	deadlineBudget := threshold + b.ConnectLatencyPolicy().SpikeCeiling
 	echo := StartPlainEcho(t)
 	opts := SetupOptions{
 		NumListeners:   1,
@@ -376,21 +445,44 @@ func runColdStartConnectLatency(t *testing.T, b Backend, mode SenderMode) {
 	if mode == ModePortForward {
 		opts.Target = echo.Addr()
 	}
-	tun := b.Setup(t, opts)
-	dumpConnectLatencyLogsOnFail(t, tun)
 
 	payload := []byte{0x42}
 	buf := make([]byte, 1)
 
-	elapsed, err := timeOneConnect(tun.SenderAddr, echo.Addr(), mode, payload, buf, threshold)
-	if err != nil {
-		t.Fatalf("cold-start dial: %v (elapsed=%v)", err, elapsed)
+	// Best-of-2-on-spike: a cold-start dial occasionally pays an
+	// isolated Azure Relay rendezvous spike on top of the genuine
+	// one-time cold-token cost. Because the spike originates in the
+	// relay control plane and is independent of aztunnel, a second
+	// attempt with a freshly-started sender (a new sender process =>
+	// still a cold token, because the token cache lives in that
+	// process) almost never spikes again. Passing if either attempt is
+	// under budget turns a per-attempt spike probability p into ~p^2
+	// without widening the threshold (which would mask real cold-start
+	// regressions). The mock backend is deterministic and never spikes,
+	// so attempt 1 always passes there and the retry is dead code in CI
+	// for it.
+	const attempts = 2
+	var elapsed time.Duration
+	for attempt := 1; attempt <= attempts; attempt++ {
+		// A fresh Setup spawns a brand-new sender process, which is
+		// what makes the token cold again. Each Setup registers its own
+		// t.Cleanup, so the prior attempt's resources are released at
+		// test end.
+		tun := b.Setup(t, opts)
+		dumpConnectLatencyLogsOnFail(t, tun)
+
+		var err error
+		elapsed, err = timeOneConnect(tun.SenderAddr, echo.Addr(), mode, payload, buf, deadlineBudget)
+		if err != nil {
+			t.Fatalf("cold-start dial (attempt %d/%d): %v (elapsed=%v)", attempt, attempts, err, elapsed)
+		}
+		if elapsed < threshold {
+			t.Logf("ConnectLatency_ColdStart_%v: %v (< %v) [attempt %d/%d]", mode, elapsed, threshold, attempt, attempts)
+			return
+		}
+		t.Logf("ConnectLatency_ColdStart_%v: attempt %d/%d spiked at %v (>= %v)", mode, attempt, attempts, elapsed, threshold)
 	}
-	if elapsed >= threshold {
-		t.Errorf("cold-start connect latency %v >= threshold %v", elapsed, threshold)
-		return
-	}
-	t.Logf("ConnectLatency_ColdStart_%v: %v (< %v)", mode, elapsed, threshold)
+	t.Errorf("cold-start connect latency %v >= threshold %v on all %d attempts", elapsed, threshold, attempts)
 }
 
 // timeOneConnect opens one connection in the given mode, writes
@@ -404,33 +496,33 @@ func runColdStartConnectLatency(t *testing.T, b Backend, mode SenderMode) {
 // against the budget by design.
 //
 // The dial timeout and connection deadline both use
-// threshold + connectSlack rather than threshold so a timing
-// regression surfaces as the explicit elapsed >= threshold
-// assertion in the caller rather than as an i/o timeout from
-// the deadline firing exactly at threshold. The slack only widens
-// the timeout headroom; it does not change the threshold being
-// asserted.
+// deadlineBudget + connectSlack. deadlineBudget is the caller's
+// generous per-dial ceiling (the serial scenario passes its
+// SpikeCeiling, the cold-start scenario passes its threshold); the
+// slack only widens the timeout headroom so a tolerated slow dial is
+// measured and returned to the caller rather than surfacing as an i/o
+// timeout from the deadline firing.
 //
 // The deadline is anchored to start (the pre-dial timestamp),
 // not to time.Now() after the dial returns. Anchoring to start
 // bounds the entire dial+write+read+close iteration to a single
-// threshold + connectSlack window; if dial itself burns most of
+// deadlineBudget + connectSlack window; if dial itself burns most of
 // that window the remaining read/write inherit whatever is left.
 // Anchoring to post-dial time.Now() would let the whole
-// iteration take up to 2 × (threshold + connectSlack) in the
+// iteration take up to 2 × (deadlineBudget + connectSlack) in the
 // worst case (dial uses one window, deadline allows another),
 // violating the bound documented on the calling scenario.
 //
 // Returns the elapsed time even on error so the caller can log
 // timing context alongside the failure reason.
-func timeOneConnect(senderAddr, target string, mode SenderMode, payload, buf []byte, threshold time.Duration) (time.Duration, error) {
+func timeOneConnect(senderAddr, target string, mode SenderMode, payload, buf []byte, deadlineBudget time.Duration) (time.Duration, error) {
 	const connectSlack = 5 * time.Second
 	start := time.Now()
-	conn, err := dialSender(senderAddr, target, mode, threshold+connectSlack)
+	conn, err := dialSender(senderAddr, target, mode, deadlineBudget+connectSlack)
 	if err != nil {
 		return time.Since(start), err
 	}
-	_ = conn.SetDeadline(start.Add(threshold + connectSlack))
+	_ = conn.SetDeadline(start.Add(deadlineBudget + connectSlack))
 	if err := writeFull(conn, payload); err != nil {
 		_ = conn.Close()
 		return time.Since(start), err

--- a/e2e/scenarios/performance.go
+++ b/e2e/scenarios/performance.go
@@ -498,8 +498,8 @@ func runColdStartConnectLatency(t *testing.T, b Backend, mode SenderMode) {
 // The dial timeout and connection deadline both use
 // deadlineBudget + connectSlack. deadlineBudget is the caller's
 // generous per-dial ceiling (the serial scenario passes its
-// SpikeCeiling, the cold-start scenario passes its threshold); the
-// slack only widens the timeout headroom so a tolerated slow dial is
+// SpikeCeiling; the cold-start scenario passes its threshold +
+// SpikeCeiling); the slack only widens the timeout headroom so a tolerated slow dial is
 // measured and returned to the caller rather than surfacing as an i/o
 // timeout from the deadline firing.
 //

--- a/e2e/scenarios/performance.go
+++ b/e2e/scenarios/performance.go
@@ -275,12 +275,14 @@ func runSerialConnectLatency(t *testing.T, b Backend, mode SenderMode) {
 	// into the sender/listener log buffers on every dial, but the
 	// failure dump only fires on t.Failed() — so on a green-but-spiky
 	// run the very trace that diagnoses Phase 2 (sender cold dial) vs
-	// Phase 3 (relay hold) would otherwise be discarded. Skip when the
-	// batch failed: dumpConnectLatencyLogsOnFail already dumps then.
+	// Phase 3 (relay hold) would otherwise be discarded. We dump only
+	// the trace lines (not the full DEBUG buffers) to keep green-run CI
+	// output lean. Skip when the batch failed: dumpConnectLatencyLogsOnFail
+	// already dumps the full logs then.
 	if spikes > 0 && !t.Failed() {
 		t.Logf("ConnectLatency_Serial_%v: %d tolerated spike(s) >= NormalP50 %v on a passing run; dumping rendezvous traces for phase analysis",
 			mode, spikes, policy.NormalP50)
-		dumpTunnelLogs(t, tun)
+		dumpTunnelRendezvousTraces(t, tun)
 	}
 }
 
@@ -374,7 +376,9 @@ func dumpConnectLatencyLogsOnFail(t *testing.T, tun *Tunnel) {
 // dumpTunnelLogs prints the captured sender and listener logs for
 // every process in the tunnel, skipping nil handles and backends that
 // did not wire log capture (Logs == nil). It is unconditional; the
-// failure gate lives in dumpConnectLatencyLogsOnFail's cleanup.
+// failure gate lives in dumpConnectLatencyLogsOnFail's cleanup. It
+// dumps the FULL buffers and so is reserved for failing runs — passing
+// runs use the lean dumpTunnelRendezvousTraces instead.
 func dumpTunnelLogs(t *testing.T, tun *Tunnel) {
 	t.Helper()
 	for i, s := range tun.Senders {
@@ -389,6 +393,64 @@ func dumpTunnelLogs(t *testing.T, tun *Tunnel) {
 		}
 		t.Logf("--- listener[%d] logs ---\n%s", i, l.Logs())
 	}
+}
+
+// dumpTunnelRendezvousTraces prints ONLY the rendezvous-trace log lines
+// (the dns/tcp/tls/req_written/first_byte/resp_wait phase split emitted
+// by internal/relay's dial tracer) from each process in the tunnel. It
+// is the lean counterpart to dumpTunnelLogs, used on PASSING-but-spiky
+// runs: the Azure sender/listener subprocesses log at DEBUG, so dumping
+// their entire buffers on every green run that happened to tolerate a
+// spike would bloat CI output (and risk hitting log truncation limits),
+// while phase analysis only needs the trace lines. Full-buffer dumps
+// stay reserved for failing runs (dumpConnectLatencyLogsOnFail).
+func dumpTunnelRendezvousTraces(t *testing.T, tun *Tunnel) {
+	t.Helper()
+	emitted := false
+	dump := func(label string, logs func() string) {
+		if traces := filterTraceLines(logs()); traces != "" {
+			t.Logf("--- %s rendezvous traces ---\n%s", label, traces)
+			emitted = true
+		}
+	}
+	for i, s := range tun.Senders {
+		if s == nil || s.Logs == nil {
+			continue
+		}
+		dump(fmt.Sprintf("sender[%d]", i), s.Logs)
+	}
+	for i, l := range tun.Listeners {
+		if l == nil || l.Logs == nil {
+			continue
+		}
+		dump(fmt.Sprintf("listener[%d]", i), l.Logs)
+	}
+	if !emitted {
+		// Distinguish "tracer fired, here are the spans" from "nothing
+		// captured" (tracer disabled, buffer rolled, or no log capture
+		// wired) so the preceding "dumping…" announcement is never
+		// followed by confusing silence.
+		t.Logf("(no rendezvous trace lines captured)")
+	}
+}
+
+// filterTraceLines returns only the lines of logs that carry a
+// rendezvous trace (both the "relay rendezvous trace" sender lines and
+// the "accept rendezvous trace" listener lines, including their
+// "(dial failed)" variants), joined by newlines. Returns "" when none
+// match.
+func filterTraceLines(logs string) string {
+	var b strings.Builder
+	for _, line := range strings.Split(logs, "\n") {
+		if !strings.Contains(line, "rendezvous trace") {
+			continue
+		}
+		if b.Len() > 0 {
+			b.WriteByte('\n')
+		}
+		b.WriteString(line)
+	}
+	return b.String()
 }
 
 // ScenarioConnectLatency_ColdStart_PortForward opens exactly one
@@ -515,10 +577,12 @@ func runColdStartConnectLatency(t *testing.T, b Backend, mode SenderMode) {
 			// If an earlier attempt spiked but this one recovered, the
 			// scenario passes and the failure dump never fires — so
 			// surface the spiked attempt's rendezvous trace (resp_wait)
-			// for phase analysis, mirroring the serial scenario.
+			// for phase analysis, mirroring the serial scenario. Dump
+			// only the trace lines, not the full DEBUG buffers, to keep
+			// passing-run CI output lean.
 			if spikedTun != nil {
 				t.Logf("ConnectLatency_ColdStart_%v: recovered after a tolerated spike; dumping the spiked attempt's rendezvous trace for phase analysis", mode)
-				dumpTunnelLogs(t, spikedTun)
+				dumpTunnelRendezvousTraces(t, spikedTun)
 			}
 			return
 		}

--- a/e2e/scenarios/performance.go
+++ b/e2e/scenarios/performance.go
@@ -210,6 +210,11 @@ func ScenarioShortSession_Serial(t *testing.T, b Backend) {
 // brand-new tunnels, but by the first measured iteration the relay is
 // fully warm (one untimed warm-up dial precedes the loop); failing on
 // a real dial error here is what we want to measure.
+//
+// When a tolerated spike occurs (a sample >= NormalP50) but the batch
+// still passes, the captured sender/listener rendezvous traces are
+// dumped so the resp_wait phase split is visible for that run — the
+// failure dump alone would discard them on a green run.
 func runSerialConnectLatency(t *testing.T, b Backend, mode SenderMode) {
 	t.Helper()
 	policy := b.ConnectLatencyPolicy()
@@ -241,20 +246,41 @@ func runSerialConnectLatency(t *testing.T, b Backend, mode SenderMode) {
 	t.Logf("ConnectLatency_Serial_%v warmup: %v (untimed)", mode, warmupElapsed)
 
 	samples := make([]time.Duration, 0, policy.Iterations)
+	spikes := 0
 	for i := 0; i < policy.Iterations; i++ {
 		elapsed, err := timeOneConnect(tun.SenderAddr, echo.Addr(), mode, payload, buf, deadlineBudget)
 		if err != nil {
 			t.Fatalf("iter %d: %v (elapsed=%v)", i, err, elapsed)
 		}
 		samples = append(samples, elapsed)
+		if elapsed >= policy.NormalP50 {
+			spikes++
+			t.Logf("ConnectLatency_Serial_%v iter %d: %v [tolerated spike >= NormalP50 %v; see rendezvous trace dump below for the resp_wait phase split]",
+				mode, i, elapsed, policy.NormalP50)
+			continue
+		}
 		t.Logf("ConnectLatency_Serial_%v iter %d: %v", mode, i, elapsed)
 	}
 
-	t.Logf("ConnectLatency_Serial_%v distribution: %s (policy normalP50=%v softTail=%v over %d iters)",
-		mode, fmtDist("connect", samples), policy.NormalP50, policy.SoftTail, policy.Iterations)
+	t.Logf("ConnectLatency_Serial_%v distribution: %s (policy normalP50=%v softTail=%v over %d iters, %d tolerated spike(s))",
+		mode, fmtDist("connect", samples), policy.NormalP50, policy.SoftTail, policy.Iterations, spikes)
 
 	if ok, reason := evaluateConnectLatency(samples, policy); !ok {
 		t.Errorf("ConnectLatency_Serial_%v: %s", mode, reason)
+	}
+
+	// Surface the per-dial rendezvous traces (which carry resp_wait, the
+	// relay-side hold of the HTTP 101) whenever a tolerated spike
+	// occurred but the batch still passed. The DEBUG trace is captured
+	// into the sender/listener log buffers on every dial, but the
+	// failure dump only fires on t.Failed() — so on a green-but-spiky
+	// run the very trace that diagnoses Phase 2 (sender cold dial) vs
+	// Phase 3 (relay hold) would otherwise be discarded. Skip when the
+	// batch failed: dumpConnectLatencyLogsOnFail already dumps then.
+	if spikes > 0 && !t.Failed() {
+		t.Logf("ConnectLatency_Serial_%v: %d tolerated spike(s) >= NormalP50 %v on a passing run; dumping rendezvous traces for phase analysis",
+			mode, spikes, policy.NormalP50)
+		dumpTunnelLogs(t, tun)
 	}
 }
 
@@ -463,6 +489,7 @@ func runColdStartConnectLatency(t *testing.T, b Backend, mode SenderMode) {
 	// for it.
 	const attempts = 2
 	var elapsed time.Duration
+	var spikedTun *Tunnel
 	for attempt := 1; attempt <= attempts; attempt++ {
 		// A fresh Setup spawns a brand-new sender process, which is
 		// what makes the token cold again. Each Setup registers its own
@@ -478,8 +505,17 @@ func runColdStartConnectLatency(t *testing.T, b Backend, mode SenderMode) {
 		}
 		if elapsed < threshold {
 			t.Logf("ConnectLatency_ColdStart_%v: %v (< %v) [attempt %d/%d]", mode, elapsed, threshold, attempt, attempts)
+			// If an earlier attempt spiked but this one recovered, the
+			// scenario passes and the failure dump never fires — so
+			// surface the spiked attempt's rendezvous trace (resp_wait)
+			// for phase analysis, mirroring the serial scenario.
+			if spikedTun != nil {
+				t.Logf("ConnectLatency_ColdStart_%v: recovered after a tolerated spike; dumping the spiked attempt's rendezvous trace for phase analysis", mode)
+				dumpTunnelLogs(t, spikedTun)
+			}
 			return
 		}
+		spikedTun = tun
 		t.Logf("ConnectLatency_ColdStart_%v: attempt %d/%d spiked at %v (>= %v)", mode, attempt, attempts, elapsed, threshold)
 	}
 	t.Errorf("cold-start connect latency %v >= threshold %v on all %d attempts", elapsed, threshold, attempts)

--- a/e2e/scenarios/performance.go
+++ b/e2e/scenarios/performance.go
@@ -439,16 +439,23 @@ func ScenarioConnectLatency_ColdStart_SOCKS5(t *testing.T, b Backend) {
 }
 
 // runColdStartConnectLatency is the shared implementation of the
-// two ConnectLatency_ColdStart variants. It builds a fresh topology,
-// performs exactly one timed dial through the cold sender, and
-// asserts the elapsed time is below b.ColdStartLatencyThreshold().
+// two ConnectLatency_ColdStart variants. It builds a fresh topology
+// and times a cold-sender dial, asserting the elapsed time is below
+// b.ColdStartLatencyThreshold(). To absorb isolated Azure Relay
+// rendezvous spikes (independent of aztunnel) it uses a best-of-2
+// attempt loop: each attempt spawns a brand-new sender process (still
+// a cold token) and the scenario passes if either attempt is under
+// threshold. On a passing run where an earlier attempt spiked, the
+// spiked attempt's rendezvous trace is dumped for phase analysis.
 //
 // Unlike runSerialConnectLatency, no warm-up dial precedes the
 // measurement — measuring the cold-start cost is the whole point.
-// The dial timeout and connection deadline both use
-// threshold + connectSlack so a regression surfaces as the explicit
-// elapsed >= threshold assertion rather than as an i/o timeout from
-// the deadline firing exactly at the threshold.
+// The per-dial deadline budget is decoupled from the assertion
+// threshold (deadlineBudget = threshold + SpikeCeiling, plus
+// connectSlack inside timeOneConnect) so a tolerable spike returns a
+// measured over-threshold sample for the retry instead of a fatal i/o
+// timeout, while a genuine regression still surfaces as the explicit
+// elapsed >= threshold assertion.
 func runColdStartConnectLatency(t *testing.T, b Backend, mode SenderMode) {
 	t.Helper()
 	threshold := b.ColdStartLatencyThreshold()

--- a/e2e/scenarios/performance_test.go
+++ b/e2e/scenarios/performance_test.go
@@ -1,6 +1,7 @@
 package scenarios
 
 import (
+	"strings"
 	"sync/atomic"
 	"testing"
 )
@@ -26,6 +27,47 @@ func tunnelWithLogCounters(senderCalls, listenerCalls *atomic.Int32) *Tunnel {
 func TestDumpTunnelLogs(t *testing.T) {
 	var senderCalls, listenerCalls atomic.Int32
 	dumpTunnelLogs(t, tunnelWithLogCounters(&senderCalls, &listenerCalls))
+	if got := senderCalls.Load(); got != 1 {
+		t.Errorf("sender Logs called %d times, want 1", got)
+	}
+	if got := listenerCalls.Load(); got != 1 {
+		t.Errorf("listener Logs called %d times, want 1", got)
+	}
+}
+
+// TestFilterTraceLines keeps only the rendezvous-trace lines (both the
+// relay and accept variants, including "(dial failed)") and drops
+// everything else, returning "" when none match.
+func TestFilterTraceLines(t *testing.T) {
+	in := strings.Join([]string{
+		`time=... level=DEBUG msg="dialing relay" bridge_id=A`,
+		`time=... level=DEBUG msg="relay rendezvous trace" bridge_id=A resp_wait=300ms`,
+		`time=... level=DEBUG msg="relay connected" bridge_id=A`,
+		`time=... level=DEBUG msg="accept rendezvous trace" bridge_id=A resp_wait=6.7s`,
+		`time=... level=DEBUG msg="relay rendezvous trace (dial failed)" bridge_id=B`,
+		`time=... level=INFO msg="something else"`,
+	}, "\n")
+	got := filterTraceLines(in)
+	want := strings.Join([]string{
+		`time=... level=DEBUG msg="relay rendezvous trace" bridge_id=A resp_wait=300ms`,
+		`time=... level=DEBUG msg="accept rendezvous trace" bridge_id=A resp_wait=6.7s`,
+		`time=... level=DEBUG msg="relay rendezvous trace (dial failed)" bridge_id=B`,
+	}, "\n")
+	if got != want {
+		t.Errorf("filterTraceLines:\n got=%q\nwant=%q", got, want)
+	}
+	if got := filterTraceLines("no traces here\njust noise"); got != "" {
+		t.Errorf("filterTraceLines(no matches) = %q, want empty", got)
+	}
+}
+
+// TestDumpTunnelRendezvousTraces verifies the lean dump reads each
+// non-nil accessor exactly once and tolerates nil handles / accessors.
+// (It emits only the trace lines; the filtering itself is covered by
+// TestFilterTraceLines.)
+func TestDumpTunnelRendezvousTraces(t *testing.T) {
+	var senderCalls, listenerCalls atomic.Int32
+	dumpTunnelRendezvousTraces(t, tunnelWithLogCounters(&senderCalls, &listenerCalls))
 	if got := senderCalls.Load(); got != 1 {
 		t.Errorf("sender Logs called %d times, want 1", got)
 	}

--- a/internal/relay/control.go
+++ b/internal/relay/control.go
@@ -367,15 +367,21 @@ func handleAccept(ctx context.Context, addr string, cfg ControlConfig, logger *s
 	logger.Debug("accept dial started")
 	dialCtx, dialCancel := context.WithTimeout(ctx, cfg.DialTimeout)
 	defer dialCancel()
+	var trace *dialTrace
+	if logger.Enabled(ctx, slog.LevelDebug) {
+		dialCtx, trace = newDialTrace(dialCtx, time.Now())
+	}
 	ws, resp, err := websocket.Dial(dialCtx, addr, cfg.Options.dialOptions())
 	if err != nil {
 		reason := AcceptDroppedDialFailed
+		trace.log(ctx, logger, "accept rendezvous trace (dial failed)")
 		if dialAuthFailed(resp) {
 			reason = AcceptDroppedAuthFailed
 		}
 		logger.Warn(EventAcceptDropped, "reason", reason, "error", sanitizeErr(err))
 		return
 	}
+	trace.log(ctx, logger, "accept rendezvous trace")
 	logger.Debug("accept dial complete", "ok", true)
 	defer func() { _ = ws.CloseNow() }()
 

--- a/internal/relay/dial.go
+++ b/internal/relay/dial.go
@@ -68,13 +68,23 @@ func DialWithRetry(ctx context.Context, endpoint, entityPath string, tp TokenPro
 			opts.wssBase(endpoint), url.PathEscape(entityPath), url.QueryEscape(token))
 
 		dialCtx, cancel := context.WithTimeout(ctx, defaultDialTimeout)
+		var trace *dialTrace
+		if logger.Enabled(ctx, slog.LevelDebug) {
+			dialCtx, trace = newDialTrace(dialCtx, time.Now())
+		}
 		ws, resp, dialErr := websocket.Dial(dialCtx, connectURL, opts.dialOptions())
 		cancel()
 
 		if dialErr == nil {
+			trace.log(ctx, logger, "relay rendezvous trace")
 			logger.Debug("relay connected", "entityPath", entityPath)
 			return ws, nil
 		}
+
+		// Emit the trace on failure too: a dial that exceeded its
+		// deadline or failed before the HTTP 101 is exactly when the
+		// phase split (local dial time vs relay hold) is most useful.
+		trace.log(ctx, logger, "relay rendezvous trace (dial failed)")
 
 		// Only retry on 404/503 (no active listener / listener transitioning).
 		if resp == nil || !IsRetryableStatus(resp.StatusCode) {

--- a/internal/relay/dialtrace.go
+++ b/internal/relay/dialtrace.go
@@ -38,7 +38,6 @@ import (
 // rendezvous to the relay; a large tls localises it to the sender's
 // cold dial.
 type dialTrace struct {
-	start        time.Time
 	dnsStart     atomic.Int64
 	dnsDone      atomic.Int64
 	connectStart atomic.Int64
@@ -47,6 +46,7 @@ type dialTrace struct {
 	tlsDone      atomic.Int64
 	reqWritten   atomic.Int64
 	firstByte    atomic.Int64
+	gotConn      atomic.Bool
 	reused       atomic.Bool
 }
 
@@ -55,7 +55,7 @@ type dialTrace struct {
 // read once the dial returns. start should be captured immediately
 // before the dial so all deltas are relative to it.
 func newDialTrace(ctx context.Context, start time.Time) (context.Context, *dialTrace) {
-	dt := &dialTrace{start: start}
+	dt := &dialTrace{}
 	since := func() int64 { return int64(time.Since(start)) }
 	trace := &httptrace.ClientTrace{
 		DNSStart:     func(httptrace.DNSStartInfo) { dt.dnsStart.CompareAndSwap(0, since()) },
@@ -77,7 +77,7 @@ func newDialTrace(ctx context.Context, start time.Time) (context.Context, *dialT
 		},
 		WroteRequest:         func(httptrace.WroteRequestInfo) { dt.reqWritten.Store(since()) },
 		GotFirstResponseByte: func() { dt.firstByte.CompareAndSwap(0, since()) },
-		GotConn:              func(info httptrace.GotConnInfo) { dt.reused.Store(info.Reused) },
+		GotConn:              func(info httptrace.GotConnInfo) { dt.gotConn.Store(true); dt.reused.Store(info.Reused) },
 	}
 	return httptrace.WithClientTrace(ctx, trace), dt
 }
@@ -114,6 +114,11 @@ func (dt *dialTrace) log(ctx context.Context, logger *slog.Logger, msg string) {
 	if req, fb := dt.reqWritten.Load(), dt.firstByte.Load(); req > 0 && fb >= req {
 		attrs = append(attrs, slog.Duration("resp_wait", time.Duration(fb-req)))
 	}
-	attrs = append(attrs, slog.Bool("reused", dt.reused.Load()))
+	// reused is only meaningful when the GotConn hook actually fired;
+	// omit it otherwise so a partial trace (no hooks ran) doesn't
+	// misreport a fresh dial as a reused connection.
+	if dt.gotConn.Load() {
+		attrs = append(attrs, slog.Bool("reused", dt.reused.Load()))
+	}
 	logger.Debug(msg, attrs...)
 }

--- a/internal/relay/dialtrace.go
+++ b/internal/relay/dialtrace.go
@@ -1,0 +1,119 @@
+package relay
+
+import (
+	"context"
+	"crypto/tls"
+	"log/slog"
+	"net/http/httptrace"
+	"sync/atomic"
+	"time"
+)
+
+// dialTrace captures coarse timing of a single rendezvous WebSocket
+// dial's HTTP setup via net/http/httptrace. Each field stores the
+// nanoseconds elapsed since the dial's start at the moment the
+// corresponding hook fires. The hooks run on net/http's transport
+// goroutines, so the fields are accessed atomically.
+//
+// Capture is deliberately best-effort: a hook that never fires (e.g.
+// because a pooled connection was reused, or because the websocket
+// library's context propagation changed) leaves its field at zero and
+// the corresponding phase is simply omitted from the log line. The
+// trace records only durations — never the dial URL, query string, or
+// token, since the sender connect URL embeds an SAS token.
+//
+// Under Happy Eyeballs (dual-stack dialing) ConnectStart/ConnectDone
+// fire once per attempted address; connectStart keeps the first fire
+// and connectDone keeps the successful one, so the reported tcp span is
+// "first-attempt start → successful-attempt done" and can overstate
+// real TCP setup by the Happy Eyeballs fallback delay. This is a
+// diagnostic-only line, never an assertion input, so the slack is
+// acceptable.
+//
+// The split it enables: for an Azure Relay rendezvous the relay holds
+// the HTTP 101 until the listener has rendezvoused, so reqWritten marks
+// the end of the sender's own DNS/TCP/TLS/WS-GET work ("Phase 2") and
+// respWait = firstByte - reqWritten is the relay-side hold ("Phase 3"
+// onward). A large respWait with small reqWritten localises a slow
+// rendezvous to the relay; a large tls localises it to the sender's
+// cold dial.
+type dialTrace struct {
+	start        time.Time
+	dnsStart     atomic.Int64
+	dnsDone      atomic.Int64
+	connectStart atomic.Int64
+	connectDone  atomic.Int64
+	tlsStart     atomic.Int64
+	tlsDone      atomic.Int64
+	reqWritten   atomic.Int64
+	firstByte    atomic.Int64
+	reused       atomic.Bool
+}
+
+// newDialTrace attaches an httptrace.ClientTrace to ctx and returns the
+// derived context to pass into websocket.Dial along with the trace to
+// read once the dial returns. start should be captured immediately
+// before the dial so all deltas are relative to it.
+func newDialTrace(ctx context.Context, start time.Time) (context.Context, *dialTrace) {
+	dt := &dialTrace{start: start}
+	since := func() int64 { return int64(time.Since(start)) }
+	trace := &httptrace.ClientTrace{
+		DNSStart:     func(httptrace.DNSStartInfo) { dt.dnsStart.CompareAndSwap(0, since()) },
+		DNSDone:      func(httptrace.DNSDoneInfo) { dt.dnsDone.Store(since()) },
+		ConnectStart: func(_, _ string) { dt.connectStart.CompareAndSwap(0, since()) },
+		// Under Happy Eyeballs ConnectDone fires once per attempted
+		// address; record the successful one so connect timing reflects
+		// the connection actually used.
+		ConnectDone: func(_, _ string, err error) {
+			if err == nil {
+				dt.connectDone.Store(since())
+			}
+		},
+		TLSHandshakeStart: func() { dt.tlsStart.CompareAndSwap(0, since()) },
+		TLSHandshakeDone: func(_ tls.ConnectionState, err error) {
+			if err == nil {
+				dt.tlsDone.Store(since())
+			}
+		},
+		WroteRequest:         func(httptrace.WroteRequestInfo) { dt.reqWritten.Store(since()) },
+		GotFirstResponseByte: func() { dt.firstByte.CompareAndSwap(0, since()) },
+		GotConn:              func(info httptrace.GotConnInfo) { dt.reused.Store(info.Reused) },
+	}
+	return httptrace.WithClientTrace(ctx, trace), dt
+}
+
+// log emits a single DEBUG line with the per-phase rendezvous timings.
+// Phase durations are only included when both of their bounding hooks
+// fired; cumulative marks (req_written, first_byte) are included when
+// present. The caller is expected to have already gated on DEBUG (the
+// trace is only attached when DEBUG is enabled), but log re-checks so
+// it is safe to call unconditionally.
+func (dt *dialTrace) log(ctx context.Context, logger *slog.Logger, msg string) {
+	if dt == nil || logger == nil || !logger.Enabled(ctx, slog.LevelDebug) {
+		return
+	}
+	attrs := make([]any, 0, 8)
+	span := func(name string, s, d int64) {
+		if s > 0 && d >= s {
+			attrs = append(attrs, slog.Duration(name, time.Duration(d-s)))
+		}
+	}
+	mark := func(name string, t int64) {
+		if t > 0 {
+			attrs = append(attrs, slog.Duration(name, time.Duration(t)))
+		}
+	}
+	span("dns", dt.dnsStart.Load(), dt.dnsDone.Load())
+	span("tcp", dt.connectStart.Load(), dt.connectDone.Load())
+	span("tls", dt.tlsStart.Load(), dt.tlsDone.Load())
+	mark("req_written", dt.reqWritten.Load())
+	mark("first_byte", dt.firstByte.Load())
+	// resp_wait is the gap between the request being fully written and
+	// the first response byte — for an Azure Relay rendezvous this is
+	// the relay holding the 101 (accept dispatch + listener rendezvous).
+	if req, fb := dt.reqWritten.Load(), dt.firstByte.Load(); req > 0 && fb >= req {
+		attrs = append(attrs, slog.Duration("resp_wait", time.Duration(fb-req)))
+	}
+	attrs = append(attrs, slog.Bool("reused", dt.reused.Load()))
+	logger.Debug(msg, attrs...)
+}

--- a/mockrelay/README.md
+++ b/mockrelay/README.md
@@ -134,8 +134,9 @@ aztunnel relay-listener \
 ```
 
 > Reminder: this is still a mock. Real production deployments need real
-> authentication; the SAS validation here only proves the client knows
-> a fixed dummy key.
+> authentication; the token validation here only proves the client
+> knows a fixed dummy key (SAS) or holds a JWT this mock itself signed
+> with that key (the fake Entra path) — neither is real identity.
 
 ## CLI flags
 
@@ -218,10 +219,14 @@ ports.
 This is a test fixture, not a production relay — file issues if you
 need any of the following:
 
-- **SAS validation only.** The relay accepts any SAS token signed with
-  the configured key (default: a hard-coded dev key). It does NOT check
-  the audience (`sr`) against the request URL, so a token signed for
-  one entity is accepted for any entity. Anyone who can reach the
+- **Dummy-key auth only.** The relay accepts any SAS token signed with
+  the configured key (default: a hard-coded dev key), OR a JWT-shaped
+  bearer token it can verify with that same key via HS256 — a stand-in
+  for the Entra (OAuth2) path that lets the mock model the per-request
+  Entra validation cost. It is NOT real Entra validation (no RS256, no
+  AAD signing keys, no issuer/audience/scope checks). It also does NOT
+  check the audience (`sr`) against the request URL, so a token signed
+  for one entity is accepted for any entity. Anyone who can reach the
   relay's TCP port AND knows the key can listen or send for any entity.
   Rendezvous URLs carry a 128-bit random ID with a short timeout (30s
   default), but they are not cryptographically bound to a particular

--- a/mockrelay/server/auth.go
+++ b/mockrelay/server/auth.go
@@ -4,6 +4,7 @@ import (
 	"crypto/hmac"
 	"crypto/sha256"
 	"encoding/base64"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -98,4 +99,161 @@ func signSAS(encodedURI string, expiry int64, key string) string {
 	mac := hmac.New(sha256.New, []byte(key))
 	mac.Write([]byte(str))
 	return base64.StdEncoding.EncodeToString(mac.Sum(nil))
+}
+
+// authKind classifies an inbound sb-hc-token by shape so the relay can
+// charge the right validation cost and run the right validator. The
+// real Azure Relay accepts either a SAS token or an Entra (OAuth2 JWT)
+// bearer token in the same slot; aztunnel sends whichever the
+// configured auth method produced (see internal/relay/dial.go).
+//
+// Classification is by shape, not by trying each validator:
+//   - a "SharedAccessSignature " prefix => authSAS;
+//   - else a JWT shape (three non-empty dot-separated parts, first
+//     starting "eyJ") => authEntra;
+//   - else => authSAS (fallback).
+//
+// The SAS fallback for unrecognised tokens is deliberate: missing,
+// truncated, or garbage tokens flow down the SAS validator, which
+// rejects them with 401 and charges AuthInternal — preserving the
+// pre-existing auth-failure timing and the malformed-token behaviour
+// exercised by auth_test.go. The heuristic is a test-fixture
+// convenience, not a security boundary; it can misclassify a SAS token
+// that happens to be JWT-shaped, which cannot occur for tokens this
+// mock actually receives.
+type authMethod int
+
+const (
+	authSAS authMethod = iota
+	authEntra
+)
+
+func authKind(tok string) authMethod {
+	if strings.HasPrefix(tok, "SharedAccessSignature ") {
+		return authSAS
+	}
+	if looksLikeJWT(tok) {
+		return authEntra
+	}
+	return authSAS
+}
+
+// looksLikeJWT reports whether tok has the compact-JWS shape: exactly
+// three non-empty dot-separated segments with the first beginning
+// "eyJ" (base64url of '{"'). It does not validate the signature — that
+// is validateBearer's job.
+func looksLikeJWT(tok string) bool {
+	if !strings.HasPrefix(tok, "eyJ") {
+		return false
+	}
+	parts := strings.Split(tok, ".")
+	if len(parts) != 3 {
+		return false
+	}
+	for _, p := range parts {
+		if p == "" {
+			return false
+		}
+	}
+	return true
+}
+
+// validateBearer verifies a fake Entra JWT minted by MintFakeBearerToken:
+// an HS256 compact JWS signed with the relay's SAS key, with a payload
+// carrying a future "exp". This is NOT how the real Azure Relay validates
+// Entra tokens (RS256 against AAD signing keys with issuer/audience
+// checks); it is a self-contained stand-in so the mock can model the
+// Entra path end-to-end without a real directory.
+//
+// Steps: split header.payload.signature; recompute HMAC-SHA256 over
+// "header.payload" with cfg.SASKey (constant-time compare); base64url-
+// decode the payload and require exp > now. Returns nil on success.
+// Like validateSAS, the error MUST NOT be echoed to the client.
+func (s *Server) validateBearer(r *http.Request) error {
+	if s.cfg.SkipAuth {
+		return nil
+	}
+	tok := r.URL.Query().Get("sb-hc-token")
+	if tok == "" {
+		return fmt.Errorf("missing sb-hc-token")
+	}
+	parts := strings.Split(tok, ".")
+	if len(parts) != 3 {
+		return fmt.Errorf("malformed JWT")
+	}
+	signingInput := parts[0] + "." + parts[1]
+	expected := signHS256(signingInput, s.cfg.SASKey)
+	if !hmac.Equal([]byte(expected), []byte(parts[2])) {
+		return fmt.Errorf("signature mismatch")
+	}
+	payloadJSON, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		return fmt.Errorf("decode payload: %w", err)
+	}
+	var claims struct {
+		Exp int64 `json:"exp"`
+	}
+	if err := json.Unmarshal(payloadJSON, &claims); err != nil {
+		return fmt.Errorf("parse claims: %w", err)
+	}
+	if claims.Exp == 0 {
+		return fmt.Errorf("missing exp")
+	}
+	if time.Now().Unix() >= claims.Exp {
+		return fmt.Errorf("token expired")
+	}
+	return nil
+}
+
+// signHS256 computes the base64url (unpadded) HMAC-SHA256 of
+// signingInput under key, i.e. the signature segment of an HS256
+// compact JWS.
+func signHS256(signingInput, key string) string {
+	mac := hmac.New(sha256.New, []byte(key))
+	mac.Write([]byte(signingInput))
+	return base64.RawURLEncoding.EncodeToString(mac.Sum(nil))
+}
+
+// MintFakeBearerToken produces a fake Entra bearer token that
+// validateBearer accepts: an HS256 compact JWS signed with key, whose
+// payload carries an exp ttl into the future. It is exported so the e2e
+// mock's fake Entra credential can mint tokens the mock relay will
+// validate as Entra (charging EntraValidate). The token is NOT a real
+// AAD token and is meaningless outside this mock.
+func MintFakeBearerToken(key string, ttl time.Duration) (string, error) {
+	header := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"HS256","typ":"JWT"}`))
+	exp := time.Now().Add(ttl).Unix()
+	payloadJSON, err := json.Marshal(struct {
+		Exp int64  `json:"exp"`
+		Aud string `json:"aud"`
+	}{Exp: exp, Aud: "https://relay.azure.net/.default"})
+	if err != nil {
+		return "", fmt.Errorf("marshal claims: %w", err)
+	}
+	payload := base64.RawURLEncoding.EncodeToString(payloadJSON)
+	signingInput := header + "." + payload
+	return signingInput + "." + signHS256(signingInput, key), nil
+}
+
+// authCost returns the relay-side token-validation delay to charge for
+// this request, chosen by the inbound token's shape: EntraValidate on
+// the Entra (JWT) path, AuthInternal on the SAS path. Exactly one
+// applies per token-bearing leg (see DelayProfile.EntraValidate).
+func (s *Server) authCost(r *http.Request) time.Duration {
+	if authKind(r.URL.Query().Get("sb-hc-token")) == authEntra {
+		return s.delayProfile.EntraValidate
+	}
+	return s.delayProfile.AuthInternal
+}
+
+// validateToken dispatches to the validator matching the inbound
+// token's shape (validateBearer for Entra JWTs, validateSAS otherwise),
+// so handleListen and handleConnect accept either auth method. As with
+// the underlying validators, callers MUST emit a generic 401 reason and
+// not echo the returned error.
+func (s *Server) validateToken(r *http.Request) error {
+	if authKind(r.URL.Query().Get("sb-hc-token")) == authEntra {
+		return s.validateBearer(r)
+	}
+	return s.validateSAS(r)
 }

--- a/mockrelay/server/bearer_test.go
+++ b/mockrelay/server/bearer_test.go
@@ -1,0 +1,244 @@
+package server
+
+import (
+	"context"
+	"encoding/base64"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/coder/websocket"
+	"github.com/philsphicas/aztunnel/internal/relay"
+)
+
+// TestAuthKind covers the token-shape classifier the relay uses to pick
+// the validation cost + validator. SAS-prefixed tokens are SAS;
+// JWT-shaped tokens are Entra; everything else (missing, truncated,
+// garbage) falls back to SAS so it lands on the SAS 401 path.
+func TestAuthKind(t *testing.T) {
+	jwt, err := MintFakeBearerToken(DefaultSASKey, time.Minute)
+	if err != nil {
+		t.Fatalf("MintFakeBearerToken: %v", err)
+	}
+	cases := []struct {
+		name string
+		tok  string
+		want authMethod
+	}{
+		{"sas prefix", "SharedAccessSignature sr=x&sig=y&se=1&skn=dev", authSAS},
+		{"real jwt", jwt, authEntra},
+		{"minimal jwt shape", "eyJ.a.b", authEntra},
+		{"empty", "", authSAS},
+		{"garbage", "not-a-token", authSAS},
+		{"bearer prefixed jwt", "Bearer " + jwt, authSAS},
+		{"jwt two parts", "eyJ.a", authSAS},
+		{"jwt empty segment", "eyJ..b", authSAS},
+		{"jwt wrong magic", "abc.def.ghi", authSAS},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := authKind(c.tok); got != c.want {
+				t.Errorf("authKind(%q) = %v, want %v", c.tok, got, c.want)
+			}
+		})
+	}
+}
+
+// TestValidateBearer covers the fake-Entra JWT validator directly:
+// a freshly minted token validates; a token signed with the wrong key,
+// an expired token, and a structurally malformed token are all
+// rejected.
+func TestValidateBearer(t *testing.T) {
+	s := makeServer(t, Config{})
+
+	good, err := MintFakeBearerToken(DefaultSASKey, time.Minute)
+	if err != nil {
+		t.Fatalf("mint good: %v", err)
+	}
+	wrongKey, err := MintFakeBearerToken("some-other-key", time.Minute)
+	if err != nil {
+		t.Fatalf("mint wrongKey: %v", err)
+	}
+	expired, err := MintFakeBearerToken(DefaultSASKey, -time.Minute)
+	if err != nil {
+		t.Fatalf("mint expired: %v", err)
+	}
+	// A JWT whose payload has no exp claim must be rejected.
+	hdr := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"HS256","typ":"JWT"}`))
+	noExpPayload := base64.RawURLEncoding.EncodeToString([]byte(`{"aud":"x"}`))
+	noExp := hdr + "." + noExpPayload + "." + signHS256(hdr+"."+noExpPayload, DefaultSASKey)
+
+	cases := []struct {
+		name    string
+		tok     string
+		wantErr bool
+	}{
+		{"valid", good, false},
+		{"wrong key", wrongKey, true},
+		{"expired", expired, true},
+		{"missing exp", noExp, true},
+		{"two parts", "eyJ.a", true},
+		{"empty", "", true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			r := httptest.NewRequest(http.MethodGet,
+				"http://relay/$hc/foo?sb-hc-token="+url.QueryEscape(c.tok), nil)
+			err := s.validateBearer(r)
+			if (err != nil) != c.wantErr {
+				t.Errorf("validateBearer(%q) err = %v, wantErr = %v", c.tok, err, c.wantErr)
+			}
+		})
+	}
+}
+
+// TestValidateToken_AcceptsEntraJWT confirms an end-to-end request
+// carrying a valid Entra JWT gets past auth on the connect path (404
+// "no listener" rather than 401), proving validateToken dispatched to
+// the bearer validator.
+func TestValidateToken_AcceptsEntraJWT(t *testing.T) {
+	s := makeServer(t, Config{})
+	srv := httptest.NewServer(s.Handler())
+	defer srv.Close()
+
+	tok, err := MintFakeBearerToken(DefaultSASKey, time.Minute)
+	if err != nil {
+		t.Fatalf("MintFakeBearerToken: %v", err)
+	}
+	resp, err := http.Get(srv.URL + "/$hc/foo?sb-hc-action=connect&sb-hc-token=" + url.QueryEscape(tok))
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close() //nolint:errcheck
+	if resp.StatusCode != http.StatusNotFound {
+		t.Errorf("status = %d, want 404 (entra auth passed; no listener)", resp.StatusCode)
+	}
+}
+
+// TestValidateToken_EntraEdgeCases pins the sniff-heuristic boundaries
+// at the HTTP layer: a JWT-shaped token with a bad signature is routed
+// to the bearer validator and rejected (401), and a "Bearer <jwt>"
+// token (space prefix, not JWT-shaped) falls back to the SAS validator
+// and is also rejected (401). Neither must slip through.
+func TestValidateToken_EntraEdgeCases(t *testing.T) {
+	s := makeServer(t, Config{})
+	srv := httptest.NewServer(s.Handler())
+	defer srv.Close()
+
+	jwt, err := MintFakeBearerToken(DefaultSASKey, time.Minute)
+	if err != nil {
+		t.Fatalf("MintFakeBearerToken: %v", err)
+	}
+	for _, tok := range []string{
+		"eyJ.a.b",       // JWT-shaped, bad signature -> bearer path -> 401
+		"Bearer " + jwt, // not JWT-shaped -> SAS fallback -> 401
+	} {
+		resp, err := http.Get(srv.URL + "/$hc/foo?sb-hc-action=connect&sb-hc-token=" + url.QueryEscape(tok))
+		if err != nil {
+			t.Fatalf("GET %q: %v", tok, err)
+		}
+		_ = resp.Body.Close()
+		if resp.StatusCode != http.StatusUnauthorized {
+			t.Errorf("token=%q status=%d, want 401", tok, resp.StatusCode)
+		}
+	}
+}
+
+// TestDelayProfile_EntraPathPaysEntraValidate asserts the relay charges
+// EntraValidate (not AuthInternal) when the inbound token is an Entra
+// JWT, on BOTH the listener (handleListen) and sender (handleConnect)
+// legs — and that a SAS token on the same handler pays only the much
+// smaller AuthInternal. The profile sets EntraValidate >> AuthInternal
+// so the two paths are wall-clock distinguishable.
+func TestDelayProfile_EntraPathPaysEntraValidate(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping wall-clock DelayProfile test in -short mode")
+	}
+	p := DelayProfile{
+		SLatency:          5 * time.Millisecond,
+		LLatency:          5 * time.Millisecond,
+		DNSLookup:         5 * time.Millisecond,
+		AuthInternal:      5 * time.Millisecond,
+		EntraValidate:     200 * time.Millisecond,
+		MatchMakeInternal: 5 * time.Millisecond,
+	}
+	s, err := NewServerForTesting(Config{
+		Logger:            slog.New(slog.NewTextHandler(io.Discard, nil)),
+		SkipAuth:          false,
+		RendezvousTimeout: 30 * time.Second,
+	}, WithDelayProfile(p))
+	if err != nil {
+		t.Fatalf("NewServerForTesting: %v", err)
+	}
+	srv := httptest.NewServer(s.Handler())
+	defer srv.Close()
+
+	jwt, err := MintFakeBearerToken(DefaultSASKey, time.Minute)
+	if err != nil {
+		t.Fatalf("MintFakeBearerToken: %v", err)
+	}
+	sas, err := relay.GenerateSASToken(
+		relay.ResourceURI("relay.example.com", "foo"),
+		DefaultSASKeyName, DefaultSASKey, time.Minute,
+	)
+	if err != nil {
+		t.Fatalf("GenerateSASToken: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	// Listener leg: a valid JWT listen reaches a 101 upgrade, so it pays
+	// the full listener lane plus EntraValidate.
+	listenEntra := p.DNSLookup +
+		(hopsHandshake+hopsWSGet+hopsResponse)*p.LLatency + p.EntraValidate
+	start := time.Now()
+	lws, _, err := websocket.Dial(ctx,
+		wsURLOf(srv.URL)+"/$hc/foo?sb-hc-action=listen&sb-hc-token="+url.QueryEscape(jwt), nil)
+	listenElapsed := time.Since(start)
+	if err != nil {
+		t.Fatalf("listen with JWT: %v", err)
+	}
+	_ = lws.CloseNow()
+	withinTolerance(t, "entra listen lane", listenElapsed, listenEntra, listenEntra+500*time.Millisecond)
+
+	// Sender leg (no listener registered): a valid JWT connect pays
+	// EntraValidate + matchmake before the 404, so its lower bound
+	// includes EntraValidate.
+	connectEntraLower := p.DNSLookup + (hopsHandshake+hopsWSGet)*p.SLatency + p.EntraValidate
+	start = time.Now()
+	resp, err := http.Get(srv.URL + "/$hc/bar?sb-hc-action=connect&sb-hc-token=" + url.QueryEscape(jwt))
+	connectElapsed := time.Since(start)
+	if err != nil {
+		t.Fatalf("connect with JWT: %v", err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("connect status = %d, want 404", resp.StatusCode)
+	}
+	if connectElapsed < connectEntraLower {
+		t.Errorf("entra connect elapsed %v < lower bound %v (EntraValidate not charged)",
+			connectElapsed, connectEntraLower)
+	}
+
+	// SAS leg on the same handler must NOT pay EntraValidate: a valid
+	// SAS connect returns 404 well under the EntraValidate floor.
+	start = time.Now()
+	resp, err = http.Get(srv.URL + "/$hc/baz?sb-hc-action=connect&sb-hc-token=" + url.QueryEscape(sas))
+	sasElapsed := time.Since(start)
+	if err != nil {
+		t.Fatalf("connect with SAS: %v", err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("sas connect status = %d, want 404", resp.StatusCode)
+	}
+	if sasElapsed >= p.EntraValidate {
+		t.Errorf("sas connect elapsed %v >= EntraValidate %v (SAS path wrongly charged EntraValidate)",
+			sasElapsed, p.EntraValidate)
+	}
+}

--- a/mockrelay/server/bearer_test.go
+++ b/mockrelay/server/bearer_test.go
@@ -225,8 +225,13 @@ func TestDelayProfile_EntraPathPaysEntraValidate(t *testing.T) {
 			connectElapsed, connectEntraLower)
 	}
 
-	// SAS leg on the same handler must NOT pay EntraValidate: a valid
-	// SAS connect returns 404 well under the EntraValidate floor.
+	// SAS leg on the same handler must NOT pay EntraValidate. It runs
+	// the identical connect-leg 404 path as the Entra connect above, so
+	// the only modeled difference is EntraValidate (Entra) vs
+	// AuthInternal (SAS). Assert relatively: the SAS leg must be faster
+	// than the Entra leg by most of that gap. A relative delta cancels
+	// the shared per-request overhead, so it stays robust under CI load
+	// where an absolute floor on sasElapsed could spuriously trip.
 	start = time.Now()
 	resp, err = http.Get(srv.URL + "/$hc/baz?sb-hc-action=connect&sb-hc-token=" + url.QueryEscape(sas))
 	sasElapsed := time.Since(start)
@@ -237,8 +242,10 @@ func TestDelayProfile_EntraPathPaysEntraValidate(t *testing.T) {
 	if resp.StatusCode != http.StatusNotFound {
 		t.Fatalf("sas connect status = %d, want 404", resp.StatusCode)
 	}
-	if sasElapsed >= p.EntraValidate {
-		t.Errorf("sas connect elapsed %v >= EntraValidate %v (SAS path wrongly charged EntraValidate)",
-			sasElapsed, p.EntraValidate)
+	savedBySAS := connectElapsed - sasElapsed
+	minSaving := (p.EntraValidate - p.AuthInternal) / 2
+	if savedBySAS < minSaving {
+		t.Errorf("sas connect (%v) was only %v faster than entra connect (%v); want >= %v saved (SAS path wrongly charged EntraValidate)",
+			sasElapsed, savedBySAS, connectElapsed, minSaving)
 	}
 }

--- a/mockrelay/server/control.go
+++ b/mockrelay/server/control.go
@@ -59,10 +59,11 @@ func (c *controlSession) writeJSON(ctx context.Context, msg interface{}) error {
 // context.WithTimeout did not.
 //
 // DelayProfile timing: handleListen models the wire as DNS lookup +
-// hopsHandshake legs + hopsWSGet leg before the listener's SAS token
-// arrives at the relay; then AuthInternal for token validation; then
-// hopsResponse leg for the 101 (or error) reply. All sleeps honor the
-// request context so server shutdown is not blocked.
+// hopsHandshake legs + hopsWSGet leg before the listener's token
+// arrives at the relay; then the auth-validation cost (AuthInternal for
+// SAS, EntraValidate for Entra) for token validation; then hopsResponse
+// leg for the 101 (or error) reply. All sleeps honor the request
+// context so server shutdown is not blocked.
 func (s *Server) handleListen(w http.ResponseWriter, r *http.Request, entity string) {
 	ctx := r.Context()
 	p := s.delayProfile
@@ -72,12 +73,13 @@ func (s *Server) handleListen(w http.ResponseWriter, r *http.Request, entity str
 		return
 	}
 	// Relay-side auth cost runs in parallel with the response leg in
-	// the real relay, but we serialise here so AuthInternal is
-	// observable as a separate knob.
-	if !sleepContext(ctx, p.AuthInternal) {
+	// the real relay, but we serialise here so the validation cost is
+	// observable as a separate knob. The cost (and validator) depend on
+	// the token shape: AuthInternal for SAS, EntraValidate for Entra.
+	if !sleepContext(ctx, s.authCost(r)) {
 		return
 	}
-	if err := s.validateSAS(r); err != nil {
+	if err := s.validateToken(r); err != nil {
 		s.log.Warn("listener auth failed", "entity", entity, "remote", r.RemoteAddr, "error", err)
 		_ = sleepContext(ctx, hopsResponse*p.LLatency)
 		http.Error(w, "unauthorized", http.StatusUnauthorized)

--- a/mockrelay/server/delay_profile.go
+++ b/mockrelay/server/delay_profile.go
@@ -28,11 +28,14 @@ import (
 //     net.Dial calls, so every cold WebSocket upgrade (handleListen,
 //     handleConnect, handleAccept) pays a fresh A+AAAA resolution.
 //
-//   - Per-handler relay-internal costs (AuthInternal, MatchMakeInternal).
-//     These model the wedge between the request landing at the relay
-//     and the response being emitted that is NOT explained by lane
-//     transit: SAS-token validation for AuthInternal, listener lookup
-//     plus cross-relay-node dispatch for MatchMakeInternal.
+//   - Per-handler relay-internal costs (AuthInternal, EntraValidate,
+//     MatchMakeInternal). These model the wedge between the request
+//     landing at the relay and the response being emitted that is NOT
+//     explained by lane transit: token validation for AuthInternal
+//     (SAS) / EntraValidate (Entra JWT) — exactly one applies per
+//     token-bearing leg, chosen by the shape of the inbound token — and
+//     listener lookup plus cross-relay-node dispatch for
+//     MatchMakeInternal.
 //
 //   - Client-side credential cost (TokenAcquire). The one-off cold
 //     token-acquisition latency a real aztunnel process pays the first
@@ -67,17 +70,32 @@ type DelayProfile struct {
 	DNSLookup time.Duration
 
 	// AuthInternal models the relay-side cost of SAS-token validation
-	// (token parse + signature check + hub-routing-table lookup).
-	// Applied in handleListen and handleConnect, both of which carry
-	// a sb-hc-token query parameter. NOT applied in handleAccept —
-	// the accept-id is the auth there; no token is present.
+	// (token parse + HMAC signature check + hub-routing-table lookup).
+	// Applied in handleListen and handleConnect when the inbound
+	// sb-hc-token is a SAS token. NOT applied in handleAccept — the
+	// accept-id is the auth there; no token is present. The Entra path
+	// pays EntraValidate instead (never both).
 	AuthInternal time.Duration
+
+	// EntraValidate models the relay-side cost of validating an Entra
+	// (OAuth2 JWT) bearer token: signature/issuer/audience checks plus
+	// any directory introspection. Unlike AuthInternal it is the
+	// per-request cost the real Azure Relay control plane pays on EVERY
+	// token-bearing rendezvous leg under Entra auth — a recurring "warm
+	// tax" distinct from the one-off client-side TokenAcquire below.
+	//
+	// It is applied INSTEAD OF AuthInternal (not in addition) whenever
+	// the inbound sb-hc-token is JWT-shaped rather than a SAS token, in
+	// handleListen and handleConnect. The SAS path never pays it; the
+	// Entra path never pays AuthInternal. The value is the TOTAL Entra
+	// validation cost, not a delta over AuthInternal.
+	EntraValidate time.Duration
 
 	// MatchMakeInternal models the relay-side cost of locating the
 	// listener's control session, RPC-ing to the listener-owning
 	// relay node if needed, and constructing the accept frame to write
 	// onto the listener's control WS. Applied only in handleConnect,
-	// in addition to AuthInternal (the two costs sum in handleConnect
+	// in addition to the auth cost (the two costs sum in handleConnect
 	// because matchmake happens after auth).
 	MatchMakeInternal time.Duration
 
@@ -125,6 +143,7 @@ var DelayProfileDefault = DelayProfile{
 	LLatency:          30 * time.Millisecond,
 	DNSLookup:         40 * time.Millisecond,
 	AuthInternal:      10 * time.Millisecond,
+	EntraValidate:     150 * time.Millisecond,
 	MatchMakeInternal: 50 * time.Millisecond,
 	TokenAcquire:      450 * time.Millisecond,
 }
@@ -132,11 +151,14 @@ var DelayProfileDefault = DelayProfile{
 // Relay-placement profiles model where the sender and listener sit
 // relative to the relay by varying only the per-lane one-way transit
 // (SLatency/LLatency). The placement-independent costs — fresh DNS
-// resolution, SAS validation, and matchmake — are held at the
-// DelayProfileDefault values so the cold-vs-warm spread the perf matrix
-// renders (est ≈ establishment cost) isolates distance alone.
-// TokenAcquire is zero because these profiles are exercised on the SAS
-// path (no AAD round trip); pin E2E_AUTH=sas when sweeping them.
+// resolution, token validation (SAS and Entra), and matchmake — are
+// held at the DelayProfileDefault values so the cold-vs-warm spread the
+// perf matrix renders (est ≈ establishment cost) isolates distance
+// alone. TokenAcquire is left zero: the cold-token premium is an
+// auth-axis concern orthogonal to placement, and these cells are
+// primarily swept on the SAS path (pin E2E_AUTH=sas). EntraValidate is
+// retained at the default so an unpinned E2E_AUTH=entra placement run
+// still models the per-request Entra validation cost correctly.
 //
 // The placement axis is the full sender×listener grid: each client sits
 // at one of three distances from the relay — near (5 ms), mid (35 ms),
@@ -164,16 +186,19 @@ const (
 )
 
 // placementProfile builds a grid cell from a sender/listener lane
-// transit, holding the placement-independent costs (DNS, SAS validation,
-// matchmake) at the DelayProfileDefault values so the cold-vs-warm spread
-// the perf matrix renders isolates distance alone. TokenAcquire is zero:
-// these cells are swept on the SAS path (pin E2E_AUTH=sas).
+// transit, holding the placement-independent costs (DNS, token
+// validation, matchmake) at the DelayProfileDefault values so the
+// cold-vs-warm spread the perf matrix renders isolates distance alone.
+// TokenAcquire is left zero (the cold-token premium is orthogonal to
+// placement); EntraValidate is retained so an E2E_AUTH=entra sweep over
+// these cells still models per-request Entra validation.
 func placementProfile(sender, listener time.Duration) DelayProfile {
 	return DelayProfile{
 		SLatency:          sender,
 		LLatency:          listener,
 		DNSLookup:         DelayProfileDefault.DNSLookup,
 		AuthInternal:      DelayProfileDefault.AuthInternal,
+		EntraValidate:     DelayProfileDefault.EntraValidate,
 		MatchMakeInternal: DelayProfileDefault.MatchMakeInternal,
 	}
 }
@@ -261,19 +286,34 @@ func FunctionalMatrixProfileNames() []string {
 }
 
 // PredictedRendezvous returns the synthetic wall-clock this profile
-// adds to a single cold hyco rendezvous (listener already attached):
-// both fresh DNS lookups, the sender and listener lane transits, the
-// shared response leg, and the relay-internal auth + matchmake costs.
-// It is the synthetic-delay component only — the in-process baseline
-// (~6 ms) is not included. The decomposition follows the hop
-// accounting above; see docs/internals/sequences/ for the wireshark
-// basis. For the zero profile this is zero.
+// adds to a single cold hyco rendezvous (listener already attached) on
+// the SAS auth path: both fresh DNS lookups, the sender and listener
+// lane transits, the shared response leg, and the relay-internal auth
+// (AuthInternal) + matchmake costs. It is the synthetic-delay component
+// only — the in-process baseline (~6 ms) is not included. The
+// decomposition follows the hop accounting above; see
+// docs/internals/sequences/ for the wireshark basis. For the zero
+// profile this is zero. Use PredictedRendezvousFor to predict the Entra
+// path (which pays EntraValidate instead of AuthInternal).
 func (p DelayProfile) PredictedRendezvous() time.Duration {
+	return p.PredictedRendezvousFor(false)
+}
+
+// PredictedRendezvousFor is PredictedRendezvous parameterised by auth
+// method. The relay pays exactly one token-validation cost per
+// token-bearing leg: EntraValidate on the Entra (JWT) path, AuthInternal
+// on the SAS path. All other terms are auth-independent. Passing
+// entra=false reproduces PredictedRendezvous exactly.
+func (p DelayProfile) PredictedRendezvousFor(entra bool) time.Duration {
+	authCost := p.AuthInternal
+	if entra {
+		authCost = p.EntraValidate
+	}
 	return 2*p.DNSLookup +
 		(hopsHandshake+hopsWSGet)*p.SLatency +
 		(hopsHandshake+hopsWSGet+hopsAcceptFrame)*p.LLatency +
 		hopsResponse*max(p.SLatency, p.LLatency) +
-		p.AuthInternal + p.MatchMakeInternal
+		authCost + p.MatchMakeInternal
 }
 
 // PredictedBridgeEcho returns the synthetic wall-clock this profile
@@ -318,6 +358,7 @@ func (p DelayProfile) validate() error {
 		{"LLatency", p.LLatency},
 		{"DNSLookup", p.DNSLookup},
 		{"AuthInternal", p.AuthInternal},
+		{"EntraValidate", p.EntraValidate},
 		{"MatchMakeInternal", p.MatchMakeInternal},
 		{"TokenAcquire", p.TokenAcquire},
 	} {

--- a/mockrelay/server/delay_profile_test.go
+++ b/mockrelay/server/delay_profile_test.go
@@ -551,6 +551,26 @@ func TestDelayProfile_PredictedTimings(t *testing.T) {
 	if got := p.PredictedRendezvous(); got != wantRendezvous {
 		t.Errorf("default PredictedRendezvous = %v, want %v", got, wantRendezvous)
 	}
+	// PredictedRendezvousFor(false) must reproduce PredictedRendezvous
+	// exactly (back-compat: the SAS path is the historical behaviour).
+	if got := p.PredictedRendezvousFor(false); got != p.PredictedRendezvous() {
+		t.Errorf("PredictedRendezvousFor(false) = %v, want %v (== PredictedRendezvous)",
+			got, p.PredictedRendezvous())
+	}
+	// The Entra path swaps AuthInternal for EntraValidate, so the only
+	// difference between the two predictions is exactly that delta.
+	gotDelta := p.PredictedRendezvousFor(true) - p.PredictedRendezvousFor(false)
+	wantDelta := p.EntraValidate - p.AuthInternal
+	if gotDelta != wantDelta {
+		t.Errorf("entra vs sas PredictedRendezvousFor delta = %v, want %v (EntraValidate-AuthInternal)",
+			gotDelta, wantDelta)
+	}
+	// With the default profile EntraValidate > AuthInternal, so the
+	// Entra path must predict a strictly larger rendezvous.
+	if p.PredictedRendezvousFor(true) <= p.PredictedRendezvousFor(false) {
+		t.Errorf("entra PredictedRendezvousFor (%v) not greater than sas (%v)",
+			p.PredictedRendezvousFor(true), p.PredictedRendezvousFor(false))
+	}
 	if got, want := p.PredictedBridgeEcho(), 2*(p.SLatency+p.LLatency); got != want {
 		t.Errorf("default PredictedBridgeEcho = %v, want %v", got, want)
 	}
@@ -665,6 +685,7 @@ func TestWithDelayProfile_RejectsNegativeDuration(t *testing.T) {
 		{"LLatency", DelayProfile{LLatency: -1 * time.Millisecond}},
 		{"DNSLookup", DelayProfile{DNSLookup: -1 * time.Millisecond}},
 		{"AuthInternal", DelayProfile{AuthInternal: -1 * time.Millisecond}},
+		{"EntraValidate", DelayProfile{EntraValidate: -1 * time.Millisecond}},
 		{"MatchMakeInternal", DelayProfile{MatchMakeInternal: -1 * time.Millisecond}},
 	}
 	for _, c := range cases {

--- a/mockrelay/server/rendezvous.go
+++ b/mockrelay/server/rendezvous.go
@@ -69,9 +69,11 @@ func (p *pendingRendezvous) abort() {
 
 // handleConnect handles the sender's connect WebSocket. The flow:
 //  1. DelayProfile entry sleeps (DNS, handshake, WSGet) so the sender's
-//     SAS token "arrives" at the relay at the modeled wire time.
-//  2. AuthInternal + validateSAS — 401 on failure (pre-upgrade, with a
-//     hopsResponse leg paid before the body is written).
+//     token "arrives" at the relay at the modeled wire time.
+//  2. authCost + validateToken — the auth-validation cost (AuthInternal
+//     for SAS, EntraValidate for Entra) then the matching validator;
+//     401 on failure (pre-upgrade, with a hopsResponse leg paid before
+//     the body is written).
 //  3. tryReserve (per-entity cap) — 503 on failure.
 //  4. Build id + rendezvous URL.
 //  5. MatchMakeInternal + lookup listener controls. Empty → 404
@@ -98,10 +100,10 @@ func (s *Server) handleConnect(w http.ResponseWriter, r *http.Request, entity st
 	if !sleepContext(ctx, p.DNSLookup+hopsHandshake*p.SLatency+hopsWSGet*p.SLatency) {
 		return
 	}
-	if !sleepContext(ctx, p.AuthInternal) {
+	if !sleepContext(ctx, s.authCost(r)) {
 		return
 	}
-	if err := s.validateSAS(r); err != nil {
+	if err := s.validateToken(r); err != nil {
 		s.log.Warn("sender auth failed", "entity", entity, "remote", r.RemoteAddr, "error", err)
 		_ = sleepContext(ctx, hopsResponse*p.SLatency)
 		http.Error(w, "unauthorized", http.StatusUnauthorized)


### PR DESCRIPTION
## Why

The Performance suite's `ConnectLatency_Serial` scenario flaked against
real Azure Relay. Roughly 1 connect dial in 10–40 spikes from a
~0.4–0.75 s steady state to 3–7 s. The spike lives in the Azure Relay
control plane's rendezvous — the relay holds the HTTP 101 while it
matches a listener — with zero client-side retries. It is not an
aztunnel defect, but the old "every iteration under one ceiling"
assertion turned an unfixable tail into a flake.

This PR makes the suite tolerant of that tail, gives us the tracing to
*prove* where the time goes, and makes the in-process mock relay model
the same connect-time costs so its timings stay faithful.

## What changed

### Outlier-tolerant assertion

`ConnectLatency_Serial` now judges the whole batch on robust quantiles
instead of any single sample:

- the upper-median must be under a normal threshold (a broad regression
  lifts the median; an isolated spike does not), and
- a soft-tail statistic — the largest sample after discarding the
  sparse top ~10% — must be under a wider threshold.

There is deliberately no hard "tolerated spike count" (a cap just moves
the flaky cliff to a higher count). A per-backend `ConnectLatencyPolicy`
carries the thresholds: real Azure Relay tolerates the sparse tail; the
deterministic mock stays strict so it still catches regressions. The
per-dial socket deadline is decoupled from the assertion threshold, so a
tolerated spike is measured rather than killed by an i/o timeout. The
cold-start scenario retries once with a freshly started (still
cold-token) sender and passes if either attempt is under budget.

### Rendezvous tracing

Both rendezvous WebSocket dials — the sender's connect dial and the
listener's accept dial — attach `net/http/httptrace` when DEBUG logging
is on. Each dial emits one DEBUG line with the DNS/TCP/TLS spans plus
`resp_wait` (request-fully-written → first-response-byte), which
cleanly separates the relay-side hold ("Phase 3") from the sender's own
dial cost ("Phase 2"). It is emitted on dial failure too, where the
split is most useful. The trace records only durations and a
connection-reused flag — never the dial URL or the SAS token embedded in
it. This tracing is what let us attribute the spikes conclusively to the
relay's accept-routing hold rather than to client dialing or retries.

On a passing run that merely tolerated a spike, only the rendezvous
trace lines are dumped (not the full DEBUG buffer) to keep CI output
lean; full buffers are still dumped on failure.

### Faithful mock relay timing

The in-process mock relay's synthetic `DelayProfile` now models the
auth-validation cost of a connect, charged differently for Entra
(bearer-JWT validation) versus SAS (cheap local HMAC check). The relay
sniffs the `sb-hc-token` shape to decide which cost to apply, and the
e2e fake credential mints a real JWT so the Entra path is exercised
end to end. This keeps the mock's per-connect timing representative of
the two real auth modes.

## Validation

- Pure-function unit tests for the quantile gate (`evaluateConnectLatency`,
  upper-median, soft-tail, spike tolerance) covering all-fast, sparse
  spikes, broad regressions, boundary `>=`, and single-sample cases.
- Unit tests for the trace-line filter and the Entra-vs-SAS auth-cost
  modeling.
- `go test -race ./internal/relay/...`, full `go vet`, and the mock e2e
  `ConnectLatency_Serial`/`_ColdStart` scenarios (both auth axes) pass.
- Multiple real-Azure E2E runs are green, including ones that captured
  and tolerated genuine 5–7 s rendezvous spikes.