### PR TITLE
Universal probe-based e2e observability + duplex perf shape + history comparison

### DIFF
--- a/e2e/backends/azure/backend_test.go
+++ b/e2e/backends/azure/backend_test.go
@@ -118,6 +118,17 @@ func (b *azureBackend) Cell(values map[string]string) scenarios.Backend {
 	return &azureBackend{authName: auth, acquireEnv: b.acquireEnv}
 }
 
+// Pins reports the dimensions pinned (not advertised as axes) on this
+// azureBackend. Only the auth dimension is dimensional on this backend;
+// the placement / delay shape is the real Azure environment and isn't
+// modelled here.
+func (b *azureBackend) Pins() map[string]string {
+	if b.axis != nil || b.authName == "" {
+		return nil
+	}
+	return map[string]string{"auth": b.authName}
+}
+
 // ConnectLatencyThreshold returns the per-backend connect-latency
 // ceiling for the Performance suite. Azure pays the real Azure
 // Relay control-plane rendezvous round-trip (~950 ms typical),

--- a/e2e/backends/mock/backend.go
+++ b/e2e/backends/mock/backend.go
@@ -76,6 +76,14 @@ type MockBackend struct {
 	// token-acquisition cost is taken from DelayProfile.TokenAcquire.
 	authName string
 
+	// delayName is the registered profile name DelayProfile was
+	// resolved from. Tracked so Pins() can report it on every recorded
+	// matrix row even when delay is pinned (not advertised as an axis),
+	// which is what makes cross-run comparison work. Empty for backends
+	// constructed without a profile name (the historical zero-value
+	// MockBackend usage in features_test / entracred_test).
+	delayName string
+
 	// authAxis and delayAxis put this backend in factory mode for the
 	// dimension they describe: when non-nil, Axes() advertises that
 	// dimension and Cell() pins it per cell. They are set only by
@@ -153,6 +161,7 @@ func NewMatrixBackend(authNames, delayNames []string) *MockBackend {
 	if len(delayNames) == 1 {
 		// ProfileByName already validated this name above.
 		b.DelayProfile, _ = server.ProfileByName(delayNames[0])
+		b.delayName = delayNames[0]
 	} else {
 		b.delayAxis = &namedAxis{name: "delay", values: append([]string(nil), delayNames...)}
 	}
@@ -191,6 +200,7 @@ func (b *MockBackend) Cell(values map[string]string) scenarios.Backend {
 	cell := &MockBackend{
 		DelayProfile: b.DelayProfile,
 		authName:     b.authName,
+		delayName:    b.delayName,
 	}
 	want := 0
 	if b.authAxis != nil {
@@ -215,11 +225,31 @@ func (b *MockBackend) Cell(values map[string]string) scenarios.Backend {
 			panic("MockBackend.Cell: " + err.Error())
 		}
 		cell.DelayProfile = p
+		cell.delayName = v
 	}
 	if len(values) != want {
 		panic(fmt.Sprintf("MockBackend.Cell: expected %d axis value(s), got %d", want, len(values)))
 	}
 	return cell
+}
+
+// Pins reports the dimensions pinned (not advertised as axes) on this
+// MockBackend, so every recorded matrix row carries its full identity
+// regardless of which dimensions happened to be axes for this run.
+// Empty names (e.g. on a directly-constructed zero-value MockBackend)
+// are omitted so they don't pollute the matrix's named-axis columns.
+func (b *MockBackend) Pins() map[string]string {
+	pins := map[string]string{}
+	if b.authAxis == nil && b.authName != "" {
+		pins["auth"] = b.authName
+	}
+	if b.delayAxis == nil && b.delayName != "" {
+		pins["delay"] = b.delayName
+	}
+	if len(pins) == 0 {
+		return nil
+	}
+	return pins
 }
 
 // mockLatencyFloor is the minimum per-connection latency ceiling. It

--- a/e2e/cmd/perfreport/main.go
+++ b/e2e/cmd/perfreport/main.go
@@ -683,6 +683,25 @@ func residualKey(r record, dim string, crossRun bool) string {
 	return recFamily(r) + "\x00" + backend + "\x00" + canonicalAxesExcept(r, dim) + "\x00" + scenario + "\x00" + mode + "\x00" + run
 }
 
+// putNewestByCell stores r at key k in m, preferring the newer of r and
+// any existing entry. "Newer" is determined by lexicographic Run id
+// comparison (run ids are UTC-timestamp-prefixed by newRunID, so
+// lexicographic ascending matches chronological order).
+//
+// This matters in cross-run pairing: when residualKey(crossRun=true)
+// drops the run id, multiple runs with the same residual can map to the
+// same key. A plain `m[k] = r` would pick by input order — non-
+// deterministic on multi-run artifacts and prone to comparing against a
+// stale run. Within-run pairing carries the run id in the key, so
+// collisions only happen on legitimate duplicate data points and the
+// newest-wins rule is harmless.
+func putNewestByCell(m map[string]record, k string, r record) {
+	if existing, ok := m[k]; ok && existing.Run >= r.Run {
+		return
+	}
+	m[k] = r
+}
+
 // distinctDimValues returns the sorted-ascending set of non-empty values a
 // dimension takes across recs (empty values are not selectable).
 func distinctDimValues(recs []record, dim string) []string {
@@ -1106,9 +1125,9 @@ func renderCompare(w io.Writer, recs []record, dim, baseSel, candSel string) (ga
 			}
 			k := residualKey(r, dim, crossRun)
 			if v == base {
-				baseByCell[k] = r
+				putNewestByCell(baseByCell, k, r)
 			} else {
-				candByCell[k] = r
+				putNewestByCell(candByCell, k, r)
 			}
 			if !seen[k] {
 				seen[k] = true
@@ -1146,7 +1165,7 @@ func renderCompare(w io.Writer, recs []record, dim, baseSel, candSel string) (ga
 		}
 	}
 	if gs.paired == 0 && dim != "run" {
-		return gs, fmt.Errorf("no cells matched on both sides of %s %q..%q; non-run comparisons require rows to share every other dimension (run id, backend, scenario, mode, all axes) for at least one cell — narrow with filters or compare runs instead", dim, base, cand)
+		return gs, fmt.Errorf("no cells matched on both sides of %s %q..%q: tried within-run pairing (rows must share backend/scenario/mode/axes/run-id) and cross-run pairing (drops run id), neither produced a pair — narrow with filters or compare runs instead", dim, base, cand)
 	}
 	if excluded > 0 {
 		_, _ = fmt.Fprintf(w, "warning: %d rows lack dimension %q and were excluded from the comparison\n", excluded, dim)
@@ -1286,9 +1305,9 @@ func renderStreamCompare(w io.Writer, recs []record, dim, baseSel, candSel strin
 			}
 			k := residualKey(r, dim, crossRun)
 			if v == base {
-				baseByCell[k] = r
+				putNewestByCell(baseByCell, k, r)
 			} else {
-				candByCell[k] = r
+				putNewestByCell(candByCell, k, r)
 			}
 			if !seen[k] {
 				seen[k] = true
@@ -1471,9 +1490,9 @@ func renderDuplexCompare(w io.Writer, recs []record, dim, baseSel, candSel strin
 			}
 			k := residualKey(r, dim, crossRun)
 			if v == base {
-				baseByCell[k] = r
+				putNewestByCell(baseByCell, k, r)
 			} else {
-				candByCell[k] = r
+				putNewestByCell(candByCell, k, r)
 			}
 			if !seen[k] {
 				seen[k] = true

--- a/e2e/cmd/perfreport/main.go
+++ b/e2e/cmd/perfreport/main.go
@@ -1577,13 +1577,13 @@ func renderDuplexCompare(w io.Writer, recs []record, dim, baseSel, candSel strin
 			comparable := false
 			if b.RTTP50Ns != nil && n.RTTP50Ns != nil {
 				comparable = true
-				if pct, absNs, ok := pctRegression(b.RTTP50Ns, n.RTTP50Ns); ok {
+				if pct, absNs, ok := regressionPct(b.RTTP50Ns, n.RTTP50Ns); ok {
 					gs.duplexRegressions = append(gs.duplexRegressions, regression{cellLabel(c) + " rtt_p50", pct, absNs})
 				}
 			}
 			if b.RTTP95Ns != nil && n.RTTP95Ns != nil {
 				comparable = true
-				if pct, absNs, ok := pctRegression(b.RTTP95Ns, n.RTTP95Ns); ok {
+				if pct, absNs, ok := regressionPct(b.RTTP95Ns, n.RTTP95Ns); ok {
 					gs.duplexRegressions = append(gs.duplexRegressions, regression{cellLabel(c) + " rtt_p95", pct, absNs})
 				}
 			}
@@ -1598,19 +1598,9 @@ func renderDuplexCompare(w io.Writer, recs []record, dim, baseSel, candSel strin
 	return gs, nil
 }
 
-// pctRegression returns the positive percent slowdown and absolute
-// nanosecond increase of cand over base, ok=true only when cand is
-// actually slower. Mirrors the rtt family's percent gating shape.
-func pctRegression(base, cand *int64) (pct float64, absNs int64, ok bool) {
-	if base == nil || cand == nil || *base <= 0 {
-		return 0, 0, false
-	}
-	d := *cand - *base
-	if d <= 0 {
-		return 0, 0, false
-	}
-	return 100.0 * float64(d) / float64(*base), d, true
-}
+// absRegression returns the absolute positive increase of cand over base,
+// with ok=true only when both are present and cand is actually larger (a
+// tighter/faster candidate is not a regression).
 func absRegression(base, cand *int64) (absNs int64, ok bool) {
 	if base == nil || cand == nil {
 		return 0, false

--- a/e2e/cmd/perfreport/main.go
+++ b/e2e/cmd/perfreport/main.go
@@ -180,36 +180,48 @@ func main() {
 		// Compare each metric family independently: filtering, a stream-only
 		// artifact, or a mid-migration history can leave one family with too
 		// few runs while the other has a real comparison to gate. Attempt
-		// both before deciding to skip, so a streaming regression is never
-		// silently dropped because the RTT side happened to be sparse.
+		// each before deciding to skip, so a regression in any family is
+		// never silently dropped because another family happened to be sparse.
 		gs, rttErr := renderCompare(os.Stdout, recs, *compareBy, base, cand)
 		sgs, streamErr := renderStreamCompare(os.Stdout, recs, *compareBy, base, cand)
+		dgs, duplexErr := renderDuplexCompare(os.Stdout, recs, *compareBy, base, cand)
 
-		// errNotEnoughRuns / errNoStreamRows mean "nothing to compare yet"
-		// for that family — skippable. Any other error is fatal.
-		rttSkippable := rttErr != nil && errors.Is(rttErr, errNotEnoughRuns)
+		// errNotEnoughRuns / errNoRTTRows / errNoStreamRows / errNoDuplexRows
+		// mean "nothing to compare yet" for that family — skippable. Any
+		// other error is fatal.
+		rttSkippable := rttErr != nil && (errors.Is(rttErr, errNotEnoughRuns) || errors.Is(rttErr, errNoRTTRows))
 		streamSkippable := streamErr != nil && (errors.Is(streamErr, errNoStreamRows) || errors.Is(streamErr, errNotEnoughRuns))
+		duplexSkippable := duplexErr != nil && (errors.Is(duplexErr, errNoDuplexRows) || errors.Is(duplexErr, errNotEnoughRuns))
 		if rttErr != nil && !rttSkippable {
 			fail(rttErr)
 		}
 		if streamErr != nil && !streamSkippable {
 			fail(streamErr)
 		}
+		if duplexErr != nil && !duplexSkippable {
+			fail(duplexErr)
+		}
 
-		// Merge the streaming accounting into the shared gateStats only when
-		// the streaming comparison actually ran.
+		// Merge per-family accounting into the shared gateStats only when
+		// that family's comparison actually ran.
 		if streamErr == nil {
 			gs.streamPaired = sgs.streamPaired
 			gs.streamComparable = sgs.streamComparable
 			gs.streamRegressions = sgs.streamRegressions
 			gs.missingInCand = append(gs.missingInCand, sgs.missingInCand...)
 		}
+		if duplexErr == nil {
+			gs.duplexPaired = dgs.duplexPaired
+			gs.duplexComparable = dgs.duplexComparable
+			gs.duplexRegressions = dgs.duplexRegressions
+			gs.missingInCand = append(gs.missingInCand, dgs.missingInCand...)
+		}
 
-		// Neither family produced a comparison: a bootstrap gate run skips
+		// No family produced a comparison: a bootstrap gate run skips
 		// (exit 0); a plain compare surfaces the error.
-		if rttErr != nil && streamErr != nil {
+		if rttErr != nil && streamErr != nil && duplexErr != nil {
 			if *failOver > 0 {
-				fmt.Fprintf(os.Stderr, "perf-gate: nothing to compare yet (skipping) — rtt: %v; stream: %v\n", rttErr, streamErr)
+				fmt.Fprintf(os.Stderr, "perf-gate: nothing to compare yet (skipping) — rtt: %v; stream: %v; duplex: %v\n", rttErr, streamErr, duplexErr)
 				return
 			}
 			fail(rttErr)
@@ -716,6 +728,11 @@ func resolveDimValue(dim, sel string, recs []record) (string, error) {
 // a gate (--fail-over) can treat it as a skip rather than a failure.
 var errNotEnoughRuns = errors.New("not enough runs to compare")
 
+// errNoRTTRows signals that a comparison input carried no rtt rows at
+// all (the run only produced stream / duplex output). Callers skip the
+// rtt comparison rather than failing.
+var errNoRTTRows = errors.New("no rtt rows present")
+
 // resolveRun maps a run selector to a concrete run id. "latest" and
 // "previous" pick the 1st and 2nd newest runs; otherwise the value must
 // equal a run id or be an unambiguous prefix of exactly one.
@@ -987,6 +1004,10 @@ type gateStats struct {
 	streamPaired      int
 	streamComparable  int
 	streamRegressions []streamRegression
+
+	duplexPaired      int
+	duplexComparable  int
+	duplexRegressions []regression // percent-based, same shape as rtt
 }
 
 // streamRegression is one positive absolute increase of a gated streaming
@@ -1052,6 +1073,9 @@ func renderCompare(w io.Writer, recs []record, dim, baseSel, candSel string) (ga
 	// rows are compared separately by renderStreamCompare with their own
 	// columns and gate.
 	recs = filterFamily(recs, "rtt")
+	if len(recs) == 0 {
+		return gs, errNoRTTRows
+	}
 	base, err := resolveDimValue(dim, baseSel, recs)
 	if err != nil {
 		return gs, fmt.Errorf("baseline %q: %w", baseSel, err)
@@ -1402,9 +1426,196 @@ func renderStreamCompare(w io.Writer, recs []record, dim, baseSel, candSel strin
 	return gs, nil
 }
 
-// absRegression returns the absolute positive increase of cand over base,
-// with ok=true only when both are present and cand is actually larger (a
-// tighter/faster candidate is not a regression).
+// errNoDuplexRows signals that a comparison input carried no duplex
+// rows at all, so the duplex comparison is a clean no-op (not a gate
+// failure). The caller skips duplex when it sees this.
+var errNoDuplexRows = errors.New("no duplex rows present")
+
+// renderDuplexCompare matches duplex-family cells across two values of a
+// dimension and prints the duplex metrics side by side. It populates the
+// duplex* fields of gateStats: duplexPaired (cells matched on both
+// sides), duplexComparable (paired cells with at least one gated metric
+// present on both sides), and duplexRegressions (percent increases of
+// the gated metrics rtt_p50 and rtt_p95).
+//
+// Duplex metrics are compared on percent deltas (same as rtt), because
+// the duplex shape produces real measured timings that scale with
+// backend latency rather than with an injected interval.
+func renderDuplexCompare(w io.Writer, recs []record, dim, baseSel, candSel string) (gateStats, error) {
+	var gs gateStats
+	recs = filterFamily(recs, duplexFamily)
+	if len(recs) == 0 {
+		return gs, errNoDuplexRows
+	}
+	base, err := resolveDimValue(dim, baseSel, recs)
+	if err != nil {
+		return gs, fmt.Errorf("baseline %q: %w", baseSel, err)
+	}
+	cand, err := resolveDimValue(dim, candSel, recs)
+	if err != nil {
+		return gs, fmt.Errorf("candidate %q: %w", candSel, err)
+	}
+	if base == cand {
+		return gs, fmt.Errorf("baseline and candidate resolve to the same %s %q", dim, base)
+	}
+
+	baseByCell := map[string]record{}
+	candByCell := map[string]record{}
+	cellOrder := []record{}
+	seen := map[string]bool{}
+	crossRun := false
+	buildMaps := func(crossRun bool) {
+		baseByCell = map[string]record{}
+		candByCell = map[string]record{}
+		cellOrder = []record{}
+		seen = map[string]bool{}
+		for _, r := range recs {
+			v, ok := dimValue(r, dim)
+			if !ok || (v != base && v != cand) {
+				continue
+			}
+			k := residualKeyOpts(r, dim, crossRun)
+			if v == base {
+				baseByCell[k] = r
+			} else {
+				candByCell[k] = r
+			}
+			if !seen[k] {
+				seen[k] = true
+				cellOrder = append(cellOrder, r)
+			}
+		}
+	}
+	buildMaps(false)
+	for k, br := range baseByCell {
+		if _, ok := candByCell[k]; ok {
+			gs.duplexPaired++
+		} else {
+			gs.missingInCand = append(gs.missingInCand, cellLabel(br))
+		}
+	}
+	if gs.duplexPaired == 0 && dim != "run" {
+		gs.missingInCand = nil
+		buildMaps(true)
+		for k, br := range baseByCell {
+			if _, ok := candByCell[k]; ok {
+				gs.duplexPaired++
+			} else {
+				gs.missingInCand = append(gs.missingInCand, cellLabel(br))
+			}
+		}
+		if gs.duplexPaired > 0 {
+			crossRun = true
+			_, _ = fmt.Fprintf(w, "note: pairing duplex rows across runs — no within-run %s pairs found\n", dim)
+		}
+	}
+
+	sortRecs(cellOrder)
+	cols := axisColumns(cellOrder)
+	namedAxes := len(cols) > 0
+	if isAxisDim(dim) {
+		cols = removeStr(cols, dim)
+	}
+	showBackend := dim != "backend"
+	showScenario := dim != "scenario"
+	showMode := dim != "mode"
+	showRun := dim != "run" && len(distinctRuns(cellOrder)) > 1
+
+	_, _ = fmt.Fprintf(w, "PERF COMPARE (duplex)  %s: baseline=%s  candidate=%s  (Δ%% = (candidate−baseline)/baseline; negative is faster)\n", dim, base, cand)
+	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
+	var header []string
+	if showBackend {
+		header = append(header, "backend")
+	}
+	if namedAxes {
+		header = append(header, cols...)
+	} else if dim != "axis" {
+		header = append(header, "axis")
+	}
+	if showRun {
+		header = append(header, "run")
+	}
+	if showScenario {
+		header = append(header, "scenario")
+	}
+	if showMode {
+		header = append(header, "mode")
+	}
+	header = append(header,
+		"rtt_p50_base", "rtt_p50_cand", "rtt_p50_Δ%",
+		"rtt_p95_base", "rtt_p95_cand", "rtt_p95_Δ%",
+		"req_leg_p95_base", "req_leg_p95_cand", "req_leg_p95_Δ%",
+		"resp_leg_p95_base", "resp_leg_p95_cand", "resp_leg_p95_Δ%")
+	_, _ = fmt.Fprintln(tw, strings.Join(header, "\t"))
+
+	for _, c := range cellOrder {
+		k := residualKeyOpts(c, dim, crossRun)
+		b, bok := baseByCell[k]
+		n, nok := candByCell[k]
+		var cells []string
+		if showBackend {
+			cells = append(cells, dash(c.Backend))
+		}
+		if namedAxes {
+			for _, key := range cols {
+				cells = append(cells, dash(c.Axes[key]))
+			}
+		} else if dim != "axis" {
+			cells = append(cells, dash(c.Axis))
+		}
+		if showRun {
+			cells = append(cells, dash(c.Run))
+		}
+		if showScenario {
+			cells = append(cells, c.Scenario)
+		}
+		if showMode {
+			cells = append(cells, dash(c.Mode))
+		}
+		cells = append(cells, compareTriplet(ptrIf(bok, b.RTTP50Ns), ptrIf(nok, n.RTTP50Ns))...)
+		cells = append(cells, compareTriplet(ptrIf(bok, b.RTTP95Ns), ptrIf(nok, n.RTTP95Ns))...)
+		cells = append(cells, compareTriplet(ptrIf(bok, b.ReqLegP95Ns), ptrIf(nok, n.ReqLegP95Ns))...)
+		cells = append(cells, compareTriplet(ptrIf(bok, b.RespLegP95Ns), ptrIf(nok, n.RespLegP95Ns))...)
+		_, _ = fmt.Fprintln(tw, strings.Join(cells, "\t"))
+
+		if bok && nok {
+			comparable := false
+			if b.RTTP50Ns != nil && n.RTTP50Ns != nil {
+				comparable = true
+				if pct, absNs, ok := pctRegression(b.RTTP50Ns, n.RTTP50Ns); ok {
+					gs.duplexRegressions = append(gs.duplexRegressions, regression{cellLabel(c) + " rtt_p50", pct, absNs})
+				}
+			}
+			if b.RTTP95Ns != nil && n.RTTP95Ns != nil {
+				comparable = true
+				if pct, absNs, ok := pctRegression(b.RTTP95Ns, n.RTTP95Ns); ok {
+					gs.duplexRegressions = append(gs.duplexRegressions, regression{cellLabel(c) + " rtt_p95", pct, absNs})
+				}
+			}
+			if comparable {
+				gs.duplexComparable++
+			}
+		}
+	}
+	if err := tw.Flush(); err != nil {
+		return gs, err
+	}
+	return gs, nil
+}
+
+// pctRegression returns the positive percent slowdown and absolute
+// nanosecond increase of cand over base, ok=true only when cand is
+// actually slower. Mirrors the rtt family's percent gating shape.
+func pctRegression(base, cand *int64) (pct float64, absNs int64, ok bool) {
+	if base == nil || cand == nil || *base <= 0 {
+		return 0, 0, false
+	}
+	d := *cand - *base
+	if d <= 0 {
+		return 0, 0, false
+	}
+	return 100.0 * float64(d) / float64(*base), d, true
+}
 func absRegression(base, cand *int64) (absNs int64, ok bool) {
 	if base == nil || cand == nil {
 		return 0, false
@@ -1437,7 +1648,7 @@ func absCompareTriplet(base, cand *int64) []string {
 // the absolute floor (nil when none do), or an error when the comparison
 // paired no cells (the gate must never silently pass on nothing).
 func gateVerdict(gs gateStats, failOverPct float64, floor time.Duration) (*regression, error) {
-	if gs.paired == 0 && gs.streamPaired == 0 {
+	if gs.paired == 0 && gs.streamPaired == 0 && gs.duplexPaired == 0 {
 		return nil, errors.New("no cells paired across baseline and candidate — nothing was compared")
 	}
 	var worst *regression
@@ -1487,6 +1698,31 @@ func streamGateVerdict(gs gateStats, floor time.Duration) (*streamRegression, er
 	return worst, nil
 }
 
+// duplexGateVerdict is the duplex-family analogue of gateVerdict. Duplex
+// metrics are percent-gated (same shape as rtt) because they're real
+// measured timings that scale with backend latency rather than an
+// injected interval. Returns the worst gated duplex regression that
+// breaches BOTH failOverPct and the floor; (nil, nil) when no duplex
+// cells paired; an error when paired-but-uncomparable.
+func duplexGateVerdict(gs gateStats, failOverPct float64, floor time.Duration) (*regression, error) {
+	if gs.duplexPaired == 0 {
+		return nil, nil
+	}
+	if gs.duplexComparable == 0 {
+		return nil, errors.New("duplex cells paired but none carried a comparable gated metric (rtt_p50 / rtt_p95) on both sides — nothing was gated")
+	}
+	var worst *regression
+	for i := range gs.duplexRegressions {
+		r := &gs.duplexRegressions[i]
+		if r.pct > failOverPct && time.Duration(r.absNs) > floor {
+			if worst == nil || r.pct > worst.pct {
+				worst = r
+			}
+		}
+	}
+	return worst, nil
+}
+
 // It exits non-zero when any paired warm/cold p50 cell regressed by more
 // than failOverPct AND by more than the failMinAbs duration floor (so a
 // large percent on a tiny baseline can't flake the gate). A comparison
@@ -1510,6 +1746,10 @@ func applyGate(gs gateStats, failOverPct float64, failMinAbs string) {
 	if err != nil {
 		fail(fmt.Errorf("perf-gate: %w", err))
 	}
+	duplexWorst, err := duplexGateVerdict(gs, failOverPct, floor)
+	if err != nil {
+		fail(fmt.Errorf("perf-gate: %w", err))
+	}
 	failed := false
 	if worst != nil {
 		fmt.Fprintf(os.Stderr, "perf-gate: FAIL — %s regressed %+.1f%% (+%s), exceeding --fail-over %.1f%% / --fail-min-abs %s\n",
@@ -1523,6 +1763,11 @@ func applyGate(gs gateStats, failOverPct float64, failMinAbs string) {
 		}
 		fmt.Fprintf(os.Stderr, "perf-gate: FAIL — %s regressed +%s (absolute), exceeding streaming floor %s\n",
 			streamWorst.label, time.Duration(streamWorst.absNs).Round(time.Millisecond), streamFloor)
+		failed = true
+	}
+	if duplexWorst != nil {
+		fmt.Fprintf(os.Stderr, "perf-gate: FAIL — %s regressed %+.1f%% (+%s), exceeding --fail-over %.1f%% / --fail-min-abs %s\n",
+			duplexWorst.label, duplexWorst.pct, time.Duration(duplexWorst.absNs).Round(time.Millisecond), failOverPct, floor)
 		failed = true
 	}
 	if failed {

--- a/e2e/cmd/perfreport/main.go
+++ b/e2e/cmd/perfreport/main.go
@@ -1341,6 +1341,9 @@ func renderStreamCompare(w io.Writer, recs []record, dim, baseSel, candSel strin
 			_, _ = fmt.Fprintf(w, "note: pairing streaming rows across runs — no within-run %s pairs found\n", dim)
 		}
 	}
+	if gs.streamPaired == 0 && dim != "run" {
+		return gs, fmt.Errorf("no streaming cells matched on both sides of %s %q..%q: tried within-run pairing (rows must share backend/scenario/mode/axes/run-id) and cross-run pairing (drops run id), neither produced a pair", dim, base, cand)
+	}
 
 	sortRecs(cellOrder)
 	cols := axisColumns(cellOrder)
@@ -1522,6 +1525,9 @@ func renderDuplexCompare(w io.Writer, recs []record, dim, baseSel, candSel strin
 			crossRun = true
 			_, _ = fmt.Fprintf(w, "note: pairing duplex rows across runs — no within-run %s pairs found\n", dim)
 		}
+	}
+	if gs.duplexPaired == 0 && dim != "run" {
+		return gs, fmt.Errorf("no duplex cells matched on both sides of %s %q..%q: tried within-run pairing (rows must share backend/scenario/mode/axes/run-id) and cross-run pairing (drops run id), neither produced a pair", dim, base, cand)
 	}
 
 	sortRecs(cellOrder)

--- a/e2e/cmd/perfreport/main.go
+++ b/e2e/cmd/perfreport/main.go
@@ -657,20 +657,15 @@ func isAxisDim(dim string) bool {
 // residualKey identifies a row by every identity dimension EXCEPT the one
 // under comparison, so two rows differing only in that dimension (e.g.
 // auth=sas vs auth=entra of the same run/scenario/mode) collapse to one
-// comparison cell. Run is part of the residual for non-run dimensions, so
-// comparisons stay apples-to-apples within a single run.
-func residualKey(r record, dim string) string {
-	return residualKeyOpts(r, dim, false)
-}
-
-// residualKeyOpts is the configurable form of residualKey. When
-// crossRun is true the run id is dropped from the identity, so two rows
-// from different runs that agree on every other dimension pair up.
-// renderCompare uses this as a fallback when within-run pairing
-// produces zero matches, which is the typical situation when a user has
-// done two separate single-value runs (e.g. E2E_DELAY=zero in one and
-// E2E_DELAY=default in another) and wants to compare them.
-func residualKeyOpts(r record, dim string, crossRun bool) string {
+// comparison cell. When crossRun is true the run id is dropped from the
+// identity too, so two rows from different runs that agree on every
+// other dimension pair up. renderCompare/renderStreamCompare/
+// renderDuplexCompare use the crossRun=true mode as a fallback when
+// within-run pairing produces zero matches, which is the typical
+// situation when a user has done two separate single-value runs (e.g.
+// E2E_DELAY=zero in one and E2E_DELAY=default in another) and wants to
+// compare them.
+func residualKey(r record, dim string, crossRun bool) string {
 	backend, scenario, mode, run := r.Backend, r.Scenario, r.Mode, r.Run
 	switch dim {
 	case "backend":
@@ -943,7 +938,7 @@ func renderDuplexReportTable(w io.Writer, recs []record) error {
 	if showRun {
 		header = append(header, "run")
 	}
-	header = append(header, "scenario", "mode", "rtt_p50", "rtt_p95", "req_leg_p50", "req_leg_p95", "resp_leg_p50", "resp_leg_p95", "think_p95", "acks/s", "bytes/s", "ack_spread", "sample_n", "success", "wall")
+	header = append(header, "scenario", "mode", "rtt_p50", "rtt_p95", "req_leg_p50", "req_leg_p95", "resp_leg_p50", "resp_leg_p95", "think_p50", "think_p95", "acks/s", "bytes/s", "ack_spread", "sample_n", "success", "wall")
 	_, _ = fmt.Fprintln(tw, strings.Join(header, "\t"))
 
 	for _, r := range recs {
@@ -963,7 +958,7 @@ func renderDuplexReportTable(w io.Writer, recs []record) error {
 			durOrDash(r.RTTP50Ns), durOrDash(r.RTTP95Ns),
 			durOrDash(r.ReqLegP50Ns), durOrDash(r.ReqLegP95Ns),
 			durOrDash(r.RespLegP50Ns), durOrDash(r.RespLegP95Ns),
-			durOrDash(r.ThinkP95Ns),
+			durOrDash(r.ThinkP50Ns), durOrDash(r.ThinkP95Ns),
 			i64Cell(r.AcksPerSec), i64Cell(r.BytesPerSecPerDir), i64Cell(r.AckSpread),
 			fmt.Sprintf("%d", r.SampleN),
 			fmt.Sprintf("%d/%d", r.SuccessN, r.AttemptN), dur(r.WallNs),
@@ -1109,7 +1104,7 @@ func renderCompare(w io.Writer, recs []record, dim, baseSel, candSel string) (ga
 			if v != base && v != cand {
 				continue
 			}
-			k := residualKeyOpts(r, dim, crossRun)
+			k := residualKey(r, dim, crossRun)
 			if v == base {
 				baseByCell[k] = r
 			} else {
@@ -1195,7 +1190,7 @@ func renderCompare(w io.Writer, recs []record, dim, baseSel, candSel string) (ga
 	_, _ = fmt.Fprintln(tw, strings.Join(header, "\t"))
 
 	for _, c := range cellOrder {
-		k := residualKeyOpts(c, dim, crossRun)
+		k := residualKey(c, dim, crossRun)
 		b, bok := baseByCell[k]
 		n, nok := candByCell[k]
 		var cells []string
@@ -1289,7 +1284,7 @@ func renderStreamCompare(w io.Writer, recs []record, dim, baseSel, candSel strin
 			if !ok || (v != base && v != cand) {
 				continue
 			}
-			k := residualKeyOpts(r, dim, crossRun)
+			k := residualKey(r, dim, crossRun)
 			if v == base {
 				baseByCell[k] = r
 			} else {
@@ -1367,7 +1362,7 @@ func renderStreamCompare(w io.Writer, recs []record, dim, baseSel, candSel strin
 	_, _ = fmt.Fprintln(tw, strings.Join(header, "\t"))
 
 	for _, c := range cellOrder {
-		k := residualKeyOpts(c, dim, crossRun)
+		k := residualKey(c, dim, crossRun)
 		b, bok := baseByCell[k]
 		n, nok := candByCell[k]
 		var cells []string
@@ -1474,7 +1469,7 @@ func renderDuplexCompare(w io.Writer, recs []record, dim, baseSel, candSel strin
 			if !ok || (v != base && v != cand) {
 				continue
 			}
-			k := residualKeyOpts(r, dim, crossRun)
+			k := residualKey(r, dim, crossRun)
 			if v == base {
 				baseByCell[k] = r
 			} else {
@@ -1549,7 +1544,7 @@ func renderDuplexCompare(w io.Writer, recs []record, dim, baseSel, candSel strin
 	_, _ = fmt.Fprintln(tw, strings.Join(header, "\t"))
 
 	for _, c := range cellOrder {
-		k := residualKeyOpts(c, dim, crossRun)
+		k := residualKey(c, dim, crossRun)
 		b, bok := baseByCell[k]
 		n, nok := candByCell[k]
 		var cells []string

--- a/e2e/cmd/perfreport/main.go
+++ b/e2e/cmd/perfreport/main.go
@@ -648,6 +648,17 @@ func isAxisDim(dim string) bool {
 // comparison cell. Run is part of the residual for non-run dimensions, so
 // comparisons stay apples-to-apples within a single run.
 func residualKey(r record, dim string) string {
+	return residualKeyOpts(r, dim, false)
+}
+
+// residualKeyOpts is the configurable form of residualKey. When
+// crossRun is true the run id is dropped from the identity, so two rows
+// from different runs that agree on every other dimension pair up.
+// renderCompare uses this as a fallback when within-run pairing
+// produces zero matches, which is the typical situation when a user has
+// done two separate single-value runs (e.g. E2E_DELAY=zero in one and
+// E2E_DELAY=default in another) and wants to compare them.
+func residualKeyOpts(r record, dim string, crossRun bool) string {
 	backend, scenario, mode, run := r.Backend, r.Scenario, r.Mode, r.Run
 	switch dim {
 	case "backend":
@@ -657,6 +668,9 @@ func residualKey(r record, dim string) string {
 	case "mode":
 		mode = ""
 	case "run":
+		run = ""
+	}
+	if crossRun {
 		run = ""
 	}
 	return recFamily(r) + "\x00" + backend + "\x00" + canonicalAxesExcept(r, dim) + "\x00" + scenario + "\x00" + mode + "\x00" + run
@@ -1055,26 +1069,35 @@ func renderCompare(w io.Writer, recs []record, dim, baseSel, candSel string) (ga
 	cellOrder := []record{}
 	seen := map[string]bool{}
 	excluded := 0
-	for _, r := range recs {
-		v, ok := dimValue(r, dim)
-		if !ok {
-			excluded++
-			continue
-		}
-		if v != base && v != cand {
-			continue
-		}
-		k := residualKey(r, dim)
-		if v == base {
-			baseByCell[k] = r
-		} else {
-			candByCell[k] = r
-		}
-		if !seen[k] {
-			seen[k] = true
-			cellOrder = append(cellOrder, r)
+	crossRun := false
+	buildMaps := func(crossRun bool) {
+		baseByCell = map[string]record{}
+		candByCell = map[string]record{}
+		cellOrder = []record{}
+		seen = map[string]bool{}
+		excluded = 0
+		for _, r := range recs {
+			v, ok := dimValue(r, dim)
+			if !ok {
+				excluded++
+				continue
+			}
+			if v != base && v != cand {
+				continue
+			}
+			k := residualKeyOpts(r, dim, crossRun)
+			if v == base {
+				baseByCell[k] = r
+			} else {
+				candByCell[k] = r
+			}
+			if !seen[k] {
+				seen[k] = true
+				cellOrder = append(cellOrder, r)
+			}
 		}
 	}
+	buildMaps(false)
 
 	for k, br := range baseByCell {
 		if _, ok := candByCell[k]; ok {
@@ -1083,8 +1106,28 @@ func renderCompare(w io.Writer, recs []record, dim, baseSel, candSel string) (ga
 			gs.missingInCand = append(gs.missingInCand, cellLabel(br))
 		}
 	}
+	// Auto-fallback: if within-run pairing produced nothing (typical when
+	// a user has two separate runs each pinning one of the compared
+	// values), retry with run dropped from the residual key. This pairs
+	// rows across runs that agree on every other dimension. Announce the
+	// fallback so the user knows the comparison spans runs.
 	if gs.paired == 0 && dim != "run" {
-		return gs, fmt.Errorf("no cells matched on both sides of %s %q..%q; non-run comparisons require rows to share every other dimension including run id (e.g. mock and azure are separate runs) — narrow with filters or compare runs instead", dim, base, cand)
+		gs.missingInCand = nil
+		buildMaps(true)
+		for k, br := range baseByCell {
+			if _, ok := candByCell[k]; ok {
+				gs.paired++
+			} else {
+				gs.missingInCand = append(gs.missingInCand, cellLabel(br))
+			}
+		}
+		if gs.paired > 0 {
+			crossRun = true
+			_, _ = fmt.Fprintf(w, "note: pairing rows across runs — no within-run %s pairs found\n", dim)
+		}
+	}
+	if gs.paired == 0 && dim != "run" {
+		return gs, fmt.Errorf("no cells matched on both sides of %s %q..%q; non-run comparisons require rows to share every other dimension (run id, backend, scenario, mode, all axes) for at least one cell — narrow with filters or compare runs instead", dim, base, cand)
 	}
 	if excluded > 0 {
 		_, _ = fmt.Fprintf(w, "warning: %d rows lack dimension %q and were excluded from the comparison\n", excluded, dim)
@@ -1128,7 +1171,7 @@ func renderCompare(w io.Writer, recs []record, dim, baseSel, candSel string) (ga
 	_, _ = fmt.Fprintln(tw, strings.Join(header, "\t"))
 
 	for _, c := range cellOrder {
-		k := residualKey(c, dim)
+		k := residualKeyOpts(c, dim, crossRun)
 		b, bok := baseByCell[k]
 		n, nok := candByCell[k]
 		var cells []string
@@ -1211,27 +1254,53 @@ func renderStreamCompare(w io.Writer, recs []record, dim, baseSel, candSel strin
 	candByCell := map[string]record{}
 	cellOrder := []record{}
 	seen := map[string]bool{}
-	for _, r := range recs {
-		v, ok := dimValue(r, dim)
-		if !ok || (v != base && v != cand) {
-			continue
-		}
-		k := residualKey(r, dim)
-		if v == base {
-			baseByCell[k] = r
-		} else {
-			candByCell[k] = r
-		}
-		if !seen[k] {
-			seen[k] = true
-			cellOrder = append(cellOrder, r)
+	crossRun := false
+	buildMaps := func(crossRun bool) {
+		baseByCell = map[string]record{}
+		candByCell = map[string]record{}
+		cellOrder = []record{}
+		seen = map[string]bool{}
+		for _, r := range recs {
+			v, ok := dimValue(r, dim)
+			if !ok || (v != base && v != cand) {
+				continue
+			}
+			k := residualKeyOpts(r, dim, crossRun)
+			if v == base {
+				baseByCell[k] = r
+			} else {
+				candByCell[k] = r
+			}
+			if !seen[k] {
+				seen[k] = true
+				cellOrder = append(cellOrder, r)
+			}
 		}
 	}
+	buildMaps(false)
 	for k, br := range baseByCell {
 		if _, ok := candByCell[k]; ok {
 			gs.streamPaired++
 		} else {
 			gs.missingInCand = append(gs.missingInCand, cellLabel(br))
+		}
+	}
+	// Auto-fallback to cross-run pairing when within-run produced no
+	// matches, mirroring renderCompare. Same shape: stream comparison
+	// across two single-value runs is just as legitimate as rtt.
+	if gs.streamPaired == 0 && dim != "run" {
+		gs.missingInCand = nil
+		buildMaps(true)
+		for k, br := range baseByCell {
+			if _, ok := candByCell[k]; ok {
+				gs.streamPaired++
+			} else {
+				gs.missingInCand = append(gs.missingInCand, cellLabel(br))
+			}
+		}
+		if gs.streamPaired > 0 {
+			crossRun = true
+			_, _ = fmt.Fprintf(w, "note: pairing streaming rows across runs — no within-run %s pairs found\n", dim)
 		}
 	}
 
@@ -1274,7 +1343,7 @@ func renderStreamCompare(w io.Writer, recs []record, dim, baseSel, candSel strin
 	_, _ = fmt.Fprintln(tw, strings.Join(header, "\t"))
 
 	for _, c := range cellOrder {
-		k := residualKey(c, dim)
+		k := residualKeyOpts(c, dim, crossRun)
 		b, bok := baseByCell[k]
 		n, nok := candByCell[k]
 		var cells []string

--- a/e2e/cmd/perfreport/main.go
+++ b/e2e/cmd/perfreport/main.go
@@ -86,6 +86,25 @@ type record struct {
 	CompletionSpreadNs *int64 `json:"completion_spread_ns,omitempty"`
 	GoodputBytesPerSec *int64 `json:"goodput_bytes_per_sec,omitempty"`
 	StreamN            int    `json:"stream_n,omitempty"`
+
+	// Duplex family (metric_family == "duplex"). Per-leg p50/p95 from
+	// the steady-state sample population pooled across flows, plus
+	// throughput and per-flow ack fairness. BytesPerSecPerDir is the
+	// per-direction application payload throughput (DuplexShape uses
+	// symmetric BodySize so both legs carry the same byte count).
+	RTTP50Ns          *int64 `json:"rtt_p50_ns,omitempty"`
+	RTTP95Ns          *int64 `json:"rtt_p95_ns,omitempty"`
+	ReqLegP50Ns       *int64 `json:"req_leg_p50_ns,omitempty"`
+	ReqLegP95Ns       *int64 `json:"req_leg_p95_ns,omitempty"`
+	RespLegP50Ns      *int64 `json:"resp_leg_p50_ns,omitempty"`
+	RespLegP95Ns      *int64 `json:"resp_leg_p95_ns,omitempty"`
+	ThinkP50Ns        *int64 `json:"think_p50_ns,omitempty"`
+	ThinkP95Ns        *int64 `json:"think_p95_ns,omitempty"`
+	AcksPerSec        *int64 `json:"acks_per_sec,omitempty"`
+	BytesPerSecPerDir *int64 `json:"bytes_per_sec_per_dir,omitempty"`
+	AckSpread         *int64 `json:"ack_spread,omitempty"`
+	SampleN           int    `json:"sample_n,omitempty"`
+	FlowN             int    `json:"flow_n,omitempty"`
 }
 
 // streamFamily is the metric_family value for streaming rows; the rtt
@@ -93,6 +112,7 @@ type record struct {
 // keys and gating never confuse the families (an empty value from a
 // legacy v1 artifact is the rtt family).
 const streamFamily = "stream"
+const duplexFamily = "duplex"
 
 func recFamily(r record) string {
 	if r.MetricFamily == "" {
@@ -739,11 +759,14 @@ func sortRecs(recs []record) {
 }
 
 func renderTable(w io.Writer, recs []record) error {
-	var rtt, stream []record
+	var rtt, stream, duplex []record
 	for _, r := range recs {
-		if recFamily(r) == streamFamily {
+		switch recFamily(r) {
+		case streamFamily:
 			stream = append(stream, r)
-		} else {
+		case duplexFamily:
+			duplex = append(duplex, r)
+		default:
 			rtt = append(rtt, r)
 		}
 	}
@@ -757,6 +780,14 @@ func renderTable(w io.Writer, recs []record) error {
 			_, _ = fmt.Fprintln(w)
 		}
 		if err := renderStreamReportTable(w, stream); err != nil {
+			return err
+		}
+	}
+	if len(duplex) > 0 {
+		if len(rtt) > 0 || len(stream) > 0 {
+			_, _ = fmt.Fprintln(w)
+		}
+		if err := renderDuplexReportTable(w, duplex); err != nil {
 			return err
 		}
 	}
@@ -860,6 +891,63 @@ func goodputCell(bps *int64) string {
 		return "-"
 	}
 	return fmt.Sprintf("%.1f", float64(*bps)/1024)
+}
+
+// renderDuplexReportTable renders the duplex-family rows: per-leg p50/p95,
+// pooled exchange throughput, and per-flow ack fairness.
+func renderDuplexReportTable(w io.Writer, recs []record) error {
+	sortRecs(recs)
+	cols := axisColumns(recs)
+	warnMixedAxisKeys(w, recs, cols)
+	showRun := len(distinctRuns(recs)) >= 2
+	_, _ = fmt.Fprintln(w, "PERF MATRIX (duplex; per-leg latency under sustained bidirectional load, bytes/s is per direction, ack_spread = max−min acks across successful flows)")
+	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
+
+	header := []string{"backend"}
+	if len(cols) == 0 {
+		header = append(header, "axis")
+	} else {
+		header = append(header, cols...)
+	}
+	if showRun {
+		header = append(header, "run")
+	}
+	header = append(header, "scenario", "mode", "rtt_p50", "rtt_p95", "req_leg_p50", "req_leg_p95", "resp_leg_p50", "resp_leg_p95", "think_p95", "acks/s", "bytes/s", "ack_spread", "sample_n", "success", "wall")
+	_, _ = fmt.Fprintln(tw, strings.Join(header, "\t"))
+
+	for _, r := range recs {
+		cells := []string{dash(r.Backend)}
+		if len(cols) == 0 {
+			cells = append(cells, dash(r.Axis))
+		} else {
+			for _, k := range cols {
+				cells = append(cells, dash(r.Axes[k]))
+			}
+		}
+		if showRun {
+			cells = append(cells, dash(r.Run))
+		}
+		cells = append(cells,
+			r.Scenario, dash(r.Mode),
+			durOrDash(r.RTTP50Ns), durOrDash(r.RTTP95Ns),
+			durOrDash(r.ReqLegP50Ns), durOrDash(r.ReqLegP95Ns),
+			durOrDash(r.RespLegP50Ns), durOrDash(r.RespLegP95Ns),
+			durOrDash(r.ThinkP95Ns),
+			i64Cell(r.AcksPerSec), i64Cell(r.BytesPerSecPerDir), i64Cell(r.AckSpread),
+			fmt.Sprintf("%d", r.SampleN),
+			fmt.Sprintf("%d/%d", r.SuccessN, r.AttemptN), dur(r.WallNs),
+		)
+		_, _ = fmt.Fprintln(tw, strings.Join(cells, "\t"))
+	}
+	return tw.Flush()
+}
+
+// i64Cell renders a nullable int64 metric, "-" when unmeasured.
+func i64Cell(v *int64) string {
+	if v == nil {
+		return "-"
+	}
+	return fmt.Sprintf("%d", *v)
 }
 
 // regression is one positive warm/cold p50 delta for a single cell, used

--- a/e2e/cmd/perfreport/main.go
+++ b/e2e/cmd/perfreport/main.go
@@ -1180,7 +1180,7 @@ func renderCompare(w io.Writer, recs []record, dim, baseSel, candSel string) (ga
 	showBackend := dim != "backend"
 	showScenario := dim != "scenario"
 	showMode := dim != "mode"
-	showRun := dim != "run" && len(distinctRuns(cellOrder)) > 1
+	showRun := dim != "run" && !crossRun && len(distinctRuns(cellOrder)) > 1
 
 	_, _ = fmt.Fprintf(w, "PERF COMPARE  %s: baseline=%s  candidate=%s  (Δ%% = (candidate−baseline)/baseline; negative is faster)\n", dim, base, cand)
 	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
@@ -1351,7 +1351,7 @@ func renderStreamCompare(w io.Writer, recs []record, dim, baseSel, candSel strin
 	showBackend := dim != "backend"
 	showScenario := dim != "scenario"
 	showMode := dim != "mode"
-	showRun := dim != "run" && len(distinctRuns(cellOrder)) > 1
+	showRun := dim != "run" && !crossRun && len(distinctRuns(cellOrder)) > 1
 
 	_, _ = fmt.Fprintf(w, "PERF COMPARE (streaming)  %s: baseline=%s  candidate=%s  (Δ = candidate−baseline; negative is faster/tighter)\n", dim, base, cand)
 	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
@@ -1533,7 +1533,7 @@ func renderDuplexCompare(w io.Writer, recs []record, dim, baseSel, candSel strin
 	showBackend := dim != "backend"
 	showScenario := dim != "scenario"
 	showMode := dim != "mode"
-	showRun := dim != "run" && len(distinctRuns(cellOrder)) > 1
+	showRun := dim != "run" && !crossRun && len(distinctRuns(cellOrder)) > 1
 
 	_, _ = fmt.Fprintf(w, "PERF COMPARE (duplex)  %s: baseline=%s  candidate=%s  (Δ%% = (candidate−baseline)/baseline; negative is faster)\n", dim, base, cand)
 	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)

--- a/e2e/cmd/perfreport/main_test.go
+++ b/e2e/cmd/perfreport/main_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -855,6 +856,53 @@ func TestRenderCompare_UnknownValueListsAvailable(t *testing.T) {
 	_, err = renderCompare(&b, recs, "auth", "sas", "ntlm")
 	if err == nil || !strings.Contains(err.Error(), "available: entra, sas") {
 		t.Errorf("expected available-values error, got %v", err)
+	}
+}
+
+// TestRenderCompare_CrossRunPicksNewest verifies that when multiple
+// runs share the same residual key after dropping run id (the typical
+// multi-run history case for cross-run pairing), the pair maps pick
+// the newest run deterministically rather than whichever rec the
+// iteration order happened to last assign.
+func TestRenderCompare_CrossRunPicksNewest(t *testing.T) {
+	// Three baseline mock-sas rows with successively newer run ids,
+	// plus one azure-sas candidate. Cross-run pairing drops run id,
+	// so all three baseline rows collide on the same residual key.
+	// The pair must pick the newest (rid ccc), not whichever came
+	// last in input order — so reverse the input to defeat that
+	// accidental property.
+	mkRow := func(run string, warmNs int64) string {
+		return fmt.Sprintf(`{"type":"row","schema":"perfmatrix/v1","run":%q,"backend":"mock","axes":{"auth":"sas","delay":"nn"},"scenario":"S","mode":"PortForward","cold_p50_ns":250000000,"warm_p50_ns":%d,"warm_p95_ns":23000000,"cold_n":5,"warm_n":25,"success_n":5,"attempt_n":5,"wall_ns":360000000}`, run, warmNs)
+	}
+	baseOld := mkRow("20260601T100000.000Z-aaa", 10_000_000)
+	baseMid := mkRow("20260601T110000.000Z-bbb", 20_000_000)
+	baseNew := mkRow("20260601T120000.000Z-ccc", 30_000_000)
+	const cand = `{"type":"row","schema":"perfmatrix/v1","run":"20260601T130000.000Z-ddd","backend":"azure","axes":{"auth":"sas","delay":"nn"},"scenario":"S","mode":"PortForward","cold_p50_ns":1450000000,"warm_p50_ns":210000000,"warm_p95_ns":215000000,"cold_n":5,"warm_n":25,"success_n":5,"attempt_n":5,"wall_ns":2500000000}`
+
+	// Reverse input order: oldest LAST. A naive `m[k] = r` would
+	// pick the oldest row instead of the newest. Assert we pick ccc.
+	recs, _, err := load([]string{writeTemp(t, cand, baseNew, baseMid, baseOld)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var b strings.Builder
+	if _, err := renderCompare(&b, recs, "backend", "mock", "azure"); err != nil {
+		t.Fatalf("renderCompare: %v", err)
+	}
+	out := b.String()
+	if !strings.Contains(out, "note: pairing rows across runs") {
+		t.Errorf("expected cross-run fallback note:\n%s", out)
+	}
+	// The Δ% column distinguishes which baseline was paired:
+	//   baseline=ccc(30ms) vs cand(210ms) → +600.0%
+	//   baseline=bbb(20ms) vs cand(210ms) → +950.0%
+	//   baseline=aaa(10ms) vs cand(210ms) → +2000.0%
+	// Asserting +600% confirms the newest baseline (ccc) was picked.
+	if !strings.Contains(out, "+600.0%") {
+		t.Errorf("expected +600.0%% warm delta (newest baseline 30ms vs cand 210ms); got:\n%s", out)
+	}
+	if strings.Contains(out, "+950.0%") || strings.Contains(out, "+2000.0%") {
+		t.Errorf("older baseline was paired — newest-wins broken:\n%s", out)
 	}
 }
 

--- a/e2e/cmd/perfreport/main_test.go
+++ b/e2e/cmd/perfreport/main_test.go
@@ -1003,6 +1003,48 @@ func TestRenderDuplexCompare_NoDuplexRowsIsSkippable(t *testing.T) {
 	}
 }
 
+// TestRenderDuplexCompare_NoOverlapErrorsAfterFallback verifies the
+// post-fallback zero-pairs error fires: if duplex rows exist but
+// neither within-run nor cross-run pairing finds a match (e.g.
+// different scenarios), the compare must error rather than silently
+// rendering all-dash rows. Without this, --fail-over could exit 0 on
+// an RTT pass while the duplex section produced no comparable data.
+func TestRenderDuplexCompare_NoOverlapErrorsAfterFallback(t *testing.T) {
+	// Two duplex rows with the same auth on each side (so the auth
+	// compare picks them) but DIFFERENT scenarios. Neither within-run
+	// (different runs anyway) nor cross-run (still different scenarios)
+	// pairing produces a match.
+	rowB := strings.Replace(duplexRowOld, `"scenario":"Duplex_Probe_FanOut"`, `"scenario":"Duplex_PortForward"`, 1)
+	rowB = strings.Replace(rowB, `"axes":{"auth":"sas","delay":"zero"}`, `"axes":{"auth":"entra","delay":"zero"}`, 1)
+	rowB = strings.Replace(rowB, `"run":"20260601T100000.000Z-aaaa"`, `"run":"20260601T110000.000Z-bbbb"`, 1)
+	recs, _, err := load([]string{writeTemp(t, duplexRowOld, rowB)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = renderDuplexCompare(&strings.Builder{}, recs, "auth", "sas", "entra")
+	if err == nil || !strings.Contains(err.Error(), "no duplex cells matched on both sides") {
+		t.Errorf("want post-fallback no-overlap error, got %v", err)
+	}
+}
+
+// TestRenderStreamCompare_NoOverlapErrorsAfterFallback is the streaming
+// counterpart of the duplex post-fallback test. Without this, a
+// streaming side that paired nothing would silently render dashes and
+// let --fail-over exit 0 if rtt happened to pass.
+func TestRenderStreamCompare_NoOverlapErrorsAfterFallback(t *testing.T) {
+	rowB := strings.Replace(streamRowOld, `"scenario":"StreamS"`, `"scenario":"StreamOther"`, 1)
+	rowB = strings.Replace(rowB, `"axes":{"auth":"sas","delay":"ff"}`, `"axes":{"auth":"entra","delay":"ff"}`, 1)
+	rowB = strings.Replace(rowB, `"run":"20260601T100000.000Z-aaaa"`, `"run":"20260601T110000.000Z-bbbb"`, 1)
+	recs, _, err := load([]string{writeTemp(t, streamRowOld, rowB)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = renderStreamCompare(&strings.Builder{}, recs, "auth", "sas", "entra")
+	if err == nil || !strings.Contains(err.Error(), "no streaming cells matched on both sides") {
+		t.Errorf("want post-fallback no-overlap error, got %v", err)
+	}
+}
+
 func TestDuplexGateVerdict_PercentAndFloor(t *testing.T) {
 	gs := gateStats{
 		duplexPaired:     1,

--- a/e2e/cmd/perfreport/main_test.go
+++ b/e2e/cmd/perfreport/main_test.go
@@ -825,8 +825,15 @@ func TestRenderCompare_CrossRunFallback(t *testing.T) {
 	if gs.paired == 0 {
 		t.Errorf("expected at least one paired cell via cross-run fallback")
 	}
-	if !strings.Contains(b.String(), "note: pairing rows across runs") {
-		t.Errorf("expected cross-run fallback note, got:\n%s", b.String())
+	out := b.String()
+	if !strings.Contains(out, "note: pairing rows across runs") {
+		t.Errorf("expected cross-run fallback note, got:\n%s", out)
+	}
+	// The two paired rows came from different runs; a single "run"
+	// column would arbitrarily pick one of them and misrepresent the
+	// comparison. It should be hidden in cross-run mode.
+	if hdr := headerLine(out); strings.Contains(hdr, "\trun\t") || strings.HasSuffix(hdr, "\trun") {
+		t.Errorf("cross-run compare should not show a run column (each side is a different run):\n%s", out)
 	}
 }
 

--- a/e2e/cmd/perfreport/main_test.go
+++ b/e2e/cmd/perfreport/main_test.go
@@ -805,10 +805,37 @@ func TestRenderCompare_ByLegacyAxis(t *testing.T) {
 	}
 }
 
-func TestRenderCompare_NoOverlapNonRunErrors(t *testing.T) {
-	// mock and azure live in separate runs, so a backend compare has no
-	// residual that exists on both sides.
+func TestRenderCompare_CrossRunFallback(t *testing.T) {
+	// mock and azure live in separate runs but share scenario/mode/axes,
+	// so a backend compare cannot pair them within a run. The cross-run
+	// fallback should pair them anyway, with a note announcing the
+	// cross-run pairing, because that comparison ("what does the real
+	// network cost on top of the mock?") is exactly what someone asks
+	// when they compare backends across two runs.
 	recs, _, err := load([]string{writeTemp(t, rowR1SasNN, rowAzureRun)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var b strings.Builder
+	gs, err := renderCompare(&b, recs, "backend", "mock", "azure")
+	if err != nil {
+		t.Fatalf("cross-run compare should succeed, got: %v", err)
+	}
+	if gs.paired == 0 {
+		t.Errorf("expected at least one paired cell via cross-run fallback")
+	}
+	if !strings.Contains(b.String(), "note: pairing rows across runs") {
+		t.Errorf("expected cross-run fallback note, got:\n%s", b.String())
+	}
+}
+
+func TestRenderCompare_TrueNoOverlapErrors(t *testing.T) {
+	// rowR1SasNN: backend=mock, scenario=S, mode=PortForward.
+	// rowDifferentScenario: backend=azure, scenario=DIFFERENT (otherwise
+	// matching). Cross-run fallback can't bridge the different scenarios,
+	// so the comparison legitimately has no pairs and errors.
+	const rowDifferentScenario = `{"type":"row","schema":"perfmatrix/v1","run":"20260601T120000.000Z-cccc","backend":"azure","axes":{"auth":"sas","delay":"nn"},"scenario":"DIFFERENT","mode":"PortForward","cold_p50_ns":1450000000,"warm_p50_ns":210000000,"warm_p95_ns":215000000,"cold_n":5,"warm_n":25,"success_n":5,"attempt_n":5,"wall_ns":2500000000}`
+	recs, _, err := load([]string{writeTemp(t, rowR1SasNN, rowDifferentScenario)})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/e2e/cmd/perfreport/main_test.go
+++ b/e2e/cmd/perfreport/main_test.go
@@ -901,6 +901,88 @@ func headerLine(out string) string {
 	return ""
 }
 
+// Duplex-family rows (metric_family="duplex"). Old/new share a cell
+// across two runs so renderDuplexCompare pairs them via the cross-run
+// fallback. rtt_p50 moves 5ms->10ms (+100%, a gated regression);
+// rtt_p95 moves 9ms->18ms (also gated).
+const (
+	duplexRowOld = `{"type":"row","schema":"perfmatrix/v1","metric_family":"duplex","run":"20260601T100000.000Z-aaaa","backend":"mock","axes":{"auth":"sas","delay":"zero"},"scenario":"Duplex_Probe_FanOut","mode":"SOCKS5","rtt_p50_ns":5000000,"rtt_p95_ns":9000000,"req_leg_p50_ns":2000000,"req_leg_p95_ns":4000000,"resp_leg_p50_ns":2000000,"resp_leg_p95_ns":4000000,"think_p50_ns":1000,"think_p95_ns":3000,"acks_per_sec":100,"bytes_per_sec_per_dir":5000,"ack_spread":2,"sample_n":50,"flow_n":4,"success_n":4,"attempt_n":4,"wall_ns":2000000000}`
+	duplexRowNew = `{"type":"row","schema":"perfmatrix/v1","metric_family":"duplex","run":"20260601T120000.000Z-bbbb","backend":"mock","axes":{"auth":"sas","delay":"default"},"scenario":"Duplex_Probe_FanOut","mode":"SOCKS5","rtt_p50_ns":10000000,"rtt_p95_ns":18000000,"req_leg_p50_ns":4000000,"req_leg_p95_ns":8000000,"resp_leg_p50_ns":4000000,"resp_leg_p95_ns":8000000,"think_p50_ns":1000,"think_p95_ns":3000,"acks_per_sec":50,"bytes_per_sec_per_dir":2500,"ack_spread":1,"sample_n":50,"flow_n":4,"success_n":4,"attempt_n":4,"wall_ns":2100000000}`
+)
+
+func TestRenderDuplexCompare_CrossRunDeltas(t *testing.T) {
+	recs, _, err := load([]string{writeTemp(t, duplexRowOld, duplexRowNew)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var b strings.Builder
+	gs, err := renderDuplexCompare(&b, recs, "delay", "zero", "default")
+	if err != nil {
+		t.Fatalf("renderDuplexCompare: %v", err)
+	}
+	out := b.String()
+	// rtt_p50 5ms -> 10ms = +100%; rtt_p95 9ms -> 18ms = +100%.
+	if !strings.Contains(out, "+100.0%") {
+		t.Errorf("expected +100%% delta on rtt p50/p95:\n%s", out)
+	}
+	if !strings.Contains(out, "note: pairing duplex rows across runs") {
+		t.Errorf("expected cross-run note for separate-run duplex compare:\n%s", out)
+	}
+	if gs.duplexPaired != 1 || gs.duplexComparable != 1 {
+		t.Errorf("paired=%d comparable=%d; want 1/1", gs.duplexPaired, gs.duplexComparable)
+	}
+	if len(gs.duplexRegressions) != 2 {
+		t.Errorf("expected 2 regressions (rtt_p50 + rtt_p95), got %d", len(gs.duplexRegressions))
+	}
+}
+
+func TestRenderDuplexCompare_NoDuplexRowsIsSkippable(t *testing.T) {
+	// Only rtt rows; renderDuplexCompare must signal nothing to compare.
+	recs, _, err := load([]string{writeTemp(t, rowR1SasNN, rowR1EntraNN)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = renderDuplexCompare(&strings.Builder{}, recs, "auth", "sas", "entra")
+	if !errors.Is(err, errNoDuplexRows) {
+		t.Errorf("want errNoDuplexRows, got %v", err)
+	}
+}
+
+func TestDuplexGateVerdict_PercentAndFloor(t *testing.T) {
+	gs := gateStats{
+		duplexPaired:     1,
+		duplexComparable: 1,
+		duplexRegressions: []regression{
+			{label: "small", pct: 5, absNs: int64(2 * time.Millisecond)},        // below pct
+			{label: "big-noisy", pct: 200, absNs: int64(10 * time.Microsecond)}, // below abs floor
+			{label: "real", pct: 50, absNs: int64(30 * time.Millisecond)},       // breaches both
+		},
+	}
+	worst, err := duplexGateVerdict(gs, 30, 20*time.Millisecond)
+	if err != nil {
+		t.Fatalf("verdict err: %v", err)
+	}
+	if worst == nil || worst.label != "real" {
+		t.Errorf("worst=%+v, want label=real", worst)
+	}
+}
+
+func TestDuplexGateVerdict_PairedButUncomparableErrors(t *testing.T) {
+	gs := gateStats{duplexPaired: 1, duplexComparable: 0}
+	_, err := duplexGateVerdict(gs, 10, time.Millisecond)
+	if err == nil || !strings.Contains(err.Error(), "duplex cells paired but none carried a comparable") {
+		t.Errorf("want paired-but-uncomparable error, got %v", err)
+	}
+}
+
+func TestDuplexGateVerdict_NoPairsIsNoOp(t *testing.T) {
+	gs := gateStats{}
+	worst, err := duplexGateVerdict(gs, 10, time.Millisecond)
+	if err != nil || worst != nil {
+		t.Errorf("no-pairs duplex gate must be (nil, nil), got worst=%v err=%v", worst, err)
+	}
+}
+
 const rowAzureRun = `{"type":"row","schema":"perfmatrix/v1","run":"20260601T120000.000Z-cccc","backend":"azure","axes":{"auth":"sas","delay":"nn"},"scenario":"S","mode":"PortForward","cold_p50_ns":1450000000,"warm_p50_ns":210000000,"warm_p95_ns":215000000,"cold_n":5,"warm_n":25,"success_n":5,"attempt_n":5,"wall_ns":2500000000}`
 
 // Streaming-family rows (metric_family="stream"). Old/new share a cell
@@ -1067,8 +1149,10 @@ func TestCompare_StreamOnlyArtifactStillGates(t *testing.T) {
 		t.Fatal(err)
 	}
 	// RTT side: nothing to compare (no rtt rows) -> skippable, not fatal.
-	if _, rttErr := renderCompare(&strings.Builder{}, recs, "run", "previous", "latest"); !errors.Is(rttErr, errNotEnoughRuns) {
-		t.Fatalf("rtt renderCompare err = %v, want errNotEnoughRuns", rttErr)
+	// Either errNotEnoughRuns or errNoRTTRows is acceptable — both are
+	// in the orchestration's "skippable" set.
+	if _, rttErr := renderCompare(&strings.Builder{}, recs, "run", "previous", "latest"); !errors.Is(rttErr, errNotEnoughRuns) && !errors.Is(rttErr, errNoRTTRows) {
+		t.Fatalf("rtt renderCompare err = %v, want errNotEnoughRuns or errNoRTTRows", rttErr)
 	}
 	// Streaming side: pairs and trips the gate on its own.
 	sgs, sErr := renderStreamCompare(&strings.Builder{}, recs, "run", "previous", "latest")

--- a/e2e/scenarios/backend.go
+++ b/e2e/scenarios/backend.go
@@ -137,6 +137,17 @@ type Backend interface {
 	// no testing.TB to fail on cleanly).
 	Cell(values map[string]string) Backend
 
+	// Pins returns the dimensional values this Backend has baked in
+	// rather than advertised as axes — the configuration knobs a run
+	// is using but not sweeping. Combined with the per-cell axis
+	// values from Axes/Cell, this gives every recorded matrix row a
+	// complete identity (e.g., {"auth":"sas","delay":"zero"}) so
+	// cross-run and cross-cell comparisons work regardless of which
+	// dimensions happened to be axes vs pinned for any given run.
+	// Backends that have nothing pinned (or no dimensional knobs at
+	// all) return nil.
+	Pins() map[string]string
+
 	// ConnectLatencyThreshold is the per-backend ceiling for a single
 	// fresh-connection round-trip (Dial → 1-byte write → 1-byte echo
 	// read → Close). It feeds the echo-workload scenarios' per-round

--- a/e2e/scenarios/duplexworkload.go
+++ b/e2e/scenarios/duplexworkload.go
@@ -1,0 +1,407 @@
+package scenarios
+
+import (
+	"fmt"
+	"net"
+	"sync"
+	"testing"
+	"time"
+)
+
+// DuplexShape configures a continuous, bidirectional request/response
+// workload driven by probeFlow against ServerProbe targets. It is the
+// perf-family peer of WorkloadShape (short-conn rtt) and StreamShape
+// (server-paced trickle). Each flow holds one TCP connection open for
+// Duration and runs paced request/response exchanges, recording per-leg
+// timings in a bounded sample ring.
+//
+// The duplex shape exists so a test can answer "what round-trip and
+// per-leg latency should I expect under sustained bidirectional load",
+// across the same backend/auth/delay axes as the other families.
+type DuplexShape struct {
+	// Flows is the number of concurrent probeFlows held open after the
+	// release barrier. Each flow runs on its own TCP connection.
+	Flows int
+
+	// NumTargets is the count of distinct ServerProbe targets the flows
+	// fan out across (round-robin). SOCKS5 fan-out requires >1; the
+	// PortForward path is single-target by design.
+	NumTargets int
+
+	// Mode is the sender mode. ModeSOCKS5 supports NumTargets > 1;
+	// ModePortForward implies NumTargets == 1 (the single sender bind
+	// terminates at one target).
+	Mode SenderMode
+
+	// Interval is the per-flow probe interval; passed to ProbeConfig.
+	Interval time.Duration
+
+	// MaxOutstanding bounds in-flight requests per flow. 1 gives clean
+	// per-leg latency (no self-induced queueing in requestLeg). Values
+	// > 1 measure pipelined throughput at the cost of per-leg purity.
+	MaxOutstanding int
+
+	// BodySize is the request and response body pattern bytes per
+	// exchange, excluding the 28-byte probe header.
+	BodySize int
+
+	// ProcessingDelay is the server-side think time, mirrored from the
+	// other shapes for parity.
+	ProcessingDelay time.Duration
+
+	// Duration is the steady-state window after the release barrier.
+	// Flows are stopped at Duration's end and metrics aggregated from
+	// the samples retained in each flow's ring buffer.
+	Duration time.Duration
+
+	// SampleSize is the per-flow ring-buffer size, passed to ProbeConfig.
+	// Larger values give percentiles a longer steady-state tail at the
+	// cost of memory. Set such that SampleSize * Flows is the maximum
+	// resident sample population.
+	SampleSize int
+
+	// RepeatRounds runs the whole barrier-and-run cycle this many times
+	// (default 1).
+	RepeatRounds int
+}
+
+func (s DuplexShape) probeConfig() ProbeConfig {
+	return ProbeConfig{
+		Interval:       s.Interval,
+		ReqSize:        s.BodySize,
+		RespSize:       s.BodySize,
+		MaxOutstanding: s.MaxOutstanding,
+		SampleSize:     s.SampleSize,
+	}
+}
+
+func (s DuplexShape) serverBehavior() ServerBehavior {
+	return ServerBehavior{
+		Mode:            ServerProbe,
+		RespSize:        s.BodySize,
+		ProcessingDelay: s.ProcessingDelay,
+	}
+}
+
+// validate checks DuplexShape invariants after defaults are filled.
+func (s DuplexShape) validate() error {
+	if s.Flows < 1 {
+		return fmt.Errorf("DuplexShape.Flows must be >= 1, got %d", s.Flows)
+	}
+	if s.NumTargets < 1 {
+		return fmt.Errorf("DuplexShape.NumTargets must be >= 1, got %d", s.NumTargets)
+	}
+	if s.BodySize < 1 {
+		return fmt.Errorf("DuplexShape.BodySize must be >= 1, got %d", s.BodySize)
+	}
+	if s.Duration <= 0 {
+		return fmt.Errorf("DuplexShape.Duration must be > 0, got %v", s.Duration)
+	}
+	if s.MaxOutstanding < 1 {
+		return fmt.Errorf("DuplexShape.MaxOutstanding must be >= 1, got %d", s.MaxOutstanding)
+	}
+	if s.Mode != ModeSOCKS5 && s.Mode != ModePortForward {
+		return fmt.Errorf("DuplexShape.Mode must be ModeSOCKS5 or ModePortForward, got %v", s.Mode)
+	}
+	if s.Mode == ModePortForward && s.NumTargets != 1 {
+		return fmt.Errorf("DuplexShape.Mode=PortForward requires NumTargets==1, got %d", s.NumTargets)
+	}
+	return nil
+}
+
+func runDuplexWorkload(t *testing.T, b Backend, s DuplexShape) {
+	t.Helper()
+	AssertNoLeaks(t)
+	if s.NumTargets <= 0 {
+		s.NumTargets = 1
+	}
+	if s.MaxOutstanding <= 0 {
+		s.MaxOutstanding = 1
+	}
+	if s.RepeatRounds <= 0 {
+		s.RepeatRounds = 1
+	}
+	if err := s.validate(); err != nil {
+		t.Fatalf("invalid DuplexShape: %v", err)
+	}
+
+	// One ServerProbe target per fan-out endpoint. SOCKS5 fans out
+	// across them; PortForward terminates at NumTargets==1.
+	addrs := make([]string, s.NumTargets)
+	behavior := s.serverBehavior()
+	srvs := make([]*WorkloadServer, s.NumTargets)
+	for i := range addrs {
+		srvs[i] = StartWorkloadServer(t, behavior)
+		addrs[i] = srvs[i].Addr()
+	}
+
+	setup := SetupOptions{
+		NumListeners:   1,
+		SenderMode:     s.Mode,
+		AllowedTargets: addrs,
+	}
+	if s.Mode == ModePortForward {
+		setup.Target = addrs[0]
+	}
+	tun := b.Setup(t, setup)
+
+	for r := 0; r < s.RepeatRounds; r++ {
+		if s.RepeatRounds > 1 {
+			t.Logf("--- duplex round %d/%d ---", r+1, s.RepeatRounds)
+		}
+		runDuplexRound(t, tun, addrs, srvs, b.ConnectLatencyThreshold(), s)
+	}
+}
+
+// flowResult is one probeFlow's outcome at the end of a duplex round.
+type flowResult struct {
+	samples []probeExchange
+	summary probeSummary
+	acked   int64
+	err     error
+}
+
+func runDuplexRound(t *testing.T, tun *Tunnel, addrs []string, srvs []*WorkloadServer, threshold time.Duration, s DuplexShape) {
+	budget := duplexBudget(threshold, s)
+	start := time.Now()
+	roundDeadline := start.Add(budget)
+
+	flows := make([]*probeFlow, s.Flows)
+	conns := make([]net.Conn, s.Flows)
+	results := make([]flowResult, s.Flows)
+	cfg := s.probeConfig()
+
+	// Phase 1: each goroutine dials and constructs (but does not start)
+	// a probeFlow. We don't use startProbeFlow because that would begin
+	// traffic before the barrier — the point of the barrier is that all
+	// flows run under simultaneous load for fairness comparisons.
+	var ready sync.WaitGroup
+	var done sync.WaitGroup
+	release := make(chan struct{})
+	var releaseTime time.Time
+	ready.Add(s.Flows)
+	done.Add(s.Flows)
+
+	for i := 0; i < s.Flows; i++ {
+		go func(i int) {
+			defer done.Done()
+			target := addrs[i%len(addrs)]
+
+			dialTimeout := time.Until(roundDeadline)
+			if dialTimeout > 60*time.Second {
+				dialTimeout = 60 * time.Second
+			}
+			if dialTimeout <= 0 {
+				results[i] = flowResult{err: fmt.Errorf("flow[%d]: round budget exhausted before dial", i)}
+				ready.Done()
+				return
+			}
+
+			var (
+				c   net.Conn
+				err error
+			)
+			switch s.Mode {
+			case ModeSOCKS5:
+				c, err = DialSOCKS5(tun.SenderAddr, target, dialTimeout)
+			case ModePortForward:
+				c, err = net.DialTimeout("tcp", tun.SenderAddr, dialTimeout)
+			}
+			if err != nil {
+				results[i] = flowResult{err: fmt.Errorf("flow[%d] dial: %w", i, err)}
+				ready.Done()
+				return
+			}
+			conns[i] = c
+
+			f := newProbeFlow(c, cfg)
+			flows[i] = f
+
+			ready.Done()
+			<-release
+
+			f.Start()
+			// Run for Duration, then Stop. Any read-side break terminates
+			// the flow early via reader's defer; Stop after that is a
+			// no-op.
+			deadline := releaseTime.Add(s.Duration)
+			select {
+			case <-time.After(time.Until(deadline)):
+			case <-f.stopCh:
+			}
+			f.Stop()
+
+			samples := f.Samples()
+			summary := f.Summary()
+			res := flowResult{
+				samples: samples,
+				summary: summary,
+				acked:   summary.acked,
+			}
+			minAcks := minProgressFloor(s)
+			switch {
+			case summary.broken:
+				res.err = fmt.Errorf("flow[%d] broken: %v", i, summary.firstErr)
+			case summary.writeErr != nil:
+				res.err = fmt.Errorf("flow[%d] write error: %v", i, summary.writeErr)
+			case summary.acked+1 < int64(minAcks):
+				res.err = fmt.Errorf("flow[%d] insufficient progress: acked %d, want >= %d", i, summary.acked+1, minAcks)
+			}
+			results[i] = res
+		}(i)
+	}
+
+	ready.Wait()
+	releaseTime = time.Now()
+	close(release)
+	done.Wait()
+	wall := time.Since(start)
+
+	// Best-effort conn cleanup (Stop already closed them, but if a flow
+	// failed before construction the conn may still be live).
+	for i := range conns {
+		if conns[i] != nil {
+			_ = conns[i].Close() //nolint:errcheck
+		}
+	}
+	// Free server-side records held for any nonces the flows allocated.
+	for i, f := range flows {
+		if f == nil {
+			continue
+		}
+		// The flow's target was addrs[i%len(addrs)], which is srvs[i%len(addrs)].
+		_, _ = srvs[i%len(srvs)].ConsumeProbeRecord(f.nonce)
+	}
+
+	m := aggregateDuplex(results, s, wall)
+	logDuplexSummary(t, s, addrs, m)
+	if m.successN < s.Flows {
+		for i, r := range results {
+			if r.err != nil {
+				t.Logf("duplex flow[%d] failed: %v (samples=%d acked=%d)", i, r.err, len(r.samples), r.acked)
+			}
+		}
+		t.Errorf("%d/%d duplex flows failed", s.Flows-m.successN, s.Flows)
+	}
+	recordDuplexMatrixRow(t.Name(), m)
+
+	const sanityEpsilon = 5 * time.Second
+	if wall > budget+sanityEpsilon {
+		t.Fatalf("sanity: duplex round wall=%v exceeded budget=%v + epsilon=%v (shape: %+v)", wall, budget, sanityEpsilon, s)
+	}
+}
+
+// duplexMetrics is the aggregate of one duplex round.
+type duplexMetrics struct {
+	rttP50, rttP95         time.Duration
+	reqLegP50, reqLegP95   time.Duration
+	respLegP50, respLegP95 time.Duration
+	thinkP50, thinkP95     time.Duration
+	acksPerSec             int64
+	// bytesPerSecPerDir is the per-direction application throughput.
+	// DuplexShape uses a symmetric BodySize, so each leg carries the
+	// same number of bytes; the wire load on the bridge is therefore
+	// 2 * bytesPerSecPerDir.
+	bytesPerSecPerDir int64
+	// ackSpread is max-min acks across successful flows. Broken flows
+	// are excluded (their ack count is meaningless after the break),
+	// so this measures fairness among the surviving population.
+	ackSpread int64
+	sampleN   int // total samples pooled across flows
+	flowN     int
+	successN  int
+	wall      time.Duration
+}
+
+func aggregateDuplex(results []flowResult, s DuplexShape, wall time.Duration) duplexMetrics {
+	m := duplexMetrics{flowN: s.Flows, wall: wall}
+	var (
+		rtt, req, resp, think []time.Duration
+		totalAcks             int64
+		minAcks               int64 = -1
+		maxAcks               int64
+	)
+	for _, r := range results {
+		if r.err != nil {
+			continue
+		}
+		m.successN++
+		for _, ex := range r.samples {
+			rtt = append(rtt, ex.rtt)
+			req = append(req, ex.requestLeg)
+			resp = append(resp, ex.responseLeg)
+			think = append(think, ex.serverThink)
+		}
+		// acked is the highest seq acked (-1 before first); count is +1.
+		count := r.acked + 1
+		if count < 0 {
+			count = 0
+		}
+		totalAcks += count
+		if minAcks < 0 || count < minAcks {
+			minAcks = count
+		}
+		if count > maxAcks {
+			maxAcks = count
+		}
+	}
+	m.sampleN = len(rtt)
+	m.rttP50 = repr(rtt, 0.50)
+	m.rttP95 = repr(rtt, 0.95)
+	m.reqLegP50 = repr(req, 0.50)
+	m.reqLegP95 = repr(req, 0.95)
+	m.respLegP50 = repr(resp, 0.50)
+	m.respLegP95 = repr(resp, 0.95)
+	m.thinkP50 = repr(think, 0.50)
+	m.thinkP95 = repr(think, 0.95)
+
+	// Throughput uses the steady-state Duration rather than wall to
+	// exclude the dial/barrier phase. Each ack carries BodySize request
+	// + BodySize response application bytes (probe header excluded).
+	if s.Duration > 0 && m.successN > 0 {
+		secs := s.Duration.Seconds()
+		m.acksPerSec = int64(float64(totalAcks) / secs)
+		m.bytesPerSecPerDir = int64(float64(totalAcks*int64(s.BodySize)) / secs)
+	}
+	if minAcks >= 0 && maxAcks >= minAcks {
+		m.ackSpread = maxAcks - minAcks
+	}
+	return m
+}
+
+// minProgressFloor returns the minimum ack count a flow must reach to
+// be counted as successful. Without a floor, a flow that stalls after
+// its very first ack reports as a success — masking a partial break in
+// the duplex matrix.
+//
+// The floor is a small absolute number (5) rather than scaled to
+// Duration/Interval, because the effective ack rate is bounded by RTT
+// (one outstanding probe at a time waits for the round-trip), which
+// the shape cannot know a priori. A floor that scales with the
+// theoretical max would unfairly fail RTT-bound healthy flows on
+// slower backends; 5 acks is well above a stalled flow (1 ack or
+// fewer) but well below any healthy short-duration run.
+func minProgressFloor(s DuplexShape) int {
+	_ = s
+	return 5
+}
+
+func logDuplexSummary(t *testing.T, s DuplexShape, addrs []string, m duplexMetrics) {
+	t.Logf("duplex-summary scenario=%s rtt_p50=%v rtt_p95=%v req_leg_p50=%v req_leg_p95=%v resp_leg_p50=%v resp_leg_p95=%v think_p50=%v think_p95=%v acks_per_sec=%d bytes_per_sec_per_dir=%d ack_spread=%d sample_n=%d flows=%d num_targets=%d success=%d/%d wall=%v",
+		t.Name(), m.rttP50, m.rttP95, m.reqLegP50, m.reqLegP95, m.respLegP50, m.respLegP95, m.thinkP50, m.thinkP95, m.acksPerSec, m.bytesPerSecPerDir, m.ackSpread, m.sampleN, s.Flows, len(addrs), m.successN, s.Flows, m.wall)
+}
+
+// duplexBudget bounds a duplex round's wall time. It covers concurrent
+// cold connect (two connect thresholds — all flows dial at once, not
+// multiplied by Flows), the active Duration with a generous safety
+// factor for tunnel and scheduler jitter, plus fixed slack and a 60s
+// floor.
+func duplexBudget(threshold time.Duration, s DuplexShape) time.Duration {
+	connect := 2 * threshold
+	active := s.Duration + s.Duration/2 // 1.5x for jitter
+	budget := connect + active + 10*time.Second
+	if budget < 60*time.Second {
+		budget = 60 * time.Second
+	}
+	return budget
+}

--- a/e2e/scenarios/duplexworkload.go
+++ b/e2e/scenarios/duplexworkload.go
@@ -221,9 +221,11 @@ func runDuplexRound(t *testing.T, tun *Tunnel, addrs []string, srvs []*WorkloadS
 			<-release
 
 			f.Start()
-			// Run for Duration, then Stop. Any read-side break terminates
-			// the flow early via reader's defer; Stop after that is a
-			// no-op.
+			// Run for Duration. A read-side break causes the flow's
+			// reader to call signalDone (close stopCh + conn), which
+			// wakes the select below so a broken flow reports
+			// promptly instead of sitting until the full Duration.
+			// Stop afterwards is a no-op for an already-broken flow.
 			deadline := releaseTime.Add(s.Duration)
 			select {
 			case <-time.After(time.Until(deadline)):

--- a/e2e/scenarios/duplexworkload_test.go
+++ b/e2e/scenarios/duplexworkload_test.go
@@ -1,0 +1,217 @@
+package scenarios
+
+import (
+	"testing"
+	"time"
+)
+
+func TestMinProgressFloor(t *testing.T) {
+	cases := []struct {
+		name     string
+		duration time.Duration
+		interval time.Duration
+		want     int
+	}{
+		// Floor is a small absolute number regardless of shape, because
+		// the achievable ack rate is RTT-bounded and unknown a priori.
+		{"zero interval", 5 * time.Second, 0, 5},
+		{"zero duration", 0, 25 * time.Millisecond, 5},
+		{"short coarse", 100 * time.Millisecond, 100 * time.Millisecond, 5},
+		{"medium", 5 * time.Second, 25 * time.Millisecond, 5},
+		{"large", 60 * time.Second, 10 * time.Millisecond, 5},
+	}
+	for _, c := range cases {
+		c := c
+		t.Run(c.name, func(t *testing.T) {
+			got := minProgressFloor(DuplexShape{Duration: c.duration, Interval: c.interval})
+			if got != c.want {
+				t.Errorf("minProgressFloor(%v, %v) = %d, want %d", c.duration, c.interval, got, c.want)
+			}
+		})
+	}
+}
+
+func TestDuplexShape_Validate(t *testing.T) {
+	good := DuplexShape{
+		Flows:          2,
+		NumTargets:     2,
+		Mode:           ModeSOCKS5,
+		Interval:       10 * time.Millisecond,
+		MaxOutstanding: 1,
+		BodySize:       32,
+		Duration:       1 * time.Second,
+		SampleSize:     16,
+	}
+	if err := good.validate(); err != nil {
+		t.Fatalf("good shape: %v", err)
+	}
+
+	type tc struct {
+		name string
+		fn   func(s *DuplexShape)
+	}
+	bad := []tc{
+		{"Flows<1", func(s *DuplexShape) { s.Flows = 0 }},
+		{"NumTargets<1", func(s *DuplexShape) { s.NumTargets = 0 }},
+		{"BodySize<1", func(s *DuplexShape) { s.BodySize = 0 }},
+		{"Duration<=0", func(s *DuplexShape) { s.Duration = 0 }},
+		{"MaxOutstanding<1", func(s *DuplexShape) { s.MaxOutstanding = 0 }},
+		{"BadMode", func(s *DuplexShape) { s.Mode = ModeConnect }},
+		{"PortForwardWithFanOut", func(s *DuplexShape) { s.Mode = ModePortForward; s.NumTargets = 2 }},
+	}
+	for _, c := range bad {
+		c := c
+		t.Run(c.name, func(t *testing.T) {
+			s := good
+			c.fn(&s)
+			if err := s.validate(); err == nil {
+				t.Errorf("expected validation error")
+			}
+		})
+	}
+}
+
+func TestAggregateDuplex_PerLegPercentilesAndThroughput(t *testing.T) {
+	// Construct a fixed flow result set with deterministic per-leg timings
+	// so the aggregator's percentile and throughput math is verifiable.
+	mkSamples := func(rtts []time.Duration) []probeExchange {
+		out := make([]probeExchange, len(rtts))
+		for i, r := range rtts {
+			out[i] = probeExchange{
+				seq:         uint32(i),
+				rtt:         r,
+				requestLeg:  r / 2,
+				responseLeg: r/2 - time.Microsecond,
+				serverThink: time.Microsecond,
+			}
+		}
+		return out
+	}
+	results := []flowResult{
+		{samples: mkSamples([]time.Duration{10 * time.Millisecond, 20 * time.Millisecond, 30 * time.Millisecond}), acked: 9},  // 10 acks
+		{samples: mkSamples([]time.Duration{15 * time.Millisecond, 25 * time.Millisecond, 35 * time.Millisecond}), acked: 19}, // 20 acks
+		{err: errTestFlow},
+	}
+	s := DuplexShape{Flows: 3, BodySize: 100, Duration: 1 * time.Second}
+	m := aggregateDuplex(results, s, 2*time.Second)
+
+	if m.flowN != 3 || m.successN != 2 {
+		t.Errorf("flowN/successN = %d/%d, want 3/2", m.flowN, m.successN)
+	}
+	if m.sampleN != 6 {
+		t.Errorf("sampleN=%d, want 6", m.sampleN)
+	}
+	// Pooled rtt = [10,20,30,15,25,35] ms; sorted -> 10,15,20,25,30,35.
+	// p50 with nearest-rank floor on (n-1)*p ≈ position 2 = 20ms.
+	if m.rttP50 != 20*time.Millisecond {
+		t.Errorf("rttP50=%v, want 20ms", m.rttP50)
+	}
+	// p95 ≈ position 4 or 5 (depending on percentile def) -> 30 or 35ms.
+	if m.rttP95 < 30*time.Millisecond || m.rttP95 > 35*time.Millisecond {
+		t.Errorf("rttP95=%v, want 30..35ms", m.rttP95)
+	}
+	// Throughput: 10 + 20 = 30 acks across Duration (1s) = 30 acks/s.
+	if m.acksPerSec != 30 {
+		t.Errorf("acksPerSec=%d, want 30", m.acksPerSec)
+	}
+	// Bytes/sec per direction = acks * BodySize = 30 * 100 = 3000.
+	if m.bytesPerSecPerDir != 3000 {
+		t.Errorf("bytesPerSecPerDir=%d, want 3000", m.bytesPerSecPerDir)
+	}
+	// ack spread = 20 - 10 = 10.
+	if m.ackSpread != 10 {
+		t.Errorf("ackSpread=%d, want 10", m.ackSpread)
+	}
+}
+
+func TestAggregateDuplex_AllFailed_ZeroSafe(t *testing.T) {
+	results := []flowResult{{err: errTestFlow}, {err: errTestFlow}}
+	s := DuplexShape{Flows: 2, BodySize: 100, Duration: 1 * time.Second}
+	m := aggregateDuplex(results, s, 2*time.Second)
+	if m.successN != 0 {
+		t.Errorf("successN=%d, want 0", m.successN)
+	}
+	if m.sampleN != 0 || m.acksPerSec != 0 || m.ackSpread != 0 {
+		t.Errorf("expected all metrics zero on all-failed, got %+v", m)
+	}
+}
+
+func TestRecordDuplexMatrixRow_RoundTrips(t *testing.T) {
+	perfMatrixSink.drain() // start clean
+	t.Cleanup(func() { perfMatrixSink.drain() })
+
+	m := duplexMetrics{
+		rttP50: 5 * time.Millisecond, rttP95: 9 * time.Millisecond,
+		reqLegP50: 2 * time.Millisecond, reqLegP95: 4 * time.Millisecond,
+		respLegP50: 2 * time.Millisecond, respLegP95: 4 * time.Millisecond,
+		thinkP50: 1 * time.Microsecond, thinkP95: 3 * time.Microsecond,
+		acksPerSec: 100, bytesPerSecPerDir: 5000,
+		ackSpread: 2, sampleN: 50, flowN: 4, successN: 4,
+		wall: 2 * time.Second,
+	}
+	recordDuplexMatrixRow("TestE2E_Mock/sas/Duplex_Probe_SOCKS5_FanOut", m)
+	rows := perfMatrixSink.drain()
+	if len(rows) != 1 {
+		t.Fatalf("rows=%d, want 1", len(rows))
+	}
+	r := rows[0]
+	if r.family != duplexFamily {
+		t.Errorf("family=%q, want %q", r.family, duplexFamily)
+	}
+	if r.rttP50 != 5*time.Millisecond || r.rttP95 != 9*time.Millisecond {
+		t.Errorf("rtt p50/p95 mismatch: %v/%v", r.rttP50, r.rttP95)
+	}
+	if r.acksPerSec != 100 || r.sampleN != 50 {
+		t.Errorf("acks/sample mismatch: %d/%d", r.acksPerSec, r.sampleN)
+	}
+
+	rec := r.record()
+	if rec.MetricFamily != duplexFamily {
+		t.Errorf("MetricFamily=%q want %q", rec.MetricFamily, duplexFamily)
+	}
+	if rec.RTTP50Ns == nil || *rec.RTTP50Ns != (5*time.Millisecond).Nanoseconds() {
+		t.Errorf("RTTP50Ns=%v want 5ms", rec.RTTP50Ns)
+	}
+	if rec.AcksPerSec == nil || *rec.AcksPerSec != 100 {
+		t.Errorf("AcksPerSec=%v want 100", rec.AcksPerSec)
+	}
+	if rec.SampleN != 50 || rec.FlowN != 4 {
+		t.Errorf("SampleN/FlowN=%d/%d, want 50/4", rec.SampleN, rec.FlowN)
+	}
+}
+
+func TestRenderDuplexTable_RendersDuplexOnly(t *testing.T) {
+	rows := []perfMatrixRow{
+		{family: "", axis: "sas", scenario: "Echo", mode: "SOCKS5", coldN: 1, warmN: 1, successN: 1, attemptN: 1, wall: time.Second},
+		{family: duplexFamily, axis: "sas", scenario: "Duplex_Probe_FanOut", mode: "SOCKS5", rttP50: 5 * time.Millisecond, rttP95: 9 * time.Millisecond, sampleN: 50, acksPerSec: 100, successN: 4, attemptN: 4, wall: 2 * time.Second},
+	}
+	out := renderDuplexTable(rows)
+	if out == "" {
+		t.Fatalf("renderDuplexTable returned empty for input with one duplex row")
+	}
+	for _, want := range []string{"PERF MATRIX (duplex", "Duplex_Probe_FanOut", "5ms", "100"} {
+		if !contains(out, want) {
+			t.Errorf("rendered table missing %q\n%s", want, out)
+		}
+	}
+	// Must NOT include the rtt-only row.
+	if contains(out, "Echo") {
+		t.Errorf("duplex table erroneously included rtt-only row 'Echo':\n%s", out)
+	}
+}
+
+// errTestFlow is a sentinel for tests that synthesize failed flowResults.
+var errTestFlow = &testFlowErr{}
+
+type testFlowErr struct{}
+
+func (*testFlowErr) Error() string { return "test: synthetic flow error" }
+
+func contains(s, sub string) bool {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}

--- a/e2e/scenarios/matrix.go
+++ b/e2e/scenarios/matrix.go
@@ -256,9 +256,9 @@ func renderDuplexTable(rows []perfMatrixRow) string {
 	var b strings.Builder
 	b.WriteString("\nPERF MATRIX (duplex; per-leg latency under sustained bidirectional load, bytes/s is per direction, ack_spread = max−min acks across successful flows)\n")
 	tw := tabwriter.NewWriter(&b, 0, 0, 2, ' ', 0)
-	_, _ = fmt.Fprintln(tw, "axis\tscenario\tmode\trtt_p50\trtt_p95\treq_leg_p50\treq_leg_p95\tresp_leg_p50\tresp_leg_p95\tthink_p95\tacks/s\tbytes/s\tack_spread\tsample_n\tsuccess\twall")
+	_, _ = fmt.Fprintln(tw, "axis\tscenario\tmode\trtt_p50\trtt_p95\treq_leg_p50\treq_leg_p95\tresp_leg_p50\tresp_leg_p95\tthink_p50\tthink_p95\tacks/s\tbytes/s\tack_spread\tsample_n\tsuccess\twall")
 	for _, r := range duplex {
-		_, _ = fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%d\t%d\t%d\t%d\t%d/%d\t%s\n",
+		_, _ = fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%d\t%d\t%d\t%d\t%d/%d\t%s\n",
 			dash(r.axis), r.scenario, dash(r.mode),
 			durOrDash(r.rttP50, r.sampleN),
 			durOrDash(r.rttP95, r.sampleN),
@@ -266,6 +266,7 @@ func renderDuplexTable(rows []perfMatrixRow) string {
 			durOrDash(r.reqLegP95, r.sampleN),
 			durOrDash(r.respLegP50, r.sampleN),
 			durOrDash(r.respLegP95, r.sampleN),
+			durOrDash(r.thinkP50, r.sampleN),
 			durOrDash(r.thinkP95, r.sampleN),
 			r.acksPerSec, r.bytesPerSecPerDir, r.ackSpread, r.sampleN,
 			r.successN, r.attemptN, round1(r.wall),

--- a/e2e/scenarios/matrix.go
+++ b/e2e/scenarios/matrix.go
@@ -63,9 +63,10 @@ type perfMatrixRow struct {
 // them once at the end. Guarded by a mutex because scenarios (and the
 // conns within them) can record concurrently.
 type perfMatrix struct {
-	mu        sync.Mutex
-	rows      []perfMatrixRow
-	axisNames []string // ordered axis names for this run (from Backend.Axes()), used to label path segments
+	mu          sync.Mutex
+	rows        []perfMatrixRow
+	axisNames   []string // ordered axis names for this run (from Backend.Axes()), used to label path segments
+	backendName string   // backend name registered by the entry point; PERF_MATRIX_BACKEND env var overrides this in perfMatrixBackend()
 }
 
 var perfMatrixSink perfMatrix
@@ -89,6 +90,22 @@ func (m *perfMatrix) snapshotAxisNames() []string {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	return append([]string(nil), m.axisNames...)
+}
+
+// setBackendName records the backend the run is exercising, so the
+// recorded rows and the run header carry the right label without
+// requiring the caller to set PERF_MATRIX_BACKEND. The env var takes
+// precedence over this value in perfMatrixBackend().
+func (m *perfMatrix) setBackendName(name string) {
+	m.mu.Lock()
+	m.backendName = name
+	m.mu.Unlock()
+}
+
+func (m *perfMatrix) snapshotBackendName() string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.backendName
 }
 
 // drain returns the recorded rows in a stable sort order and clears the
@@ -444,11 +461,17 @@ type perfMatrixRunRecord struct {
 }
 
 // perfMatrixBackend names the backend that produced these rows (mock or
-// azure), taken from PERF_MATRIX_BACKEND. The harness itself is
-// backend-agnostic — the entrypoint's Makefile target sets this — so a
-// merged artifact can distinguish, and the reporter can group by, rows
-// from different backends.
-func perfMatrixBackend() string { return os.Getenv("PERF_MATRIX_BACKEND") }
+// azure). PERF_MATRIX_BACKEND overrides; otherwise the recorder uses the
+// backend name the run entry-point registered on the sink via
+// setBackendName, so a normal `make e2e-mock` produces correctly-labeled
+// history with no extra env setup. The env var stays as an explicit
+// override for CI shards or alternative drivers that want a custom label.
+func perfMatrixBackend() string {
+	if v := os.Getenv("PERF_MATRIX_BACKEND"); v != "" {
+		return v
+	}
+	return perfMatrixSink.snapshotBackendName()
+}
 
 func newRunRecord(runID string) perfMatrixRunRecord {
 	return perfMatrixRunRecord{

--- a/e2e/scenarios/matrix.go
+++ b/e2e/scenarios/matrix.go
@@ -43,6 +43,20 @@ type perfMatrixRow struct {
 	finalChunkSpread   time.Duration
 	completionSpread   time.Duration
 	goodputBytesPerSec int64
+
+	// Duplex family (family == "duplex"). Zero on other rows.
+	rttP50            time.Duration
+	rttP95            time.Duration
+	reqLegP50         time.Duration
+	reqLegP95         time.Duration
+	respLegP50        time.Duration
+	respLegP95        time.Duration
+	thinkP50          time.Duration
+	thinkP95          time.Duration
+	acksPerSec        int64
+	bytesPerSecPerDir int64
+	ackSpread         int64
+	sampleN           int
 }
 
 // perfMatrix collects rows across all scenarios in a run and renders
@@ -100,12 +114,12 @@ func (m *perfMatrix) drain() []perfMatrixRow {
 }
 
 // renderTable formats the rtt-family rows as the aligned human-readable
-// matrix. Streaming rows are rendered separately by renderStreamTable.
-// Returns "" if there are no rtt rows.
+// matrix. Streaming and duplex rows are rendered separately. Returns ""
+// if there are no rtt rows.
 func renderTable(rows []perfMatrixRow) string {
 	var rtt []perfMatrixRow
 	for _, r := range rows {
-		if r.family != streamFamily {
+		if r.family == "" {
 			rtt = append(rtt, r)
 		}
 	}
@@ -174,6 +188,42 @@ func goodputCol(r perfMatrixRow) string {
 		return "-"
 	}
 	return fmt.Sprintf("%.1f", float64(r.goodputBytesPerSec)/1024)
+}
+
+// renderDuplexTable formats the duplex-family rows as their own aligned
+// matrix (per-leg p50/p95 + throughput + fairness). Returns "" if there
+// are no duplex rows.
+func renderDuplexTable(rows []perfMatrixRow) string {
+	var duplex []perfMatrixRow
+	for _, r := range rows {
+		if r.family == duplexFamily {
+			duplex = append(duplex, r)
+		}
+	}
+	if len(duplex) == 0 {
+		return ""
+	}
+	var b strings.Builder
+	b.WriteString("\nPERF MATRIX (duplex; per-leg latency under sustained bidirectional load, bytes/s is per direction, ack_spread = max−min acks across successful flows)\n")
+	tw := tabwriter.NewWriter(&b, 0, 0, 2, ' ', 0)
+	_, _ = fmt.Fprintln(tw, "axis\tscenario\tmode\trtt_p50\trtt_p95\treq_leg_p50\treq_leg_p95\tresp_leg_p50\tresp_leg_p95\tthink_p95\tacks/s\tbytes/s\tack_spread\tsample_n\tsuccess\twall")
+	for _, r := range duplex {
+		_, _ = fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%d\t%d\t%d\t%d\t%d/%d\t%s\n",
+			dash(r.axis), r.scenario, dash(r.mode),
+			durOrDash(r.rttP50, r.sampleN),
+			durOrDash(r.rttP95, r.sampleN),
+			durOrDash(r.reqLegP50, r.sampleN),
+			durOrDash(r.reqLegP95, r.sampleN),
+			durOrDash(r.respLegP50, r.sampleN),
+			durOrDash(r.respLegP95, r.sampleN),
+			durOrDash(r.thinkP95, r.sampleN),
+			r.acksPerSec, r.bytesPerSecPerDir, r.ackSpread, r.sampleN,
+			r.successN, r.attemptN, round1(r.wall),
+		)
+	}
+	_ = tw.Flush()
+	b.WriteString("END PERF MATRIX\n")
+	return b.String()
 }
 
 func estCol(r perfMatrixRow) string {
@@ -273,6 +323,35 @@ func recordStreamMatrixRow(scenarioPath string, m streamMetrics) {
 	})
 }
 
+// recordDuplexMatrixRow distils a finished duplex round into one
+// duplex-family matrix row. The duplex metrics live in their own
+// columns; the rtt cold/warm and streaming fields stay zero.
+func recordDuplexMatrixRow(scenarioPath string, m duplexMetrics) {
+	axis, axes, scenario, mode := matrixIdentity(scenarioPath)
+	perfMatrixSink.add(perfMatrixRow{
+		axis:              axis,
+		axes:              axes,
+		scenario:          scenario,
+		mode:              mode,
+		family:            duplexFamily,
+		successN:          m.successN,
+		attemptN:          m.flowN,
+		wall:              m.wall,
+		rttP50:            m.rttP50,
+		rttP95:            m.rttP95,
+		reqLegP50:         m.reqLegP50,
+		reqLegP95:         m.reqLegP95,
+		respLegP50:        m.respLegP50,
+		respLegP95:        m.respLegP95,
+		thinkP50:          m.thinkP50,
+		thinkP95:          m.thinkP95,
+		acksPerSec:        m.acksPerSec,
+		bytesPerSecPerDir: m.bytesPerSecPerDir,
+		ackSpread:         m.ackSpread,
+		sampleN:           m.sampleN,
+	})
+}
+
 // perfMatrixSchema is the artifact schema tag carried by every emitted
 // record. Bump it on any breaking field change so consumers can branch.
 const perfMatrixSchema = "perfmatrix/v1"
@@ -321,6 +400,28 @@ type perfMatrixRecord struct {
 	CompletionSpreadNs *int64 `json:"completion_spread_ns,omitempty"`
 	GoodputBytesPerSec *int64 `json:"goodput_bytes_per_sec,omitempty"`
 	StreamN            int    `json:"stream_n,omitempty"`
+
+	// Duplex family (metric_family == "duplex"). Per-leg p50/p95 from
+	// the steady-state sample population pooled across flows, plus
+	// throughput and per-flow ack fairness. Duration fields are
+	// nullable pointers (null when no flow contributed any samples);
+	// the *PerSec and AckSpread counters use SampleN as their gate.
+	// BytesPerSecPerDir is the per-direction application payload
+	// throughput; DuplexShape currently uses a symmetric BodySize so
+	// both legs carry the same byte count.
+	RTTP50Ns          *int64 `json:"rtt_p50_ns,omitempty"`
+	RTTP95Ns          *int64 `json:"rtt_p95_ns,omitempty"`
+	ReqLegP50Ns       *int64 `json:"req_leg_p50_ns,omitempty"`
+	ReqLegP95Ns       *int64 `json:"req_leg_p95_ns,omitempty"`
+	RespLegP50Ns      *int64 `json:"resp_leg_p50_ns,omitempty"`
+	RespLegP95Ns      *int64 `json:"resp_leg_p95_ns,omitempty"`
+	ThinkP50Ns        *int64 `json:"think_p50_ns,omitempty"`
+	ThinkP95Ns        *int64 `json:"think_p95_ns,omitempty"`
+	AcksPerSec        *int64 `json:"acks_per_sec,omitempty"`
+	BytesPerSecPerDir *int64 `json:"bytes_per_sec_per_dir,omitempty"`
+	AckSpread         *int64 `json:"ack_spread,omitempty"`
+	SampleN           int    `json:"sample_n,omitempty"`
+	FlowN             int    `json:"flow_n,omitempty"`
 }
 
 // perfMatrixRunRecord is the leading "run" meta record that makes an
@@ -438,6 +539,7 @@ func nsIf(d time.Duration, n int) *int64 {
 // streamFamily is the metric_family value carried by streaming rows; the
 // rtt family is the empty string (so legacy v1 artifacts are unchanged).
 const streamFamily = "stream"
+const duplexFamily = "duplex"
 
 // i64If returns a pointer to v when n>0, else nil — the non-duration
 // counterpart of nsIf, used for the goodput counter so an all-failed
@@ -478,6 +580,22 @@ func (r perfMatrixRow) record() perfMatrixRecord {
 		rec.FinalChunkSpreadNs = nsIf(r.finalChunkSpread, r.successN)
 		rec.CompletionSpreadNs = nsIf(r.completionSpread, r.successN)
 		rec.GoodputBytesPerSec = i64If(r.goodputBytesPerSec, r.successN)
+	}
+	if r.family == duplexFamily {
+		rec.MetricFamily = duplexFamily
+		rec.FlowN = r.attemptN
+		rec.SampleN = r.sampleN
+		rec.RTTP50Ns = nsIf(r.rttP50, r.sampleN)
+		rec.RTTP95Ns = nsIf(r.rttP95, r.sampleN)
+		rec.ReqLegP50Ns = nsIf(r.reqLegP50, r.sampleN)
+		rec.ReqLegP95Ns = nsIf(r.reqLegP95, r.sampleN)
+		rec.RespLegP50Ns = nsIf(r.respLegP50, r.sampleN)
+		rec.RespLegP95Ns = nsIf(r.respLegP95, r.sampleN)
+		rec.ThinkP50Ns = nsIf(r.thinkP50, r.sampleN)
+		rec.ThinkP95Ns = nsIf(r.thinkP95, r.sampleN)
+		rec.AcksPerSec = i64If(r.acksPerSec, r.sampleN)
+		rec.BytesPerSecPerDir = i64If(r.bytesPerSecPerDir, r.sampleN)
+		rec.AckSpread = i64If(r.ackSpread, r.sampleN)
 	}
 	return rec
 }
@@ -537,6 +655,9 @@ func finishPerfMatrix(t logf) {
 		t.Logf("%s", table)
 	}
 	if table := renderStreamTable(rows); table != "" {
+		t.Logf("%s", table)
+	}
+	if table := renderDuplexTable(rows); table != "" {
 		t.Logf("%s", table)
 	}
 	if len(rows) == 0 {

--- a/e2e/scenarios/matrix.go
+++ b/e2e/scenarios/matrix.go
@@ -65,8 +65,9 @@ type perfMatrixRow struct {
 type perfMatrix struct {
 	mu          sync.Mutex
 	rows        []perfMatrixRow
-	axisNames   []string // ordered axis names for this run (from Backend.Axes()), used to label path segments
-	backendName string   // backend name registered by the entry point; PERF_MATRIX_BACKEND env var overrides this in perfMatrixBackend()
+	axisNames   []string          // ordered axis names for this run (from Backend.Axes()), used to label path segments
+	backendName string            // backend name registered by the entry point; PERF_MATRIX_BACKEND env var overrides this in perfMatrixBackend()
+	pins        map[string]string // dimensional values pinned by the entry-point Backend (not advertised as axes); merged into every row's axes map so cross-run comparison sees the full identity
 }
 
 var perfMatrixSink perfMatrix
@@ -106,6 +107,38 @@ func (m *perfMatrix) snapshotBackendName() string {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	return m.backendName
+}
+
+// setPins records the dimensional values pinned by the entry-point
+// Backend (auth=sas when E2E_AUTH=sas, delay=zero when E2E_DELAY=zero,
+// etc.). Every recorded row's axes map includes these pins in addition
+// to the per-cell axis values, so a row from a single-delay run still
+// carries its delay identity and is comparable to a row from a different
+// run with a different pinned delay.
+func (m *perfMatrix) setPins(pins map[string]string) {
+	m.mu.Lock()
+	if len(pins) == 0 {
+		m.pins = nil
+	} else {
+		m.pins = make(map[string]string, len(pins))
+		for k, v := range pins {
+			m.pins[k] = v
+		}
+	}
+	m.mu.Unlock()
+}
+
+func (m *perfMatrix) snapshotPins() map[string]string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if len(m.pins) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(m.pins))
+	for k, v := range m.pins {
+		out[k] = v
+	}
+	return out
 }
 
 // drain returns the recorded rows in a stable sort order and clears the
@@ -275,13 +308,26 @@ func round1(d time.Duration) time.Duration {
 // matrixIdentity derives the axis path, named axes, scenario, and mode
 // columns from a sub-test path (t.Name()), shared by the rtt and stream
 // recorders so both families label cells identically.
+//
+// The named axes map merges per-cell axis values (from the sub-test
+// path) with run-wide pinned dimensions (from perfMatrixSink.pins). Pins
+// give a row from a single-value run its full identity — e.g., a row
+// recorded under E2E_DELAY=zero (no delay axis sub-layer) still has
+// axes["delay"]="zero" — so cross-run comparison along the pinned
+// dimension works.
 func matrixIdentity(scenarioPath string) (axis string, axes map[string]string, scenario, mode string) {
 	names := perfMatrixSink.snapshotAxisNames()
+	pins := perfMatrixSink.snapshotPins()
 	axisVals, leaf := splitScenarioPath(scenarioPath, len(names))
 	scenario, mode = splitMode(leaf)
 	axis = strings.Join(axisVals, "/")
-	if len(axisVals) > 0 {
-		axes = make(map[string]string, len(axisVals))
+	if len(axisVals) > 0 || len(pins) > 0 {
+		axes = make(map[string]string, len(axisVals)+len(pins))
+		// Pins first so per-cell axis values win if the same key
+		// appears in both (shouldn't happen, but explicit > implicit).
+		for k, v := range pins {
+			axes[k] = v
+		}
 		for i, v := range axisVals {
 			key := fmt.Sprintf("axis%d", i)
 			if i < len(names) && names[i] != "" {

--- a/e2e/scenarios/matrix_run_test.go
+++ b/e2e/scenarios/matrix_run_test.go
@@ -145,3 +145,37 @@ func TestFinishPerfMatrix_ExplicitWriteIsFatal(t *testing.T) {
 		t.Fatalf("explicit PERF_MATRIX_JSONL write failure must Errorf exactly once, got %d", rec.errorfN)
 	}
 }
+
+// TestPerfMatrixBackend_PrefersEnvOverSink verifies the env var wins
+// over a sink-registered backend name when both are set.
+func TestPerfMatrixBackend_PrefersEnvOverSink(t *testing.T) {
+	perfMatrixSink.setBackendName("mock")
+	t.Cleanup(func() { perfMatrixSink.setBackendName("") })
+	t.Setenv("PERF_MATRIX_BACKEND", "ci-override")
+	if got := perfMatrixBackend(); got != "ci-override" {
+		t.Errorf("perfMatrixBackend()=%q with env set, want ci-override", got)
+	}
+}
+
+// TestPerfMatrixBackend_FallsBackToSink verifies the sink-registered
+// backend name is used when the env var is empty — the "just works"
+// path for a normal `make e2e-mock` invocation.
+func TestPerfMatrixBackend_FallsBackToSink(t *testing.T) {
+	perfMatrixSink.setBackendName("mock")
+	t.Cleanup(func() { perfMatrixSink.setBackendName("") })
+	t.Setenv("PERF_MATRIX_BACKEND", "")
+	if got := perfMatrixBackend(); got != "mock" {
+		t.Errorf("perfMatrixBackend()=%q with sink-set name, want mock", got)
+	}
+}
+
+// TestPerfMatrixBackend_EmptyWhenNeitherSet documents the legacy
+// behavior — if a caller bypasses RunAllScenarios and doesn't set the
+// env, the label stays empty (it can't be inferred from nothing).
+func TestPerfMatrixBackend_EmptyWhenNeitherSet(t *testing.T) {
+	perfMatrixSink.setBackendName("")
+	t.Setenv("PERF_MATRIX_BACKEND", "")
+	if got := perfMatrixBackend(); got != "" {
+		t.Errorf("perfMatrixBackend()=%q with nothing set, want empty", got)
+	}
+}

--- a/e2e/scenarios/matrix_run_test.go
+++ b/e2e/scenarios/matrix_run_test.go
@@ -179,3 +179,51 @@ func TestPerfMatrixBackend_EmptyWhenNeitherSet(t *testing.T) {
 		t.Errorf("perfMatrixBackend()=%q with nothing set, want empty", got)
 	}
 }
+
+// TestMatrixIdentity_PinsMergedIntoAxes verifies that a row recorded
+// from a single-cell run (no axis sub-layers) still carries the pinned
+// dimensional identity from setPins. This is the property that makes
+// cross-run comparison along a pinned dimension work.
+func TestMatrixIdentity_PinsMergedIntoAxes(t *testing.T) {
+	perfMatrixSink.setAxisNames(nil)
+	perfMatrixSink.setPins(map[string]string{"auth": "sas", "delay": "zero"})
+	t.Cleanup(func() {
+		perfMatrixSink.setAxisNames(nil)
+		perfMatrixSink.setPins(nil)
+	})
+
+	axis, axes, scenario, mode := matrixIdentity("TestE2E_Mock/Duplex_Probe_SOCKS5_FanOut")
+	if axis != "" {
+		t.Errorf("axis=%q with no axis layers, want empty", axis)
+	}
+	if scenario != "Duplex_Probe_FanOut" || mode != "SOCKS5" {
+		t.Errorf("scenario/mode = %q/%q, want Duplex_Probe_FanOut/SOCKS5", scenario, mode)
+	}
+	if got, want := axes["auth"], "sas"; got != want {
+		t.Errorf("axes[auth]=%q, want %q", got, want)
+	}
+	if got, want := axes["delay"], "zero"; got != want {
+		t.Errorf("axes[delay]=%q, want %q", got, want)
+	}
+}
+
+// TestMatrixIdentity_AxisValuesWinOverPins verifies that when a
+// dimension is both pinned (shouldn't happen, but guard) and varied as
+// an axis, the per-cell axis value wins so the cell isn't silently
+// mislabelled.
+func TestMatrixIdentity_AxisValuesWinOverPins(t *testing.T) {
+	perfMatrixSink.setAxisNames([]string{"delay"})
+	perfMatrixSink.setPins(map[string]string{"delay": "zero", "auth": "sas"})
+	t.Cleanup(func() {
+		perfMatrixSink.setAxisNames(nil)
+		perfMatrixSink.setPins(nil)
+	})
+
+	_, axes, _, _ := matrixIdentity("TestE2E_Mock/default/Duplex_Probe_SOCKS5_FanOut")
+	if got, want := axes["delay"], "default"; got != want {
+		t.Errorf("axes[delay]=%q, want %q (axis value should win over pin)", got, want)
+	}
+	if got, want := axes["auth"], "sas"; got != want {
+		t.Errorf("axes[auth]=%q, want %q (pin should still appear)", got, want)
+	}
+}

--- a/e2e/scenarios/observability.go
+++ b/e2e/scenarios/observability.go
@@ -311,12 +311,12 @@ func ScenarioControlSessionID_OnConnectedLine(t *testing.T, b Backend) {
 	t.Helper()
 	AssertNoLeaks(t)
 
-	echo := StartPlainEcho(t)
+	srv := StartWorkloadServer(t, ServerBehavior{Mode: ServerProbe, RespSize: defaultProbeBody})
 	tun := b.Setup(t, SetupOptions{
 		NumListeners:   1,
 		SenderMode:     ModePortForward,
-		Target:         echo.Addr(),
-		AllowedTargets: []string{echo.Addr()},
+		Target:         srv.Addr(),
+		AllowedTargets: []string{srv.Addr()},
 	})
 	requireLogs(t, tun)
 
@@ -334,8 +334,8 @@ func ScenarioControlSessionID_OnConnectedLine(t *testing.T, b Backend) {
 	// and accept_ok log lines fire. Subsumes the legacy
 	// TestControl_Events_AzureSuccessPath, which used the same pair
 	// of substring matches against the listener log.
-	if err := runEchoOnce(tun.SenderAddr, "control-session-id-extend\n", 15*time.Second); err != nil {
-		t.Fatalf("echo to drive accept events: %v", err)
+	if err := probeOnce(srv, tun.SenderAddr, defaultProbeBody, defaultProbeBody, 15*time.Second); err != nil {
+		t.Fatalf("probe to drive accept events: %v", err)
 	}
 	waitForLogLineContaining(t, lst.Logs, 10*time.Second, "accept_attempted")
 	waitForLogLineContaining(t, lst.Logs, 10*time.Second, "accept_ok")
@@ -646,16 +646,16 @@ func ScenarioMetrics_EndpointShape(t *testing.T, b Backend) {
 func ScenarioMetrics_BothSidesConverge(t *testing.T, b Backend) {
 	t.Helper()
 	AssertNoLeaks(t)
-	echo := StartPlainEcho(t)
+	srv := StartWorkloadServer(t, ServerBehavior{Mode: ServerProbe, RespSize: defaultProbeBody})
 	tun := b.Setup(t, SetupOptions{
 		NumListeners:   1,
 		SenderMode:     ModePortForward,
-		Target:         echo.Addr(),
-		AllowedTargets: []string{echo.Addr()},
+		Target:         srv.Addr(),
+		AllowedTargets: []string{srv.Addr()},
 	})
 
 	for i := 0; i < 3; i++ {
-		if err := runEchoOnce(tun.SenderAddr, "metrics-converge\n", 15*time.Second); err != nil {
+		if err := probeOnce(srv, tun.SenderAddr, defaultProbeBody, defaultProbeBody, 15*time.Second); err != nil {
 			t.Fatalf("round-trip %d: %v", i, err)
 		}
 	}
@@ -685,19 +685,19 @@ func ScenarioMetrics_BothSidesConverge(t *testing.T, b Backend) {
 func ScenarioMetrics_DialDuration(t *testing.T, b Backend) {
 	t.Helper()
 	AssertNoLeaks(t)
-	echo := StartPlainEcho(t)
+	srv := StartWorkloadServer(t, ServerBehavior{Mode: ServerProbe, RespSize: defaultProbeBody})
 	tun := b.Setup(t, SetupOptions{
 		NumListeners:   1,
 		SenderMode:     ModePortForward,
-		Target:         echo.Addr(),
-		AllowedTargets: []string{echo.Addr()},
+		Target:         srv.Addr(),
+		AllowedTargets: []string{srv.Addr()},
 	})
 
 	if tun.Senders[0].DialDurationSamples == nil {
 		t.Skipf("Metrics_DialDuration: %s backend does not expose DialDurationSamples", b.Name())
 	}
 
-	if err := runEchoOnce(tun.SenderAddr, "dial-duration\n", 15*time.Second); err != nil {
+	if err := probeOnce(srv, tun.SenderAddr, defaultProbeBody, defaultProbeBody, 15*time.Second); err != nil {
 		t.Fatalf("round-trip: %v", err)
 	}
 
@@ -723,12 +723,12 @@ func ScenarioMetrics_DialDuration(t *testing.T, b Backend) {
 func ScenarioListenerID_PropagatesAndChangesOnRestart(t *testing.T, b Backend) {
 	t.Helper()
 	AssertNoLeaks(t)
-	echo := StartPlainEcho(t)
+	srv := StartWorkloadServer(t, ServerBehavior{Mode: ServerProbe, RespSize: defaultProbeBody})
 	tun := b.Setup(t, SetupOptions{
 		NumListeners:   1,
 		SenderMode:     ModePortForward,
-		Target:         echo.Addr(),
-		AllowedTargets: []string{echo.Addr()},
+		Target:         srv.Addr(),
+		AllowedTargets: []string{srv.Addr()},
 	})
 	requireLogs(t, tun)
 
@@ -738,10 +738,10 @@ func ScenarioListenerID_PropagatesAndChangesOnRestart(t *testing.T, b Backend) {
 
 	// Drive two flows; both must appear on the sender side with
 	// listener_id == idA.
-	if err := runEchoOnce(tun.SenderAddr, "flow-1\n", 15*time.Second); err != nil {
+	if err := probeOnce(srv, tun.SenderAddr, defaultProbeBody, defaultProbeBody, 15*time.Second); err != nil {
 		t.Fatalf("flow 1: %v", err)
 	}
-	if err := runEchoOnce(tun.SenderAddr, "flow-2\n", 15*time.Second); err != nil {
+	if err := probeOnce(srv, tun.SenderAddr, defaultProbeBody, defaultProbeBody, 15*time.Second); err != nil {
 		t.Fatalf("flow 2: %v", err)
 	}
 	obs := waitForNAcceptListenerIDs(t, tun.Senders[0].Logs, 2, 15*time.Second)
@@ -769,7 +769,7 @@ func ScenarioListenerID_PropagatesAndChangesOnRestart(t *testing.T, b Backend) {
 	deadline := time.Now().Add(60 * time.Second)
 	var lastObserved string
 	for time.Now().Before(deadline) {
-		_ = runEchoOnceBest(tun.SenderAddr, "probe\n", 10*time.Second)
+		_ = probeOnce(srv, tun.SenderAddr, defaultProbeBody, defaultProbeBody, 10*time.Second)
 		ids := acceptListenerIDsSince(tun.Senders[0].Logs(), baseline)
 		if len(ids) > 0 {
 			lastObserved = ids[len(ids)-1]
@@ -976,13 +976,6 @@ func acceptListenerIDsSince(logs string, baseline int) []string {
 		return nil
 	}
 	return ids[baseline:]
-}
-
-// runEchoOnceBest is the same as runEchoOnce but swallows errors;
-// used by listener-id restart probes that tolerate transient
-// failures during relay state propagation.
-func runEchoOnceBest(addr, payload string, timeout time.Duration) error {
-	return runEchoOnce(addr, payload, timeout)
 }
 
 // acceptIDLineRe captures the accept_id slog attribute (16 base32

--- a/e2e/scenarios/performance.go
+++ b/e2e/scenarios/performance.go
@@ -84,6 +84,9 @@ func performanceCases() []scenarioCase {
 		// Streaming workload shapes (server-paced trickle).
 		{name: "Stream_Trickle_SOCKS5_FanOut", scope: AnyBackend, run: ScenarioStream_Trickle_SOCKS5_FanOut},
 		{name: "Stream_ConcurrentTrickle_SOCKS5_DistinctTargets", scope: AnyBackend, run: ScenarioStream_ConcurrentTrickle_SOCKS5_DistinctTargets},
+		// Duplex workload shapes (bidirectional probe).
+		{name: "Duplex_Probe_SOCKS5_FanOut", scope: AnyBackend, run: ScenarioDuplex_Probe_SOCKS5_FanOut},
+		{name: "Duplex_Probe_PortForward", scope: AnyBackend, run: ScenarioDuplex_Probe_PortForward},
 	}
 }
 
@@ -1379,6 +1382,70 @@ func ScenarioStream_ConcurrentTrickle_SOCKS5_DistinctTargets(t *testing.T, b Bac
 		TrickleChunkSize: TrickleChunkBytes,
 		StreamChunks:     TrickleChunks,
 		Mode:             ModeSOCKS5,
+	})
+}
+
+// DuplexFlows is the fan-out width for the duplex perf scenarios. 4 is
+// enough to surface per-flow ack fairness without dominating runtime on
+// the slow Azure backend.
+const DuplexFlows = 4
+
+// DuplexBodySize is the request and response body bytes per probe
+// exchange (excludes the 28-byte probe header). 512 bytes is the median
+// of typical small interactive traffic — small enough that latency
+// dominates throughput, big enough that the per-leg measurement isn't
+// noise.
+const DuplexBodySize = 512
+
+// DuplexInterval is the per-flow probe interval. 25 ms gives ~40
+// exchanges per second per flow — enough to populate the sample ring in
+// the steady-state window without saturating the link.
+const DuplexInterval = 25 * time.Millisecond
+
+// DuplexDuration is the steady-state observation window after the
+// release barrier. 5 s reliably yields ~200 samples per flow at the
+// default interval — enough for stable p95s.
+const DuplexDuration = 5 * time.Second
+
+// DuplexSampleSize is the per-flow ring-buffer size. 256 covers the
+// steady-state window at the default interval with headroom for the
+// MaxOutstanding=1 case; larger windows would need a larger ring.
+const DuplexSampleSize = 256
+
+// ScenarioDuplex_Probe_SOCKS5_FanOut runs DuplexFlows concurrent
+// probeFlows fanned out across DuplexFlows distinct ServerProbe targets
+// via SOCKS5. Each flow runs MaxOutstanding=1 paced exchanges for
+// DuplexDuration; the round records per-leg p50/p95 plus per-flow ack
+// fairness. The shape answers "what round-trip and per-leg latency
+// should I expect under sustained bidirectional load on this backend".
+func ScenarioDuplex_Probe_SOCKS5_FanOut(t *testing.T, b Backend) {
+	runDuplexWorkload(t, b, DuplexShape{
+		Flows:          DuplexFlows,
+		NumTargets:     DuplexFlows,
+		Mode:           ModeSOCKS5,
+		Interval:       DuplexInterval,
+		MaxOutstanding: 1,
+		BodySize:       DuplexBodySize,
+		Duration:       DuplexDuration,
+		SampleSize:     DuplexSampleSize,
+	})
+}
+
+// ScenarioDuplex_Probe_PortForward is the single-target PortForward
+// baseline for the duplex shape — same flow count and cadence, but no
+// SOCKS5 fan-out. The pair lets a reader compare per-leg latency
+// between the simpler PortForward path and the multi-target SOCKS5
+// path on the same backend.
+func ScenarioDuplex_Probe_PortForward(t *testing.T, b Backend) {
+	runDuplexWorkload(t, b, DuplexShape{
+		Flows:          DuplexFlows,
+		NumTargets:     1,
+		Mode:           ModePortForward,
+		Interval:       DuplexInterval,
+		MaxOutstanding: 1,
+		BodySize:       DuplexBodySize,
+		Duration:       DuplexDuration,
+		SampleSize:     DuplexSampleSize,
 	})
 }
 

--- a/e2e/scenarios/probe.go
+++ b/e2e/scenarios/probe.go
@@ -543,7 +543,21 @@ func (f *probeFlow) localize(srv *WorkloadServer) string {
 // attribution.
 func probeOnce(srv *WorkloadServer, addr string, reqSize, respSize int, timeout time.Duration) error {
 	nonce := randNonce()
-	return localizeProbeError(srv, nonce, probeOnceCore(addr, nonce, reqSize, respSize, timeout))
+	err := probeOnceCore(addr, nonce, reqSize, respSize, timeout)
+	if err != nil {
+		// localizeProbeError consumes the server record (delete-on-read)
+		// while enriching the error with per-leg attribution.
+		return localizeProbeError(srv, nonce, err)
+	}
+	// Success path: the exchange validated cleanly. Free the server's
+	// per-nonce record so a high-volume caller (Distribution_*,
+	// observability triggers, etc.) doesn't accumulate one terminal
+	// record per dial for the WorkloadServer's lifetime. nil srv is a
+	// no-op.
+	if srv != nil {
+		_, _ = srv.ConsumeProbeRecord(nonce)
+	}
+	return nil
 }
 
 // probeOnceCore is the raw single-exchange driver; probeOnce wraps it

--- a/e2e/scenarios/probe.go
+++ b/e2e/scenarios/probe.go
@@ -619,13 +619,21 @@ func localizeProbeError(srv *WorkloadServer, nonce uint64, err error) error {
 	if !ok {
 		return fmt.Errorf("%w: server has no record for nonce %d (request never reached the server: outbound break)", err, nonce)
 	}
+	// The server only creates a probeConnStat after readFrame returns
+	// AND the frame is a valid frameProbeReq with len(payload) >=
+	// probeHdrLen, so by the time we have a record lastSeqSeen has at
+	// minimum the value from the first request (or the first valid
+	// request after the constructor's initial -1, set by the
+	// monotonicity check below). The non-monotonic-seq and
+	// pattern-mismatch paths in serveProbe also write back a
+	// frameError, which the client surfaces as "server reported
+	// request integrity error" — that real cause is preserved here via
+	// %w; the cases below just attribute the leg.
 	switch {
-	case rec.lastSeqSeen < 0:
-		return fmt.Errorf("%w: server recorded the connection but read no request (outbound break before first frame)", err)
 	case rec.lastWriteStart == 0 || rec.lastWriteStart < rec.lastRecvNano:
 		return fmt.Errorf("%w: server read the request (recv=%v) but had not started its reply (server-path stall)", err, dur(rec.lastRecvNano))
 	case rec.lastWriteDone < rec.lastWriteStart:
-		return fmt.Errorf("%w: server began writing (write_start=%v) but the write did not complete (return-leg failure or server->tunnel write stuck; termErr=%v)", err, dur(rec.lastWriteStart), rec.termErr)
+		return fmt.Errorf("%w: server began writing (write_start=%v) but the write has not completed (return-leg failure or server->tunnel write stuck; termErr=%v)", err, dur(rec.lastWriteStart), rec.termErr)
 	default:
 		return fmt.Errorf("%w: server completed reply (write_done=%v) but the client never read it (return/response-leg break)", err, dur(rec.lastWriteDone))
 	}

--- a/e2e/scenarios/probe.go
+++ b/e2e/scenarios/probe.go
@@ -1,0 +1,482 @@
+package scenarios
+
+import (
+	"encoding/binary"
+	"fmt"
+	"net"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// The probe protocol is a continuous, sequenced, full-duplex
+// request/response flow against a ServerProbe target. It exists so the
+// held-flow topology scenarios (and, later, a bidirectional perf shape)
+// carry observable traffic across a topology change instead of a single
+// blind ping-pong: every exchange records a request leg, server think,
+// and response leg, and a stalled or broken flow can be localized to the
+// outbound or return path.
+//
+// All timestamps in the wire frames are probeNanos() values measured from
+// one process-wide monotonic epoch. Client and target server run in the
+// same test process on the same host, so these stamps are directly
+// subtractable across the two ends; the monotonic epoch (rather than wall
+// clock) makes the per-leg durations immune to NTP slews and never
+// negative for in-order events.
+
+// probe payload header layout, prepended to the pattern bytes of every
+// probe request and response frame.
+const (
+	probeOffSeq       = 0  // uint32  request/echoed sequence number
+	probeOffClient    = 4  // int64   client send timestamp (probeNanos)
+	probeOffSrvRecv   = 12 // int64   server receive timestamp (response only)
+	probeOffSrvSend   = 20 // int64   server send timestamp (response only)
+	probeHdrLen       = 28 // = 4 + 8 + 8 + 8
+	defaultProbeIntvl = 100 * time.Millisecond
+	defaultProbeBody  = 64 // request/response body pattern bytes (excludes header)
+)
+
+// probeEpoch is the single monotonic reference shared by every probe
+// timestamp in this test process. time.Since preserves the monotonic
+// reading, so deltas are stable across the whole run.
+var probeEpoch = time.Now()
+
+func probeNanos() int64 { return int64(time.Since(probeEpoch)) }
+
+func dur(n int64) time.Duration { return time.Duration(n) }
+
+// ProbeConfig configures a probeFlow's cadence and payload sizes. The
+// zero value is filled with calibrated defaults (100ms interval, 64-byte
+// bodies, one outstanding request) by newProbeFlow.
+type ProbeConfig struct {
+	// Interval is the minimum gap between successive requests. Combined
+	// with MaxOutstanding it paces the flow as "send next on ack, no
+	// faster than Interval". Zero means send as fast as the window allows.
+	Interval time.Duration
+
+	// ReqSize / RespSize are the request and response body pattern bytes,
+	// excluding the 28-byte probe header. RespSize MUST equal the target
+	// WorkloadServer's ServerBehavior.RespSize.
+	ReqSize  int
+	RespSize int
+
+	// MaxOutstanding bounds in-flight (sent but unacked) requests. The
+	// topology scenarios use 1 so each exchange's legs are uncontaminated
+	// by self-induced send-queue depth; the perf shape may widen it.
+	MaxOutstanding int
+}
+
+// probeExchange is one completed request/response, with the round-trip
+// split into its constituent legs. All durations share the monotonic
+// epoch, so requestLeg + serverThink + responseLeg == rtt.
+type probeExchange struct {
+	seq         uint32
+	arrival     time.Duration // clientRecv relative to epoch (for inter-ack gap)
+	requestLeg  time.Duration // serverRecv - clientSend
+	serverThink time.Duration // serverSend - serverRecv
+	responseLeg time.Duration // clientRecv - serverSend
+	rtt         time.Duration // clientRecv - clientSend
+}
+
+// probeFlow drives one held-open connection with a sender and a reader
+// goroutine. broken() reports only a read-side break (EOF/RST/integrity
+// failure); a write-side error is recorded for diagnostics but never
+// marks the flow broken, because the property under test is whether the
+// bridge survives, and the canonical signal for a torn bridge is a
+// read-side close.
+type probeFlow struct {
+	conn  net.Conn
+	nonce uint64
+	cfg   ProbeConfig
+
+	stopping atomic.Bool
+	stopOnce sync.Once
+	stopCh   chan struct{}
+	slots    chan struct{}
+	wg       sync.WaitGroup
+
+	lastSeqSent atomic.Int64 // highest seq written (-1 before first)
+	lastSeqAck  atomic.Int64 // highest seq acked (-1 before first)
+	brokenFlag  atomic.Bool  // read-side break observed
+
+	mu        sync.Mutex
+	exchanges []probeExchange
+	firstErr  error // first read-side integrity/break error
+	writeErr  error // first write-side error (does not mark broken)
+}
+
+// newProbeFlow wraps an established connection in a probeFlow. It does
+// not start traffic; call Start. The caller owns the connection's
+// lifetime via Stop (which closes it).
+func newProbeFlow(conn net.Conn, cfg ProbeConfig) *probeFlow {
+	if cfg.Interval == 0 {
+		cfg.Interval = defaultProbeIntvl
+	}
+	if cfg.ReqSize == 0 {
+		cfg.ReqSize = defaultProbeBody
+	}
+	if cfg.RespSize == 0 {
+		cfg.RespSize = defaultProbeBody
+	}
+	if cfg.MaxOutstanding < 1 {
+		cfg.MaxOutstanding = 1
+	}
+	f := &probeFlow{
+		conn:   conn,
+		nonce:  randNonce(),
+		cfg:    cfg,
+		stopCh: make(chan struct{}),
+		slots:  make(chan struct{}, cfg.MaxOutstanding),
+	}
+	f.lastSeqSent.Store(-1)
+	f.lastSeqAck.Store(-1)
+	return f
+}
+
+// Start launches the sender and reader goroutines.
+func (f *probeFlow) Start() {
+	f.wg.Add(2)
+	go f.sender()
+	go f.reader()
+}
+
+// Stop signals shutdown, closes the connection to unblock any in-flight
+// read/write, and waits for both goroutines. It is idempotent.
+func (f *probeFlow) Stop() {
+	f.stopOnce.Do(func() {
+		f.stopping.Store(true)
+		close(f.stopCh)
+		_ = f.conn.Close()
+	})
+	f.wg.Wait()
+}
+
+// broken reports whether the flow has observed a read-side break. It is a
+// pure atomic load and never touches the connection, so it is safe to
+// call concurrently with the running flow and after Stop.
+func (f *probeFlow) broken() bool { return f.brokenFlag.Load() }
+
+// acked returns the highest sequence number acked so far (-1 if none).
+func (f *probeFlow) acked() int64 { return f.lastSeqAck.Load() }
+
+// waitFirstAck blocks until the flow has acked at least one exchange, the
+// flow breaks, or the timeout elapses. It is used to confirm the bridge
+// is established before a scenario proceeds.
+func (f *probeFlow) waitFirstAck(timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if f.acked() >= 0 {
+			return nil
+		}
+		if f.broken() {
+			return fmt.Errorf("flow broke before first ack: %w", f.firstError())
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	return fmt.Errorf("no ack within %v (sent up to seq %d)", timeout, f.lastSeqSent.Load())
+}
+
+func (f *probeFlow) firstError() error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.firstErr
+}
+
+// recordReadErr latches the first read-side error and marks the flow
+// broken. recordWriteErr latches the first write-side error only.
+func (f *probeFlow) recordReadErr(err error) {
+	f.mu.Lock()
+	if f.firstErr == nil {
+		f.firstErr = err
+	}
+	f.mu.Unlock()
+	f.brokenFlag.Store(true)
+}
+
+func (f *probeFlow) recordWriteErr(err error) {
+	f.mu.Lock()
+	if f.writeErr == nil {
+		f.writeErr = err
+	}
+	f.mu.Unlock()
+}
+
+func (f *probeFlow) sender() {
+	defer f.wg.Done()
+	var ticker *time.Ticker
+	if f.cfg.Interval > 0 {
+		ticker = time.NewTicker(f.cfg.Interval)
+		defer ticker.Stop()
+	}
+	body := f.cfg.ReqSize
+	var seq uint32
+	for {
+		select {
+		case <-f.stopCh:
+			return
+		default:
+		}
+		// Acquire an outstanding-request slot (bounds in-flight depth).
+		select {
+		case f.slots <- struct{}{}:
+		case <-f.stopCh:
+			return
+		}
+
+		buf := make([]byte, probeHdrLen+body)
+		binary.BigEndian.PutUint32(buf[probeOffSeq:], seq)
+		fillPattern(buf[probeHdrLen:], f.nonce, int(seq)*body)
+		binary.BigEndian.PutUint64(buf[probeOffClient:], uint64(probeNanos()))
+		if err := writeFrame(f.conn, frameProbeReq, f.nonce, buf); err != nil {
+			if !f.stopping.Load() {
+				f.recordWriteErr(fmt.Errorf("probe write seq %d: %w", seq, err))
+			}
+			return
+		}
+		f.lastSeqSent.Store(int64(seq))
+		seq++
+
+		if ticker != nil {
+			select {
+			case <-f.stopCh:
+				return
+			case <-ticker.C:
+			}
+		}
+	}
+}
+
+func (f *probeFlow) reader() {
+	defer f.wg.Done()
+	for {
+		typ, n, payload, err := readFrame(f.conn)
+		clientRecv := probeNanos()
+		if err != nil {
+			if f.stopping.Load() {
+				return
+			}
+			f.recordReadErr(fmt.Errorf("probe read: %w", err))
+			return
+		}
+		if n != f.nonce {
+			f.recordReadErr(fmt.Errorf("probe nonce %d != flow nonce %d", n, f.nonce))
+			return
+		}
+		if typ == frameError {
+			f.recordReadErr(fmt.Errorf("server reported integrity error (nonce %d)", n))
+			return
+		}
+		if typ != frameProbeResp {
+			f.recordReadErr(fmt.Errorf("unexpected probe frame type %d", typ))
+			return
+		}
+		if len(payload) < probeHdrLen {
+			f.recordReadErr(fmt.Errorf("short probe response header: %d < %d", len(payload), probeHdrLen))
+			return
+		}
+		seq := binary.BigEndian.Uint32(payload[probeOffSeq:])
+		if want := f.lastSeqAck.Load() + 1; int64(seq) != want {
+			f.recordReadErr(fmt.Errorf("probe out of order: got seq %d want %d", seq, want))
+			return
+		}
+		respBody := payload[probeHdrLen:]
+		if len(respBody) != f.cfg.RespSize {
+			f.recordReadErr(fmt.Errorf("probe resp body %d != want %d (seq %d)", len(respBody), f.cfg.RespSize, seq))
+			return
+		}
+		if off, ok := verifyPattern(respBody, f.nonce, int(seq)*f.cfg.RespSize); !ok {
+			f.recordReadErr(fmt.Errorf("probe resp pattern mismatch at offset %d (seq %d)", off, seq))
+			return
+		}
+
+		clientSend := int64(binary.BigEndian.Uint64(payload[probeOffClient:]))
+		srvRecv := int64(binary.BigEndian.Uint64(payload[probeOffSrvRecv:]))
+		srvSend := int64(binary.BigEndian.Uint64(payload[probeOffSrvSend:]))
+		ex := probeExchange{
+			seq:         seq,
+			arrival:     dur(clientRecv),
+			requestLeg:  dur(srvRecv - clientSend),
+			serverThink: dur(srvSend - srvRecv),
+			responseLeg: dur(clientRecv - srvSend),
+			rtt:         dur(clientRecv - clientSend),
+		}
+		f.mu.Lock()
+		f.exchanges = append(f.exchanges, ex)
+		f.mu.Unlock()
+		f.lastSeqAck.Store(int64(seq))
+
+		// Release the slot the matching request consumed.
+		<-f.slots
+	}
+}
+
+// probeSummary is a snapshot of a flow's progress and worst-case legs,
+// for logging and failure dumps. In PR1 the latencies are diagnostic
+// only — never an assertion threshold.
+type probeSummary struct {
+	sent, acked int64
+	exchanges   int
+	maxReqLeg   time.Duration
+	maxRespLeg  time.Duration
+	maxThink    time.Duration
+	maxRTT      time.Duration
+	maxGap      time.Duration // largest gap between successive acked arrivals
+	broken      bool
+	firstErr    error
+	writeErr    error
+}
+
+func (f *probeFlow) Summary() probeSummary {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	s := probeSummary{
+		sent:      f.lastSeqSent.Load(),
+		acked:     f.lastSeqAck.Load(),
+		exchanges: len(f.exchanges),
+		broken:    f.brokenFlag.Load(),
+		firstErr:  f.firstErr,
+		writeErr:  f.writeErr,
+	}
+	var prev time.Duration
+	for i, ex := range f.exchanges {
+		if ex.requestLeg > s.maxReqLeg {
+			s.maxReqLeg = ex.requestLeg
+		}
+		if ex.responseLeg > s.maxRespLeg {
+			s.maxRespLeg = ex.responseLeg
+		}
+		if ex.serverThink > s.maxThink {
+			s.maxThink = ex.serverThink
+		}
+		if ex.rtt > s.maxRTT {
+			s.maxRTT = ex.rtt
+		}
+		if i > 0 {
+			if gap := ex.arrival - prev; gap > s.maxGap {
+				s.maxGap = gap
+			}
+		}
+		prev = ex.arrival
+	}
+	return s
+}
+
+// Dump logs a compact diagnostic: the client-side summary, the worst
+// exchange, and — combining the client's last-acked seq with the server's
+// per-nonce record — a localization of where a break or stall sat.
+func (f *probeFlow) Dump(t *testing.T, srv *WorkloadServer, label string) {
+	t.Helper()
+	s := f.Summary()
+	t.Logf("probe-dump %s: sent=%d acked=%d exchanges=%d broken=%v max_req_leg=%v max_resp_leg=%v max_think=%v max_rtt=%v max_gap=%v first_err=%v write_err=%v",
+		label, s.sent, s.acked, s.exchanges, s.broken, s.maxReqLeg, s.maxRespLeg, s.maxThink, s.maxRTT, s.maxGap, s.firstErr, s.writeErr)
+	t.Logf("probe-dump %s: %s", label, f.localize(srv))
+}
+
+// localize correlates the client's last-acked sequence with the server's
+// last-seen record to attribute a break to the outbound (request) or
+// return (response) path, mirroring the diagnostic ladder the design
+// targets.
+func (f *probeFlow) localize(srv *WorkloadServer) string {
+	acked := f.lastSeqAck.Load()
+	rec, ok := srv.ProbeRecord(f.nonce)
+	if !ok {
+		return fmt.Sprintf("server has no record for nonce %d: no request reached the server (outbound/request-leg break for seq %d)", f.nonce, acked+1)
+	}
+	state := "live"
+	if rec.terminal {
+		state = fmt.Sprintf("terminal(err=%v)", rec.termErr)
+	}
+	switch {
+	case rec.lastSeqSeen <= acked:
+		return fmt.Sprintf("server[%s] last_seq_seen=%d <= client_acked=%d: next request never reached the server (outbound/request-leg break for seq %d)",
+			state, rec.lastSeqSeen, acked, acked+1)
+	case rec.lastWriteStart == 0 || rec.lastWriteStart < rec.lastRecvNano:
+		return fmt.Sprintf("server[%s] read seq %d (recv=%v) but had not started its reply (server-path stall; client_acked=%d)",
+			state, rec.lastSeqSeen, dur(rec.lastRecvNano), acked)
+	case rec.lastWriteDone < rec.lastWriteStart:
+		return fmt.Sprintf("server[%s] began writing seq %d (write_start=%v) but the write did not complete (server->tunnel write blocked; client_acked=%d)",
+			state, rec.lastSeqSeen, dur(rec.lastWriteStart), acked)
+	default:
+		return fmt.Sprintf("server[%s] completed reply for seq %d (write_done=%v) but client only acked %d (return/response-leg break)",
+			state, rec.lastSeqSeen, dur(rec.lastWriteDone), acked)
+	}
+}
+
+// probeOnce performs a single framed request/response exchange against a
+// ServerProbe target reached at addr (one dial, one request, one verified
+// response). It is the framed replacement for runEchoOnce in scenarios
+// whose target is a ServerProbe server.
+func probeOnce(addr string, reqSize, respSize int, timeout time.Duration) error {
+	conn, err := net.DialTimeout("tcp", addr, timeout)
+	if err != nil {
+		return fmt.Errorf("dial: %w", err)
+	}
+	defer conn.Close() //nolint:errcheck // best-effort
+	_ = conn.SetDeadline(time.Now().Add(timeout))
+
+	nonce := randNonce()
+	buf := make([]byte, probeHdrLen+reqSize)
+	binary.BigEndian.PutUint64(buf[probeOffClient:], uint64(probeNanos()))
+	fillPattern(buf[probeHdrLen:], nonce, 0)
+	if err := writeFrame(conn, frameProbeReq, nonce, buf); err != nil {
+		return fmt.Errorf("write: %w", err)
+	}
+	typ, n, payload, err := readFrame(conn)
+	if err != nil {
+		return fmt.Errorf("read: %w", err)
+	}
+	switch {
+	case n != nonce:
+		return fmt.Errorf("response nonce %d != request nonce %d", n, nonce)
+	case typ == frameError:
+		return fmt.Errorf("server reported request integrity error")
+	case typ != frameProbeResp:
+		return fmt.Errorf("unexpected response frame type %d", typ)
+	case len(payload) < probeHdrLen:
+		return fmt.Errorf("short probe response header: %d < %d", len(payload), probeHdrLen)
+	}
+	body := payload[probeHdrLen:]
+	if len(body) != respSize {
+		return fmt.Errorf("response body %d != want %d", len(body), respSize)
+	}
+	if off, ok := verifyPattern(body, nonce, 0); !ok {
+		return fmt.Errorf("response pattern mismatch at offset %d", off)
+	}
+	return nil
+}
+
+// startProbeFlow dials addr, wraps the connection in a probeFlow, starts
+// it, and waits for the first ack so the caller knows the bridge is
+// established before proceeding. On failure it stops the flow and returns
+// the error.
+func startProbeFlow(addr string, dialTimeout time.Duration, cfg ProbeConfig) (*probeFlow, error) {
+	c, err := net.DialTimeout("tcp", addr, dialTimeout)
+	if err != nil {
+		return nil, err
+	}
+	f := newProbeFlow(c, cfg)
+	f.Start()
+	if err := f.waitFirstAck(dialTimeout); err != nil {
+		f.Stop()
+		return nil, err
+	}
+	return f, nil
+}
+
+// waitProgress reports whether the flow's acked sequence advances beyond
+// base within timeout. A read-side break ends the wait immediately
+// (returns false): a broken flow makes no further progress.
+func waitProgress(f *probeFlow, base int64, timeout time.Duration) bool {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if f.broken() {
+			return false
+		}
+		if f.acked() > base {
+			return true
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	return f.acked() > base
+}

--- a/e2e/scenarios/probe.go
+++ b/e2e/scenarios/probe.go
@@ -389,9 +389,14 @@ func (f *probeFlow) Dump(t *testing.T, srv *WorkloadServer, label string) {
 // last-seen record to attribute a break to the outbound (request) or
 // return (response) path, mirroring the diagnostic ladder the design
 // targets.
+//
+// localize consumes the server-side record (ConsumeProbeRecord) so it
+// does not linger after the diagnostic has been emitted. It is intended
+// to be called at most once per flow; subsequent calls will see no
+// record and report "no record for nonce".
 func (f *probeFlow) localize(srv *WorkloadServer) string {
 	acked := f.lastSeqAck.Load()
-	rec, ok := srv.ProbeRecord(f.nonce)
+	rec, ok := srv.ConsumeProbeRecord(f.nonce)
 	if !ok {
 		return fmt.Sprintf("server has no record for nonce %d: no request reached the server (outbound/request-leg break for seq %d)", f.nonce, acked+1)
 	}

--- a/e2e/scenarios/probe.go
+++ b/e2e/scenarios/probe.go
@@ -407,7 +407,12 @@ func (f *probeFlow) localize(srv *WorkloadServer) string {
 		return fmt.Sprintf("server[%s] read seq %d (recv=%v) but had not started its reply (server-path stall; client_acked=%d)",
 			state, rec.lastSeqSeen, dur(rec.lastRecvNano), acked)
 	case rec.lastWriteDone < rec.lastWriteStart:
-		return fmt.Sprintf("server[%s] began writing seq %d (write_start=%v) but the write did not complete (server->tunnel write blocked; client_acked=%d)",
+		// write_start was stamped but write_done was not — covers both a
+		// truly blocked write (FIN/RST never arrived, conn still open)
+		// and a fast write failure that returned an error before the
+		// post-write stamp. The terminal flag and termErr distinguish
+		// them: a non-nil termErr names the write failure.
+		return fmt.Sprintf("server[%s] began writing seq %d (write_start=%v) but the write did not complete before the server gave up (return-leg failure or server->tunnel write stuck; client_acked=%d)",
 			state, rec.lastSeqSeen, dur(rec.lastWriteStart), acked)
 	default:
 		return fmt.Sprintf("server[%s] completed reply for seq %d (write_done=%v) but client only acked %d (return/response-leg break)",

--- a/e2e/scenarios/probe.go
+++ b/e2e/scenarios/probe.go
@@ -69,6 +69,17 @@ type ProbeConfig struct {
 	// in which case more than one request may sit in flight between an
 	// Interval tick and the matching ack.
 	MaxOutstanding int
+
+	// SampleSize, if > 0, enables per-exchange retention: probeFlow keeps
+	// a bounded ring of the most-recent SampleSize exchanges so a
+	// percentile aggregator (e.g., the duplex perf shape) can compute
+	// p50/p95 over the steady-state tail. SampleSize == 0 keeps the
+	// allocation-free rolling-aggregates-only behavior; topology
+	// scenarios that only need maxes and a worst-by-RTT snapshot leave
+	// it zero. "Most recent N" is a steady-state tail snapshot — not a
+	// statistical reservoir — which is what diagnostic percentiles
+	// want here.
+	SampleSize int
 }
 
 // probeExchange is one completed request/response, with the round-trip
@@ -110,11 +121,14 @@ type probeFlow struct {
 	maxRespLeg  time.Duration
 	maxThink    time.Duration
 	maxRTT      time.Duration
-	maxGap      time.Duration // largest gap between successive acked arrivals
-	prevArrival time.Duration // arrival of the previous exchange, for gap calc
-	worstByRTT  probeExchange // single highest-RTT exchange, for Dump
-	firstErr    error         // first read-side integrity/break error
-	writeErr    error         // first write-side error (does not mark broken)
+	maxGap      time.Duration   // largest gap between successive acked arrivals
+	prevArrival time.Duration   // arrival of the previous exchange, for gap calc
+	worstByRTT  probeExchange   // single highest-RTT exchange, for Dump
+	samples     []probeExchange // ring of most-recent exchanges if cfg.SampleSize > 0
+	sampleHead  int             // next write index into samples; samples[head] is oldest
+	sampleFull  bool            // true once samples has wrapped at least once
+	firstErr    error           // first read-side integrity/break error
+	writeErr    error           // first write-side error (does not mark broken)
 }
 
 // newProbeFlow wraps an established connection in a probeFlow. It does
@@ -136,12 +150,18 @@ func newProbeFlow(conn net.Conn, cfg ProbeConfig) *probeFlow {
 	if cfg.MaxOutstanding < 1 {
 		cfg.MaxOutstanding = 1
 	}
+	if cfg.SampleSize < 0 {
+		cfg.SampleSize = 0
+	}
 	f := &probeFlow{
 		conn:   conn,
 		nonce:  randNonce(),
 		cfg:    cfg,
 		stopCh: make(chan struct{}),
 		slots:  make(chan struct{}, cfg.MaxOutstanding),
+	}
+	if cfg.SampleSize > 0 {
+		f.samples = make([]probeExchange, cfg.SampleSize)
 	}
 	f.lastSeqSent.Store(-1)
 	f.lastSeqAck.Store(-1)
@@ -343,6 +363,16 @@ func (f *probeFlow) reader() {
 		}
 		f.prevArrival = ex.arrival
 		f.numExch++
+		// Append into the bounded ring sample if enabled. Wrapping keeps
+		// only the most-recent cfg.SampleSize exchanges.
+		if f.samples != nil {
+			f.samples[f.sampleHead] = ex
+			f.sampleHead++
+			if f.sampleHead >= len(f.samples) {
+				f.sampleHead = 0
+				f.sampleFull = true
+			}
+		}
 		f.mu.Unlock()
 		f.lastSeqAck.Store(int64(seq))
 
@@ -385,6 +415,30 @@ func (f *probeFlow) Summary() probeSummary {
 		firstErr:   f.firstErr,
 		writeErr:   f.writeErr,
 	}
+}
+
+// Samples returns a chronological snapshot of the per-exchange ring
+// buffer, oldest first. The slice is empty when SampleSize == 0 or no
+// exchange has completed yet. Callers can safely retain the returned
+// slice; it is a fresh copy.
+func (f *probeFlow) Samples() []probeExchange {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if len(f.samples) == 0 {
+		return nil
+	}
+	if !f.sampleFull {
+		// samples[0:sampleHead] are the only valid entries, in order.
+		out := make([]probeExchange, f.sampleHead)
+		copy(out, f.samples[:f.sampleHead])
+		return out
+	}
+	// Ring has wrapped: oldest entry is at sampleHead, newest is at
+	// sampleHead-1 (mod len). Walk from oldest forward.
+	out := make([]probeExchange, len(f.samples))
+	n := copy(out, f.samples[f.sampleHead:])
+	copy(out[n:], f.samples[:f.sampleHead])
+	return out
 }
 
 // Dump logs a compact diagnostic: the client-side summary, the worst

--- a/e2e/scenarios/probe.go
+++ b/e2e/scenarios/probe.go
@@ -50,9 +50,11 @@ func dur(n int64) time.Duration { return time.Duration(n) }
 // zero value is filled with calibrated defaults (100ms interval, 64-byte
 // bodies, one outstanding request) by newProbeFlow.
 type ProbeConfig struct {
-	// Interval is the minimum gap between successive requests. Combined
-	// with MaxOutstanding it paces the flow as "send next on ack, no
-	// faster than Interval". Zero means send as fast as the window allows.
+	// Interval is the minimum gap between successive request writes. The
+	// sender enforces it after each write via a time.Ticker. A zero
+	// value is replaced with defaultProbeIntvl (100ms) by newProbeFlow;
+	// callers that want unpaced (window-bound) sending must set a small
+	// non-zero value such as time.Microsecond.
 	Interval time.Duration
 
 	// ReqSize / RespSize are the request and response body pattern bytes,
@@ -63,7 +65,9 @@ type ProbeConfig struct {
 
 	// MaxOutstanding bounds in-flight (sent but unacked) requests. The
 	// topology scenarios use 1 so each exchange's legs are uncontaminated
-	// by self-induced send-queue depth; the perf shape may widen it.
+	// by self-induced send-queue depth; the perf shape may widen it,
+	// in which case more than one request may sit in flight between an
+	// Interval tick and the matching ack.
 	MaxOutstanding int
 }
 

--- a/e2e/scenarios/probe.go
+++ b/e2e/scenarios/probe.go
@@ -104,10 +104,17 @@ type probeFlow struct {
 	lastSeqAck  atomic.Int64 // highest seq acked (-1 before first)
 	brokenFlag  atomic.Bool  // read-side break observed
 
-	mu        sync.Mutex
-	exchanges []probeExchange
-	firstErr  error // first read-side integrity/break error
-	writeErr  error // first write-side error (does not mark broken)
+	mu          sync.Mutex
+	numExch     int64         // total exchanges completed
+	maxReqLeg   time.Duration // rolling aggregates, updated under mu by reader
+	maxRespLeg  time.Duration
+	maxThink    time.Duration
+	maxRTT      time.Duration
+	maxGap      time.Duration // largest gap between successive acked arrivals
+	prevArrival time.Duration // arrival of the previous exchange, for gap calc
+	worstByRTT  probeExchange // single highest-RTT exchange, for Dump
+	firstErr    error         // first read-side integrity/break error
+	writeErr    error         // first write-side error (does not mark broken)
 }
 
 // newProbeFlow wraps an established connection in a probeFlow. It does
@@ -313,8 +320,29 @@ func (f *probeFlow) reader() {
 			responseLeg: dur(clientRecv - srvSend),
 			rtt:         dur(clientRecv - clientSend),
 		}
+		// Update rolling aggregates incrementally — no slice growth, and
+		// Summary stays O(1) even for long-running flows.
 		f.mu.Lock()
-		f.exchanges = append(f.exchanges, ex)
+		if ex.requestLeg > f.maxReqLeg {
+			f.maxReqLeg = ex.requestLeg
+		}
+		if ex.responseLeg > f.maxRespLeg {
+			f.maxRespLeg = ex.responseLeg
+		}
+		if ex.serverThink > f.maxThink {
+			f.maxThink = ex.serverThink
+		}
+		if ex.rtt > f.maxRTT {
+			f.maxRTT = ex.rtt
+			f.worstByRTT = ex
+		}
+		if f.numExch > 0 {
+			if gap := ex.arrival - f.prevArrival; gap > f.maxGap {
+				f.maxGap = gap
+			}
+		}
+		f.prevArrival = ex.arrival
+		f.numExch++
 		f.mu.Unlock()
 		f.lastSeqAck.Store(int64(seq))
 
@@ -328,12 +356,13 @@ func (f *probeFlow) reader() {
 // only — never an assertion threshold.
 type probeSummary struct {
 	sent, acked int64
-	exchanges   int
+	exchanges   int64
 	maxReqLeg   time.Duration
 	maxRespLeg  time.Duration
 	maxThink    time.Duration
 	maxRTT      time.Duration
 	maxGap      time.Duration // largest gap between successive acked arrivals
+	worstByRTT  probeExchange // exchange that observed maxRTT (zero if none)
 	broken      bool
 	firstErr    error
 	writeErr    error
@@ -342,36 +371,20 @@ type probeSummary struct {
 func (f *probeFlow) Summary() probeSummary {
 	f.mu.Lock()
 	defer f.mu.Unlock()
-	s := probeSummary{
-		sent:      f.lastSeqSent.Load(),
-		acked:     f.lastSeqAck.Load(),
-		exchanges: len(f.exchanges),
-		broken:    f.brokenFlag.Load(),
-		firstErr:  f.firstErr,
-		writeErr:  f.writeErr,
+	return probeSummary{
+		sent:       f.lastSeqSent.Load(),
+		acked:      f.lastSeqAck.Load(),
+		exchanges:  f.numExch,
+		maxReqLeg:  f.maxReqLeg,
+		maxRespLeg: f.maxRespLeg,
+		maxThink:   f.maxThink,
+		maxRTT:     f.maxRTT,
+		maxGap:     f.maxGap,
+		worstByRTT: f.worstByRTT,
+		broken:     f.brokenFlag.Load(),
+		firstErr:   f.firstErr,
+		writeErr:   f.writeErr,
 	}
-	var prev time.Duration
-	for i, ex := range f.exchanges {
-		if ex.requestLeg > s.maxReqLeg {
-			s.maxReqLeg = ex.requestLeg
-		}
-		if ex.responseLeg > s.maxRespLeg {
-			s.maxRespLeg = ex.responseLeg
-		}
-		if ex.serverThink > s.maxThink {
-			s.maxThink = ex.serverThink
-		}
-		if ex.rtt > s.maxRTT {
-			s.maxRTT = ex.rtt
-		}
-		if i > 0 {
-			if gap := ex.arrival - prev; gap > s.maxGap {
-				s.maxGap = gap
-			}
-		}
-		prev = ex.arrival
-	}
-	return s
 }
 
 // Dump logs a compact diagnostic: the client-side summary, the worst
@@ -382,6 +395,11 @@ func (f *probeFlow) Dump(t *testing.T, srv *WorkloadServer, label string) {
 	s := f.Summary()
 	t.Logf("probe-dump %s: sent=%d acked=%d exchanges=%d broken=%v max_req_leg=%v max_resp_leg=%v max_think=%v max_rtt=%v max_gap=%v first_err=%v write_err=%v",
 		label, s.sent, s.acked, s.exchanges, s.broken, s.maxReqLeg, s.maxRespLeg, s.maxThink, s.maxRTT, s.maxGap, s.firstErr, s.writeErr)
+	if s.exchanges > 0 {
+		w := s.worstByRTT
+		t.Logf("probe-dump %s: worst-by-rtt seq=%d rtt=%v req_leg=%v server_think=%v resp_leg=%v",
+			label, w.seq, w.rtt, w.requestLeg, w.serverThink, w.responseLeg)
+	}
 	t.Logf("probe-dump %s: %s", label, f.localize(srv))
 }
 

--- a/e2e/scenarios/probe.go
+++ b/e2e/scenarios/probe.go
@@ -532,7 +532,43 @@ func (f *probeFlow) localize(srv *WorkloadServer) string {
 // ServerProbe target reached at addr (one dial, one request, one verified
 // response). It is the framed replacement for runEchoOnce in scenarios
 // whose target is a ServerProbe server.
-func probeOnce(addr string, reqSize, respSize int, timeout time.Duration) error {
+//
+// On failure, if srv is non-nil, the returned error is enriched with the
+// server's per-nonce record interpretation (request reached server vs.
+// server stalled vs. return-leg break), giving the same per-leg
+// localization the held-flow scenarios get from probeFlow.Dump. Pass nil
+// for srv when the caller can't easily get a *WorkloadServer reference;
+// the dial/read/integrity error still surfaces, just without leg
+// attribution.
+func probeOnce(srv *WorkloadServer, addr string, reqSize, respSize int, timeout time.Duration) error {
+	nonce := randNonce()
+	err := probeOnceCore(addr, nonce, reqSize, respSize, timeout)
+	if err == nil || srv == nil {
+		return err
+	}
+	// Server may have produced a record before the exchange failed;
+	// consume it (delete-on-read) so the entry doesn't linger. localize
+	// on a fresh probeFlow shape isn't applicable here (no live acked
+	// counter), but the raw record fields tell the story.
+	rec, ok := srv.ConsumeProbeRecord(nonce)
+	if !ok {
+		return fmt.Errorf("%w: server has no record for nonce %d (request never reached the server: outbound break)", err, nonce)
+	}
+	switch {
+	case rec.lastSeqSeen < 0:
+		return fmt.Errorf("%w: server recorded the connection but read no request (outbound break before first frame)", err)
+	case rec.lastWriteStart == 0 || rec.lastWriteStart < rec.lastRecvNano:
+		return fmt.Errorf("%w: server read the request (recv=%v) but had not started its reply (server-path stall)", err, dur(rec.lastRecvNano))
+	case rec.lastWriteDone < rec.lastWriteStart:
+		return fmt.Errorf("%w: server began writing (write_start=%v) but the write did not complete (return-leg failure or server->tunnel write stuck; termErr=%v)", err, dur(rec.lastWriteStart), rec.termErr)
+	default:
+		return fmt.Errorf("%w: server completed reply (write_done=%v) but the client never read it (return/response-leg break)", err, dur(rec.lastWriteDone))
+	}
+}
+
+// probeOnceCore is the raw single-exchange driver; probeOnce wraps it
+// with optional server-side localization on failure.
+func probeOnceCore(addr string, nonce uint64, reqSize, respSize int, timeout time.Duration) error {
 	conn, err := net.DialTimeout("tcp", addr, timeout)
 	if err != nil {
 		return fmt.Errorf("dial: %w", err)
@@ -540,7 +576,6 @@ func probeOnce(addr string, reqSize, respSize int, timeout time.Duration) error 
 	defer conn.Close() //nolint:errcheck // best-effort
 	_ = conn.SetDeadline(time.Now().Add(timeout))
 
-	nonce := randNonce()
 	buf := make([]byte, probeHdrLen+reqSize)
 	binary.BigEndian.PutUint64(buf[probeOffClient:], uint64(probeNanos()))
 	fillPattern(buf[probeHdrLen:], nonce, 0)

--- a/e2e/scenarios/probe.go
+++ b/e2e/scenarios/probe.go
@@ -176,14 +176,28 @@ func (f *probeFlow) Start() {
 }
 
 // Stop signals shutdown, closes the connection to unblock any in-flight
-// read/write, and waits for both goroutines. It is idempotent.
+// read/write, and waits for both goroutines. It is idempotent. The
+// reader may have already signalled done via recordReadErr; Stop's
+// stopOnce coordinates with it so close(stopCh) and conn.Close are each
+// invoked at most once.
 func (f *probeFlow) Stop() {
+	f.stopping.Store(true)
+	f.signalDone()
+	f.wg.Wait()
+}
+
+// signalDone closes stopCh and the underlying connection at most once,
+// waking any goroutine selecting on stopCh (e.g. the duplex round loop)
+// and unblocking peer-side read/writes that would otherwise hang until
+// the runtime closed the conn at process exit. Called by both Stop()
+// (external caller) and recordReadErr() (the flow itself observing a
+// read-side break), so a broken flow doesn't have to wait for an
+// external Stop before its waiters wake up.
+func (f *probeFlow) signalDone() {
 	f.stopOnce.Do(func() {
-		f.stopping.Store(true)
 		close(f.stopCh)
 		_ = f.conn.Close()
 	})
-	f.wg.Wait()
 }
 
 // broken reports whether the flow has observed a read-side break. It is a
@@ -230,8 +244,11 @@ func (f *probeFlow) writeError() error {
 	return f.writeErr
 }
 
-// recordReadErr latches the first read-side error and marks the flow
-// broken. recordWriteErr latches the first write-side error only.
+// recordReadErr latches the first read-side error, marks the flow
+// broken, and signals done so waiters (and the peer-side server) unblock
+// promptly instead of waiting for an external Stop. recordWriteErr only
+// latches the error — the flow is not considered broken on write failures
+// because the canonical signal for a torn bridge is a read-side close.
 func (f *probeFlow) recordReadErr(err error) {
 	f.mu.Lock()
 	if f.firstErr == nil {
@@ -239,6 +256,7 @@ func (f *probeFlow) recordReadErr(err error) {
 	}
 	f.mu.Unlock()
 	f.brokenFlag.Store(true)
+	f.signalDone()
 }
 
 func (f *probeFlow) recordWriteErr(err error) {

--- a/e2e/scenarios/probe.go
+++ b/e2e/scenarios/probe.go
@@ -206,6 +206,13 @@ func (f *probeFlow) waitFirstAck(timeout time.Duration) error {
 		if f.broken() {
 			return fmt.Errorf("flow broke before first ack: %w", f.firstError())
 		}
+		// A write-side failure doesn't flip brokenFlag (broken is
+		// read-side only by design), so check it explicitly here. The
+		// sender goroutine will have already returned after recording
+		// the error, so no further progress is possible.
+		if we := f.writeError(); we != nil {
+			return fmt.Errorf("flow write failed before first ack: %w", we)
+		}
 		time.Sleep(20 * time.Millisecond)
 	}
 	return fmt.Errorf("no ack within %v (sent up to seq %d)", timeout, f.lastSeqSent.Load())
@@ -215,6 +222,12 @@ func (f *probeFlow) firstError() error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	return f.firstErr
+}
+
+func (f *probeFlow) writeError() error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.writeErr
 }
 
 // recordReadErr latches the first read-side error and marks the flow

--- a/e2e/scenarios/probe.go
+++ b/e2e/scenarios/probe.go
@@ -114,13 +114,16 @@ type probeFlow struct {
 // not start traffic; call Start. The caller owns the connection's
 // lifetime via Stop (which closes it).
 func newProbeFlow(conn net.Conn, cfg ProbeConfig) *probeFlow {
-	if cfg.Interval == 0 {
+	// Clamp non-positive values so callers can't accidentally request a
+	// disabled ticker (Interval <= 0) which would spin the sender, or
+	// a non-positive payload size which would panic make.
+	if cfg.Interval <= 0 {
 		cfg.Interval = defaultProbeIntvl
 	}
-	if cfg.ReqSize == 0 {
+	if cfg.ReqSize <= 0 {
 		cfg.ReqSize = defaultProbeBody
 	}
-	if cfg.RespSize == 0 {
+	if cfg.RespSize <= 0 {
 		cfg.RespSize = defaultProbeBody
 	}
 	if cfg.MaxOutstanding < 1 {
@@ -253,6 +256,11 @@ func (f *probeFlow) sender() {
 
 func (f *probeFlow) reader() {
 	defer f.wg.Done()
+	// Close the connection on exit so the server's serveProbe goroutine
+	// for this nonce unblocks promptly (especially under MaxOutstanding>1
+	// where the server may be blocked writing a response). conn.Close is
+	// idempotent, so this is safe even when Stop already closed it.
+	defer func() { _ = f.conn.Close() }()
 	for {
 		typ, n, payload, err := readFrame(f.conn)
 		clientRecv := probeNanos()

--- a/e2e/scenarios/probe.go
+++ b/e2e/scenarios/probe.go
@@ -515,12 +515,13 @@ func (f *probeFlow) localize(srv *WorkloadServer) string {
 		return fmt.Sprintf("server[%s] read seq %d (recv=%v) but had not started its reply (server-path stall; client_acked=%d)",
 			state, rec.lastSeqSeen, dur(rec.lastRecvNano), acked)
 	case rec.lastWriteDone < rec.lastWriteStart:
-		// write_start was stamped but write_done was not — covers both a
-		// truly blocked write (FIN/RST never arrived, conn still open)
-		// and a fast write failure that returned an error before the
-		// post-write stamp. The terminal flag and termErr distinguish
-		// them: a non-nil termErr names the write failure.
-		return fmt.Sprintf("server[%s] began writing seq %d (write_start=%v) but the write did not complete before the server gave up (return-leg failure or server->tunnel write stuck; client_acked=%d)",
+		// write_start was stamped but write_done was not. The cause
+		// depends on whether the server has terminated: a non-terminal
+		// record means the write is still in flight (the conn is open
+		// and the bridge has not yet returned write_done); a terminal
+		// record with non-nil termErr names the write failure. Don't
+		// imply the server has given up when the record is still live.
+		return fmt.Sprintf("server[%s] began writing seq %d (write_start=%v) but the write has not completed (return-leg failure or server->tunnel write stuck; client_acked=%d)",
 			state, rec.lastSeqSeen, dur(rec.lastWriteStart), acked)
 	default:
 		return fmt.Sprintf("server[%s] completed reply for seq %d (write_done=%v) but client only acked %d (return/response-leg break)",

--- a/e2e/scenarios/probe.go
+++ b/e2e/scenarios/probe.go
@@ -542,28 +542,7 @@ func (f *probeFlow) localize(srv *WorkloadServer) string {
 // attribution.
 func probeOnce(srv *WorkloadServer, addr string, reqSize, respSize int, timeout time.Duration) error {
 	nonce := randNonce()
-	err := probeOnceCore(addr, nonce, reqSize, respSize, timeout)
-	if err == nil || srv == nil {
-		return err
-	}
-	// Server may have produced a record before the exchange failed;
-	// consume it (delete-on-read) so the entry doesn't linger. localize
-	// on a fresh probeFlow shape isn't applicable here (no live acked
-	// counter), but the raw record fields tell the story.
-	rec, ok := srv.ConsumeProbeRecord(nonce)
-	if !ok {
-		return fmt.Errorf("%w: server has no record for nonce %d (request never reached the server: outbound break)", err, nonce)
-	}
-	switch {
-	case rec.lastSeqSeen < 0:
-		return fmt.Errorf("%w: server recorded the connection but read no request (outbound break before first frame)", err)
-	case rec.lastWriteStart == 0 || rec.lastWriteStart < rec.lastRecvNano:
-		return fmt.Errorf("%w: server read the request (recv=%v) but had not started its reply (server-path stall)", err, dur(rec.lastRecvNano))
-	case rec.lastWriteDone < rec.lastWriteStart:
-		return fmt.Errorf("%w: server began writing (write_start=%v) but the write did not complete (return-leg failure or server->tunnel write stuck; termErr=%v)", err, dur(rec.lastWriteStart), rec.termErr)
-	default:
-		return fmt.Errorf("%w: server completed reply (write_done=%v) but the client never read it (return/response-leg break)", err, dur(rec.lastWriteDone))
-	}
+	return localizeProbeError(srv, nonce, probeOnceCore(addr, nonce, reqSize, respSize, timeout))
 }
 
 // probeOnceCore is the raw single-exchange driver; probeOnce wraps it
@@ -575,7 +554,14 @@ func probeOnceCore(addr string, nonce uint64, reqSize, respSize int, timeout tim
 	}
 	defer conn.Close() //nolint:errcheck // best-effort
 	_ = conn.SetDeadline(time.Now().Add(timeout))
+	return probeExchangeOnConn(conn, nonce, reqSize, respSize)
+}
 
+// probeExchangeOnConn drives one probe request/response on an already-
+// dialed connection. Factored out so callers that need to keep the conn
+// open after the exchange (e.g. probeWithHold for the metric sampler)
+// can reuse the same validation as probeOnceCore.
+func probeExchangeOnConn(conn net.Conn, nonce uint64, reqSize, respSize int) error {
 	buf := make([]byte, probeHdrLen+reqSize)
 	binary.BigEndian.PutUint64(buf[probeOffClient:], uint64(probeNanos()))
 	fillPattern(buf[probeHdrLen:], nonce, 0)
@@ -604,6 +590,30 @@ func probeOnceCore(addr string, nonce uint64, reqSize, respSize int, timeout tim
 		return fmt.Errorf("response pattern mismatch at offset %d", off)
 	}
 	return nil
+}
+
+// localizeProbeError consumes the server-side record for nonce and
+// returns err enriched with a per-leg attribution (or the original err
+// when srv is nil). Always consumes the record on a non-nil srv so a
+// failed exchange does not leak a probeStats entry.
+func localizeProbeError(srv *WorkloadServer, nonce uint64, err error) error {
+	if err == nil || srv == nil {
+		return err
+	}
+	rec, ok := srv.ConsumeProbeRecord(nonce)
+	if !ok {
+		return fmt.Errorf("%w: server has no record for nonce %d (request never reached the server: outbound break)", err, nonce)
+	}
+	switch {
+	case rec.lastSeqSeen < 0:
+		return fmt.Errorf("%w: server recorded the connection but read no request (outbound break before first frame)", err)
+	case rec.lastWriteStart == 0 || rec.lastWriteStart < rec.lastRecvNano:
+		return fmt.Errorf("%w: server read the request (recv=%v) but had not started its reply (server-path stall)", err, dur(rec.lastRecvNano))
+	case rec.lastWriteDone < rec.lastWriteStart:
+		return fmt.Errorf("%w: server began writing (write_start=%v) but the write did not complete (return-leg failure or server->tunnel write stuck; termErr=%v)", err, dur(rec.lastWriteStart), rec.termErr)
+	default:
+		return fmt.Errorf("%w: server completed reply (write_done=%v) but the client never read it (return/response-leg break)", err, dur(rec.lastWriteDone))
+	}
 }
 
 // startProbeFlow dials addr, wraps the connection in a probeFlow, starts

--- a/e2e/scenarios/probe_test.go
+++ b/e2e/scenarios/probe_test.go
@@ -439,10 +439,6 @@ func TestProbeFlow_WaitFirstAck_FailsFastOnWriteError(t *testing.T) {
 	}
 }
 
-// and asserts the Samples() snapshot is bounded by SampleSize and
-// returns the most-recent N exchanges in chronological order. Without
-// SampleSize, Samples must return nil to confirm the allocation-free
-// path is preserved.
 // TestProbeFlow_Samples_RingBuffer drives a probeFlow with SampleSize > 0
 // and asserts the Samples() snapshot is bounded by SampleSize and
 // returns the most-recent N exchanges in chronological order. Without

--- a/e2e/scenarios/probe_test.go
+++ b/e2e/scenarios/probe_test.go
@@ -408,3 +408,51 @@ func TestServeProbe_NonMonotonicSeq_Rejected(t *testing.T) {
 		t.Fatalf("expected frameError or close after duplicate seq, got typ=%d err=%v", typ, err)
 	}
 }
+
+// TestProbeFlow_Samples_RingBuffer drives a probeFlow with SampleSize > 0
+// and asserts the Samples() snapshot is bounded by SampleSize and
+// returns the most-recent N exchanges in chronological order. Without
+// SampleSize, Samples must return nil to confirm the allocation-free
+// path is preserved.
+func TestProbeFlow_Samples_RingBuffer(t *testing.T) {
+	srv := StartWorkloadServer(t, ServerBehavior{Mode: ServerProbe, RespSize: 16})
+
+	t.Run("Disabled", func(t *testing.T) {
+		cfg := ProbeConfig{Interval: 5 * time.Millisecond, ReqSize: 16, RespSize: 16}
+		f, err := startProbeFlow(srv.Addr(), 5*time.Second, cfg)
+		if err != nil {
+			t.Fatalf("startProbeFlow: %v", err)
+		}
+		t.Cleanup(f.Stop)
+		if !waitProgress(f, 5, 2*time.Second) {
+			t.Fatalf("flow did not advance past seq 5")
+		}
+		if s := f.Samples(); s != nil {
+			t.Errorf("Samples() with SampleSize=0 = %d entries, want nil", len(s))
+		}
+	})
+
+	t.Run("Wrapped", func(t *testing.T) {
+		const ring = 4
+		cfg := ProbeConfig{Interval: 5 * time.Millisecond, ReqSize: 16, RespSize: 16, SampleSize: ring}
+		f, err := startProbeFlow(srv.Addr(), 5*time.Second, cfg)
+		if err != nil {
+			t.Fatalf("startProbeFlow: %v", err)
+		}
+		t.Cleanup(f.Stop)
+		// Drive well past the ring size so it has definitely wrapped.
+		if !waitProgress(f, int64(ring*4), 3*time.Second) {
+			t.Fatalf("flow did not advance past seq %d", ring*4)
+		}
+		samples := f.Samples()
+		if len(samples) != ring {
+			t.Fatalf("Samples() = %d, want %d", len(samples), ring)
+		}
+		// Chronological order: seqs must be strictly increasing.
+		for i := 1; i < len(samples); i++ {
+			if samples[i].seq <= samples[i-1].seq {
+				t.Errorf("samples not chronological at i=%d: %d <= %d", i, samples[i].seq, samples[i-1].seq)
+			}
+		}
+	})
+}

--- a/e2e/scenarios/probe_test.go
+++ b/e2e/scenarios/probe_test.go
@@ -2,6 +2,7 @@ package scenarios
 
 import (
 	"encoding/binary"
+	"fmt"
 	"net"
 	"strings"
 	"testing"
@@ -409,6 +410,39 @@ func TestServeProbe_NonMonotonicSeq_Rejected(t *testing.T) {
 	}
 }
 
+// TestProbeFlow_WaitFirstAck_FailsFastOnWriteError verifies waitFirstAck
+// surfaces a latched write-side failure immediately instead of waiting
+// for the full timeout, even when the read side hasn't broken (in real
+// use this is the sender returning before the reader observes EOF).
+// We exercise the loop's writeErr check directly: construct a flow,
+// don't start goroutines, latch a synthetic write error, then call
+// waitFirstAck and assert it returns fast with that error.
+func TestProbeFlow_WaitFirstAck_FailsFastOnWriteError(t *testing.T) {
+	cli, srv := net.Pipe()
+	t.Cleanup(func() { _ = cli.Close(); _ = srv.Close() })
+
+	f := newProbeFlow(cli, ProbeConfig{Interval: 1 * time.Hour, ReqSize: 8, RespSize: 8})
+	// Don't Start — we don't want the sender/reader goroutines to run.
+	f.recordWriteErr(fmt.Errorf("synthetic write failure"))
+
+	start := time.Now()
+	err := f.waitFirstAck(5 * time.Second)
+	elapsed := time.Since(start)
+	if err == nil {
+		t.Fatalf("waitFirstAck succeeded despite latched writeErr")
+	}
+	if elapsed >= 500*time.Millisecond {
+		t.Errorf("waitFirstAck took %v; expected fast write-error path", elapsed)
+	}
+	if !strings.Contains(err.Error(), "write") {
+		t.Errorf("error %q does not mention write", err)
+	}
+}
+
+// and asserts the Samples() snapshot is bounded by SampleSize and
+// returns the most-recent N exchanges in chronological order. Without
+// SampleSize, Samples must return nil to confirm the allocation-free
+// path is preserved.
 // TestProbeFlow_Samples_RingBuffer drives a probeFlow with SampleSize > 0
 // and asserts the Samples() snapshot is bounded by SampleSize and
 // returns the most-recent N exchanges in chronological order. Without

--- a/e2e/scenarios/probe_test.go
+++ b/e2e/scenarios/probe_test.go
@@ -269,6 +269,42 @@ func TestProbeFlow_Localize_OutboundBreak(t *testing.T) {
 	}
 }
 
+// TestServeProbe_ConsumeProbeRecord verifies that ConsumeProbeRecord
+// returns a snapshot of the per-nonce record AND removes it, so future
+// lookups (Probe/Consume) report no record. This is the bounded-memory
+// path for diagnostic consumers that only need the record once.
+func TestServeProbe_ConsumeProbeRecord(t *testing.T) {
+	const body = 16
+	srv := StartWorkloadServer(t, ServerBehavior{Mode: ServerProbe, RespSize: body})
+	conn := dialServer(t, srv)
+
+	nonce := uint64(0x5555555555555555)
+	req := make([]byte, probeHdrLen+body)
+	fillPattern(req[probeHdrLen:], nonce, 0)
+	if err := writeFrame(conn, frameProbeReq, nonce, req); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if _, _, _, err := readFrame(conn); err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if _, ok := srv.ProbeRecord(nonce); !ok {
+		t.Fatalf("ProbeRecord before consume: not found")
+	}
+	rec, ok := srv.ConsumeProbeRecord(nonce)
+	if !ok {
+		t.Fatalf("ConsumeProbeRecord: not found")
+	}
+	if rec.lastSeqSeen != 0 {
+		t.Errorf("rec.lastSeqSeen=%d want 0", rec.lastSeqSeen)
+	}
+	if _, ok := srv.ProbeRecord(nonce); ok {
+		t.Errorf("ProbeRecord after consume: still present")
+	}
+	if _, ok := srv.ConsumeProbeRecord(nonce); ok {
+		t.Errorf("second ConsumeProbeRecord: still present")
+	}
+}
+
 // TestNewProbeFlow_ClampsNegativeFields verifies that negative
 // Interval/ReqSize/RespSize and MaxOutstanding are clamped to safe
 // defaults instead of producing a hot-loop sender or a make() panic.

--- a/e2e/scenarios/probe_test.go
+++ b/e2e/scenarios/probe_test.go
@@ -251,6 +251,7 @@ func TestServeProbe_NonceChange_Rejected(t *testing.T) {
 	}
 }
 
+// TestProbeFlow_Localize_OutboundBreak verifies localize() correctly
 // identifies "no record at server" (no request ever reached the server).
 func TestProbeFlow_Localize_OutboundBreak(t *testing.T) {
 	srv := StartWorkloadServer(t, ServerBehavior{Mode: ServerProbe, RespSize: 16})

--- a/e2e/scenarios/probe_test.go
+++ b/e2e/scenarios/probe_test.go
@@ -223,6 +223,25 @@ func TestProbeOnce_WrongRespSize(t *testing.T) {
 	}
 }
 
+// TestProbeOnce_FreesServerRecordOnSuccess verifies high-volume callers
+// (Distribution_*, Metrics_*) don't accumulate per-nonce records on the
+// success path. probeOnce must consume the record when srv is non-nil,
+// mirroring probeWithHold.
+func TestProbeOnce_FreesServerRecordOnSuccess(t *testing.T) {
+	srv := StartWorkloadServer(t, ServerBehavior{Mode: ServerProbe, RespSize: 32})
+	for i := 0; i < 50; i++ {
+		if err := probeOnce(srv, srv.Addr(), 32, 32, 5*time.Second); err != nil {
+			t.Fatalf("probeOnce[%d]: %v", i, err)
+		}
+	}
+	srv.probeMu.Lock()
+	n := len(srv.probeStats)
+	srv.probeMu.Unlock()
+	if n != 0 {
+		t.Errorf("probeStats has %d residual entries after 50 successful probeOnce calls; want 0 (success path must ConsumeProbeRecord)", n)
+	}
+}
+
 // TestServeProbe_NonceChange_Rejected verifies that the server rejects a
 // frame whose nonce differs from the first frame on the same connection.
 // Without this, a buggy client mixing nonces would be silently verified

--- a/e2e/scenarios/probe_test.go
+++ b/e2e/scenarios/probe_test.go
@@ -364,4 +364,3 @@ func TestServeProbe_NonMonotonicSeq_Rejected(t *testing.T) {
 		t.Fatalf("expected frameError or close after duplicate seq, got typ=%d err=%v", typ, err)
 	}
 }
-

--- a/e2e/scenarios/probe_test.go
+++ b/e2e/scenarios/probe_test.go
@@ -268,3 +268,100 @@ func TestProbeFlow_Localize_OutboundBreak(t *testing.T) {
 		t.Errorf("localize() = %q, want outbound/no-record diagnosis", got)
 	}
 }
+
+// TestNewProbeFlow_ClampsNegativeFields verifies that negative
+// Interval/ReqSize/RespSize and MaxOutstanding are clamped to safe
+// defaults instead of producing a hot-loop sender or a make() panic.
+func TestNewProbeFlow_ClampsNegativeFields(t *testing.T) {
+	c1, c2 := net.Pipe()
+	t.Cleanup(func() { _ = c1.Close(); _ = c2.Close() })
+	cfg := ProbeConfig{
+		Interval:       -1 * time.Millisecond,
+		ReqSize:        -1,
+		RespSize:       -1,
+		MaxOutstanding: -1,
+	}
+	f := newProbeFlow(c1, cfg) // must not panic
+	if f.cfg.Interval != defaultProbeIntvl {
+		t.Errorf("Interval=%v, want %v", f.cfg.Interval, defaultProbeIntvl)
+	}
+	if f.cfg.ReqSize != defaultProbeBody || f.cfg.RespSize != defaultProbeBody {
+		t.Errorf("Req/Resp size=(%d,%d), want (%d,%d)", f.cfg.ReqSize, f.cfg.RespSize, defaultProbeBody, defaultProbeBody)
+	}
+	if f.cfg.MaxOutstanding != 1 {
+		t.Errorf("MaxOutstanding=%d, want 1", f.cfg.MaxOutstanding)
+	}
+}
+
+// TestProbeFlow_ReaderClosesConnOnBreak verifies that when the reader
+// exits due to an integrity error, it closes the underlying connection
+// so the server side unblocks promptly (important under MaxOutstanding>1
+// where the server might be blocked writing a response).
+func TestProbeFlow_ReaderClosesConnOnBreak(t *testing.T) {
+	srv, cli := net.Pipe()
+	t.Cleanup(func() { _ = srv.Close() })
+
+	f := newProbeFlow(cli, ProbeConfig{Interval: 1 * time.Hour, ReqSize: 8, RespSize: 8})
+	f.Start()
+	t.Cleanup(f.Stop)
+
+	// Send a complete frame header with a bad magic so readFrame returns
+	// errBadMagic. (frameHdrLen=17 bytes: 4-byte magic + 1-byte type +
+	// 8-byte nonce + 4-byte length.) Writing fewer bytes would leave
+	// readFrame blocked in io.ReadFull and never trigger the break path.
+	bad := make([]byte, 17)
+	copy(bad, []byte("XXXX"))
+	if _, err := srv.Write(bad); err != nil {
+		t.Fatalf("server write: %v", err)
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if f.broken() {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if !f.broken() {
+		t.Fatalf("reader did not flag broken after garbled frame")
+	}
+	// Verify the conn the reader held is closed: a subsequent write from
+	// the server side returns an error.
+	_ = srv.SetWriteDeadline(time.Now().Add(500 * time.Millisecond))
+	if _, err := srv.Write([]byte{0}); err == nil {
+		t.Errorf("server write should fail after reader closed the conn, got nil")
+	}
+}
+
+// TestServeProbe_NonMonotonicSeq_Rejected verifies the server rejects a
+// request whose seq does not strictly exceed the prior request's seq.
+// Without this, a buggy client repeating or decreasing seq would regress
+// probeConnStat.lastSeqSeen and corrupt localize() output.
+func TestServeProbe_NonMonotonicSeq_Rejected(t *testing.T) {
+	const body = 16
+	srv := StartWorkloadServer(t, ServerBehavior{Mode: ServerProbe, RespSize: body})
+	conn := dialServer(t, srv)
+
+	nonce := uint64(0x4444444444444444)
+	send := func(seq uint32) {
+		req := make([]byte, probeHdrLen+body)
+		binary.BigEndian.PutUint32(req[probeOffSeq:], seq)
+		fillPattern(req[probeHdrLen:], nonce, int(seq)*body)
+		if err := writeFrame(conn, frameProbeReq, nonce, req); err != nil {
+			t.Fatalf("write seq %d: %v", seq, err)
+		}
+	}
+	// First request seq=0 should succeed.
+	send(0)
+	if _, _, _, err := readFrame(conn); err != nil {
+		t.Fatalf("read 0: %v", err)
+	}
+	// Repeat seq=0 — must be rejected.
+	send(0)
+	_ = conn.SetReadDeadline(time.Now().Add(2 * time.Second))
+	typ, _, _, err := readFrame(conn)
+	if err == nil && typ != frameError {
+		t.Fatalf("expected frameError or close after duplicate seq, got typ=%d err=%v", typ, err)
+	}
+}
+

--- a/e2e/scenarios/probe_test.go
+++ b/e2e/scenarios/probe_test.go
@@ -124,10 +124,10 @@ func TestProbeFlow_ContinuousProgress(t *testing.T) {
 // the connection abruptly, the flow flips broken() within a short window
 // and Stop is safe to call after.
 func TestProbeFlow_BrokenOnPeerClose(t *testing.T) {
-	// Stand up a one-shot proxy that immediately RSTs after accept; this
-	// gives us a deterministic peer-close without driving the
-	// WorkloadServer through a real probe exchange first (the server's
-	// orderly EOF on Stop would NOT mark broken if stopping is set).
+	// Stand up a one-shot listener that closes the accepted conn (FIN);
+	// the probeFlow's reader observes EOF and must mark broken. We use
+	// this stub instead of a real WorkloadServer so the close is
+	// unambiguously a peer-side close (not a Stop-with-stopping-flag).
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		t.Fatalf("listen: %v", err)
@@ -214,7 +214,43 @@ func TestProbeOnce_WrongRespSize(t *testing.T) {
 	}
 }
 
-// TestProbeFlow_Localize_OutboundBreak verifies localize() correctly
+// TestServeProbe_NonceChange_Rejected verifies that the server rejects a
+// frame whose nonce differs from the first frame on the same connection.
+// Without this, a buggy client mixing nonces would be silently verified
+// and stat-recorded against the original nonce, masking real bugs.
+func TestServeProbe_NonceChange_Rejected(t *testing.T) {
+	const body = 16
+	srv := StartWorkloadServer(t, ServerBehavior{Mode: ServerProbe, RespSize: body})
+	conn := dialServer(t, srv)
+
+	// First request: nonce A, seq 0, valid pattern.
+	nonceA := uint64(0x1111111111111111)
+	reqA := make([]byte, probeHdrLen+body)
+	fillPattern(reqA[probeHdrLen:], nonceA, 0)
+	if err := writeFrame(conn, frameProbeReq, nonceA, reqA); err != nil {
+		t.Fatalf("write A: %v", err)
+	}
+	if _, _, _, err := readFrame(conn); err != nil {
+		t.Fatalf("read A: %v", err)
+	}
+	// Second request: nonce B (different), seq 1. The pattern is built
+	// from nonceB so it would verify against nonceB but NOT nonceA; we
+	// want the server to reject on the nonce mismatch before any pattern
+	// check, so the test does not depend on which check fires first.
+	nonceB := uint64(0x2222222222222222)
+	reqB := make([]byte, probeHdrLen+body)
+	binary.BigEndian.PutUint32(reqB[probeOffSeq:], 1)
+	fillPattern(reqB[probeHdrLen:], nonceB, body)
+	if err := writeFrame(conn, frameProbeReq, nonceB, reqB); err != nil {
+		t.Fatalf("write B: %v", err)
+	}
+	// The server should close the connection in response.
+	_ = conn.SetReadDeadline(time.Now().Add(2 * time.Second))
+	if _, _, _, err := readFrame(conn); err == nil {
+		t.Fatalf("expected server to close after nonce change, got a frame")
+	}
+}
+
 // identifies "no record at server" (no request ever reached the server).
 func TestProbeFlow_Localize_OutboundBreak(t *testing.T) {
 	srv := StartWorkloadServer(t, ServerBehavior{Mode: ServerProbe, RespSize: 16})

--- a/e2e/scenarios/probe_test.go
+++ b/e2e/scenarios/probe_test.go
@@ -205,7 +205,7 @@ func TestProbeFlow_StopDoesNotBreakSurvivor(t *testing.T) {
 // TestProbeOnce_RoundTrip exercises the one-shot helper end-to-end.
 func TestProbeOnce_RoundTrip(t *testing.T) {
 	srv := StartWorkloadServer(t, ServerBehavior{Mode: ServerProbe, RespSize: 64})
-	if err := probeOnce(srv.Addr(), 64, 64, 5*time.Second); err != nil {
+	if err := probeOnce(srv, srv.Addr(), 64, 64, 5*time.Second); err != nil {
 		t.Fatalf("probeOnce: %v", err)
 	}
 }
@@ -214,7 +214,7 @@ func TestProbeOnce_RoundTrip(t *testing.T) {
 // response-size mismatch instead of silently passing.
 func TestProbeOnce_WrongRespSize(t *testing.T) {
 	srv := StartWorkloadServer(t, ServerBehavior{Mode: ServerProbe, RespSize: 64})
-	err := probeOnce(srv.Addr(), 64, 128, 5*time.Second)
+	err := probeOnce(srv, srv.Addr(), 64, 128, 5*time.Second)
 	if err == nil {
 		t.Fatalf("probeOnce expected error on resp-size mismatch")
 	}

--- a/e2e/scenarios/probe_test.go
+++ b/e2e/scenarios/probe_test.go
@@ -118,6 +118,14 @@ func TestProbeFlow_ContinuousProgress(t *testing.T) {
 	if s.exchanges <= 0 || s.acked < s.sent-1 {
 		t.Errorf("summary inconsistent: %+v", s)
 	}
+	// Rolling aggregates must reflect a real worst exchange: maxRTT > 0
+	// and worstByRTT.rtt == maxRTT, with seq <= acked.
+	if s.maxRTT <= 0 || s.worstByRTT.rtt != s.maxRTT {
+		t.Errorf("worstByRTT mismatch: maxRTT=%v worst=%+v", s.maxRTT, s.worstByRTT)
+	}
+	if int64(s.worstByRTT.seq) > s.acked {
+		t.Errorf("worstByRTT.seq=%d > acked=%d", s.worstByRTT.seq, s.acked)
+	}
 }
 
 // TestProbeFlow_BrokenOnPeerClose verifies that when the server closes
@@ -257,7 +265,7 @@ func TestProbeFlow_Localize_OutboundBreak(t *testing.T) {
 	srv := StartWorkloadServer(t, ServerBehavior{Mode: ServerProbe, RespSize: 16})
 	// Build a probeFlow with no traffic — pick an arbitrary nonce the
 	// server has never seen.
-	c, err := net.Dial("tcp", srv.Addr())
+	c, err := net.DialTimeout("tcp", srv.Addr(), 2*time.Second)
 	if err != nil {
 		t.Fatalf("dial: %v", err)
 	}

--- a/e2e/scenarios/probe_test.go
+++ b/e2e/scenarios/probe_test.go
@@ -1,0 +1,233 @@
+package scenarios
+
+import (
+	"encoding/binary"
+	"net"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestServeProbe_RoundTripIntegrity drives a single hand-built probe
+// request through a ServerProbe server and verifies the server echoes
+// seq + client timestamp, stamps recv/send, fills RespSize pattern bytes,
+// and publishes a non-terminal probeConnStat under the request nonce.
+func TestServeProbe_RoundTripIntegrity(t *testing.T) {
+	const reqSize, respSize = 32, 48
+	srv := StartWorkloadServer(t, ServerBehavior{Mode: ServerProbe, RespSize: respSize})
+	conn := dialServer(t, srv)
+
+	nonce := uint64(0xAABBCCDDEEFF0011)
+	const seq uint32 = 7
+	const clientStamp int64 = 0x0123456789ABCDEF
+
+	req := make([]byte, probeHdrLen+reqSize)
+	binary.BigEndian.PutUint32(req[probeOffSeq:], seq)
+	binary.BigEndian.PutUint64(req[probeOffClient:], uint64(clientStamp))
+	fillPattern(req[probeHdrLen:], nonce, int(seq)*reqSize)
+	if err := writeFrame(conn, frameProbeReq, nonce, req); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	typ, n, payload, err := readFrame(conn)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if typ != frameProbeResp {
+		t.Fatalf("type=%d, want frameProbeResp=%d", typ, frameProbeResp)
+	}
+	if n != nonce {
+		t.Fatalf("nonce=%x, want %x", n, nonce)
+	}
+	if len(payload) != probeHdrLen+respSize {
+		t.Fatalf("payload len=%d, want %d", len(payload), probeHdrLen+respSize)
+	}
+	if gotSeq := binary.BigEndian.Uint32(payload[probeOffSeq:]); gotSeq != seq {
+		t.Errorf("echoed seq=%d, want %d", gotSeq, seq)
+	}
+	if gotClient := int64(binary.BigEndian.Uint64(payload[probeOffClient:])); gotClient != clientStamp {
+		t.Errorf("echoed client stamp=%x, want %x", gotClient, clientStamp)
+	}
+	srvRecv := int64(binary.BigEndian.Uint64(payload[probeOffSrvRecv:]))
+	srvSend := int64(binary.BigEndian.Uint64(payload[probeOffSrvSend:]))
+	if srvRecv <= 0 || srvSend < srvRecv {
+		t.Errorf("server stamps invalid: recv=%d send=%d", srvRecv, srvSend)
+	}
+	if off, ok := verifyPattern(payload[probeHdrLen:], nonce, int(seq)*respSize); !ok {
+		t.Errorf("response pattern mismatch at offset %d", off)
+	}
+
+	// The server's per-nonce record must exist with this nonce's seq.
+	rec, ok := srv.ProbeRecord(nonce)
+	if !ok {
+		t.Fatalf("ProbeRecord(nonce) not found")
+	}
+	if rec.lastSeqSeen != int64(seq) {
+		t.Errorf("rec.lastSeqSeen=%d want %d", rec.lastSeqSeen, seq)
+	}
+	if rec.terminal {
+		t.Errorf("rec.terminal=true after a successful exchange; want false (conn still open)")
+	}
+}
+
+// TestServeProbe_PatternMismatch_FrameError verifies the server replies
+// with a frameError frame and closes when a request's pattern is corrupt.
+func TestServeProbe_PatternMismatch_FrameError(t *testing.T) {
+	const reqSize = 16
+	srv := StartWorkloadServer(t, ServerBehavior{Mode: ServerProbe, RespSize: 16})
+	conn := dialServer(t, srv)
+
+	nonce := uint64(0xDEADBEEFCAFEBABE)
+	req := make([]byte, probeHdrLen+reqSize)
+	// header valid, body intentionally wrong (zeros vs nonce-derived pattern)
+	if err := writeFrame(conn, frameProbeReq, nonce, req); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	typ, n, _, err := readFrame(conn)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if typ != frameError {
+		t.Fatalf("want frameError, got typ=%d", typ)
+	}
+	if n != nonce {
+		t.Fatalf("nonce mismatch: got %x want %x", n, nonce)
+	}
+}
+
+// TestProbeFlow_ContinuousProgress drives a probeFlow against a real
+// ServerProbe target and verifies acked monotonically advances under a
+// short interval, with no broken / writeErr / firstErr state.
+func TestProbeFlow_ContinuousProgress(t *testing.T) {
+	srv := StartWorkloadServer(t, ServerBehavior{Mode: ServerProbe, RespSize: 32})
+	cfg := ProbeConfig{Interval: 5 * time.Millisecond, ReqSize: 32, RespSize: 32}
+	f, err := startProbeFlow(srv.Addr(), 5*time.Second, cfg)
+	if err != nil {
+		t.Fatalf("startProbeFlow: %v", err)
+	}
+	t.Cleanup(f.Stop)
+
+	base := f.acked()
+	if !waitProgress(f, base+10, 3*time.Second) {
+		t.Fatalf("flow did not advance past %d within 3s (acked=%d)", base+10, f.acked())
+	}
+	if f.broken() {
+		t.Errorf("flow broken: %v", f.firstError())
+	}
+	s := f.Summary()
+	if s.exchanges <= 0 || s.acked < s.sent-1 {
+		t.Errorf("summary inconsistent: %+v", s)
+	}
+}
+
+// TestProbeFlow_BrokenOnPeerClose verifies that when the server closes
+// the connection abruptly, the flow flips broken() within a short window
+// and Stop is safe to call after.
+func TestProbeFlow_BrokenOnPeerClose(t *testing.T) {
+	// Stand up a one-shot proxy that immediately RSTs after accept; this
+	// gives us a deterministic peer-close without driving the
+	// WorkloadServer through a real probe exchange first (the server's
+	// orderly EOF on Stop would NOT mark broken if stopping is set).
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer ln.Close() //nolint:errcheck
+	accepted := make(chan net.Conn, 1)
+	go func() {
+		c, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		accepted <- c
+	}()
+
+	c, err := net.DialTimeout("tcp", ln.Addr().String(), 2*time.Second)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	// Wrap the client side directly in a probeFlow (skip startProbeFlow's
+	// waitFirstAck which would never see a response from this fake peer).
+	f := newProbeFlow(c, ProbeConfig{Interval: 1 * time.Millisecond, ReqSize: 16, RespSize: 16})
+	f.Start()
+	t.Cleanup(f.Stop)
+
+	// Force a server-side close on the accepted conn.
+	select {
+	case sc := <-accepted:
+		_ = sc.Close()
+	case <-time.After(2 * time.Second):
+		t.Fatalf("server side never accepted")
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if f.broken() {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if !f.broken() {
+		t.Fatalf("flow did not mark broken within 2s after peer close (firstErr=%v writeErr=%v)",
+			f.firstError(), f.Summary().writeErr)
+	}
+}
+
+// TestProbeFlow_StopDoesNotBreakSurvivor verifies Stop() shuts down a
+// healthy flow without flipping its broken() flag. This is the property
+// that lets HotDrop count "exactly A0 broken" without false positives.
+func TestProbeFlow_StopDoesNotBreakSurvivor(t *testing.T) {
+	srv := StartWorkloadServer(t, ServerBehavior{Mode: ServerProbe, RespSize: 16})
+	cfg := ProbeConfig{Interval: 5 * time.Millisecond, ReqSize: 16, RespSize: 16}
+	f, err := startProbeFlow(srv.Addr(), 5*time.Second, cfg)
+	if err != nil {
+		t.Fatalf("startProbeFlow: %v", err)
+	}
+	// Run for a few exchanges, then Stop on a healthy connection.
+	if !waitProgress(f, 1, 2*time.Second) {
+		t.Fatalf("flow did not advance to seq>1 within 2s")
+	}
+	f.Stop()
+	if f.broken() {
+		t.Errorf("Stop() on a healthy flow marked it broken: firstErr=%v", f.firstError())
+	}
+}
+
+// TestProbeOnce_RoundTrip exercises the one-shot helper end-to-end.
+func TestProbeOnce_RoundTrip(t *testing.T) {
+	srv := StartWorkloadServer(t, ServerBehavior{Mode: ServerProbe, RespSize: 64})
+	if err := probeOnce(srv.Addr(), 64, 64, 5*time.Second); err != nil {
+		t.Fatalf("probeOnce: %v", err)
+	}
+}
+
+// TestProbeOnce_WrongRespSize verifies the one-shot helper surfaces a
+// response-size mismatch instead of silently passing.
+func TestProbeOnce_WrongRespSize(t *testing.T) {
+	srv := StartWorkloadServer(t, ServerBehavior{Mode: ServerProbe, RespSize: 64})
+	err := probeOnce(srv.Addr(), 64, 128, 5*time.Second)
+	if err == nil {
+		t.Fatalf("probeOnce expected error on resp-size mismatch")
+	}
+	if !strings.Contains(err.Error(), "body") {
+		t.Errorf("error %q does not mention body size", err)
+	}
+}
+
+// TestProbeFlow_Localize_OutboundBreak verifies localize() correctly
+// identifies "no record at server" (no request ever reached the server).
+func TestProbeFlow_Localize_OutboundBreak(t *testing.T) {
+	srv := StartWorkloadServer(t, ServerBehavior{Mode: ServerProbe, RespSize: 16})
+	// Build a probeFlow with no traffic — pick an arbitrary nonce the
+	// server has never seen.
+	c, err := net.Dial("tcp", srv.Addr())
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	f := newProbeFlow(c, ProbeConfig{Interval: 1 * time.Hour, ReqSize: 16, RespSize: 16})
+	t.Cleanup(f.Stop)
+	got := f.localize(srv)
+	if !strings.Contains(got, "no record") || !strings.Contains(got, "outbound") {
+		t.Errorf("localize() = %q, want outbound/no-record diagnosis", got)
+	}
+}

--- a/e2e/scenarios/scenarios.go
+++ b/e2e/scenarios/scenarios.go
@@ -37,6 +37,7 @@ func RunAllScenarios(t *testing.T, b Backend) {
 		names[i] = a.Name()
 	}
 	perfMatrixSink.setAxisNames(names)
+	perfMatrixSink.setBackendName(b.Name())
 	t.Cleanup(func() {
 		finishPerfMatrix(t)
 	})

--- a/e2e/scenarios/scenarios.go
+++ b/e2e/scenarios/scenarios.go
@@ -38,6 +38,7 @@ func RunAllScenarios(t *testing.T, b Backend) {
 	}
 	perfMatrixSink.setAxisNames(names)
 	perfMatrixSink.setBackendName(b.Name())
+	perfMatrixSink.setPins(b.Pins())
 	t.Cleanup(func() {
 		finishPerfMatrix(t)
 	})

--- a/e2e/scenarios/scenarios.go
+++ b/e2e/scenarios/scenarios.go
@@ -41,6 +41,13 @@ func RunAllScenarios(t *testing.T, b Backend) {
 	perfMatrixSink.setPins(b.Pins())
 	t.Cleanup(func() {
 		finishPerfMatrix(t)
+		// Clear sink identity so any subsequent test in the same
+		// process (or a second RunAllScenarios call) starts from a
+		// clean slate instead of inheriting this run's labels. drain()
+		// inside finishPerfMatrix already cleared the rows.
+		perfMatrixSink.setAxisNames(nil)
+		perfMatrixSink.setBackendName("")
+		perfMatrixSink.setPins(nil)
 	})
 	forEachCell(t, axes, func(t *testing.T, cell map[string]string) {
 		cellBackend := b.Cell(cell)

--- a/e2e/scenarios/topology.go
+++ b/e2e/scenarios/topology.go
@@ -3,7 +3,6 @@ package scenarios
 import (
 	"bytes"
 	"context"
-	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -270,7 +269,7 @@ func scenarioDistributionPerSender(t *testing.T, b Backend, n, m int) {
 func scenarioHotDropListener(t *testing.T, b Backend, n, m int) {
 	t.Helper()
 	AssertNoLeaks(t)
-	echo := StartPlainEcho(t)
+	echo := StartWorkloadServer(t, ServerBehavior{Mode: ServerProbe, RespSize: defaultProbeBody})
 	tun := b.Setup(t, SetupOptions{
 		NumListeners:   m,
 		NumSenders:     n,
@@ -283,19 +282,19 @@ func scenarioHotDropListener(t *testing.T, b Backend, n, m int) {
 		kBatch = 8
 		kMax   = 40
 	)
-	var flows []*longFlow
+	var flows []*probeFlow
 	var a0 int64
 	for len(flows) < kMax {
 		// Open one batch.
 		batchStart := len(flows)
 		for i := 0; i < kBatch && len(flows) < kMax; i++ {
 			addr := tun.SenderAddrs[len(flows)%len(tun.SenderAddrs)]
-			f, err := startLongFlow(addr, 15*time.Second)
+			f, err := startProbeFlow(addr, 15*time.Second, ProbeConfig{})
 			if err != nil {
-				t.Fatalf("start long flow %d: %v", len(flows), err)
+				t.Fatalf("start probe flow %d: %v", len(flows), err)
 			}
 			flows = append(flows, f)
-			t.Cleanup(f.Close)
+			t.Cleanup(f.Stop)
 		}
 		// Wait until every long-flow opened so far is bridged.
 		if !waitForSumActive(tun, int64(len(flows)), 10*time.Second) {
@@ -361,20 +360,22 @@ func scenarioHotDropListener(t *testing.T, b Backend, n, m int) {
 		t.Errorf("after dropping listener[0]: %d/%d flows broken, want <= %d (A0); surviving listener(s) silently tore down %d in-flight bridge(s)", dead, k, a0, int64(dead)-a0)
 	}
 
-	// Verify every surviving flow still echoes. If A0 happened to
-	// equal K (all flows on the dropped listener), all flows are
-	// broken and we skip the survivor check; otherwise we exercise
-	// every non-broken flow — a regression where the surviving
-	// listener silently dropped some bridges but left others healthy
-	// would slip through if we only probed one.
+	// Verify every surviving flow keeps making forward progress. If A0
+	// happened to equal K (all flows on the dropped listener), all flows
+	// are broken and we skip the survivor check; otherwise we exercise
+	// every non-broken flow — a regression where the surviving listener
+	// silently dropped some bridges but left others healthy would slip
+	// through if we only probed one.
 	if a0 < int64(k) {
 		survivors := 0
 		for i, f := range flows {
 			if f.broken() {
 				continue
 			}
-			if err := f.exchange(fmt.Sprintf("survivor-%d\n", i), 5*time.Second); err != nil {
-				t.Errorf("survivor flow %d exchange failed: %v", i, err)
+			base := f.acked()
+			if !waitProgress(f, base, 5*time.Second) {
+				t.Errorf("survivor flow %d made no progress after drop (acked stuck at %d)", i, base)
+				f.Dump(t, echo, fmt.Sprintf("hotdrop-flow-%d", i))
 				continue
 			}
 			survivors++
@@ -382,11 +383,11 @@ func scenarioHotDropListener(t *testing.T, b Backend, n, m int) {
 		if survivors == 0 {
 			t.Fatalf("expected at least one surviving flow but all are broken")
 		}
-		t.Logf("post-drop: %d/%d surviving flows still echo", survivors, k)
+		t.Logf("post-drop: %d/%d surviving flows still progressing", survivors, k)
 	}
 
 	// A fresh dial after drop must succeed via the surviving listener.
-	if err := runEchoOnce(tun.SenderAddr, "after-drop\n", 15*time.Second); err != nil {
+	if err := probeOnce(tun.SenderAddr, defaultProbeBody, defaultProbeBody, 15*time.Second); err != nil {
 		t.Errorf("post-drop fresh dial: %v", err)
 	}
 }
@@ -404,28 +405,28 @@ func scenarioHotDropListener(t *testing.T, b Backend, n, m int) {
 func scenarioHotAddListener(t *testing.T, b Backend, n, m int) {
 	t.Helper()
 	AssertNoLeaks(t)
-	echo := StartPlainEcho(t)
+	srv := StartWorkloadServer(t, ServerBehavior{Mode: ServerProbe, RespSize: defaultProbeBody})
 	tun := b.Setup(t, SetupOptions{
 		NumListeners:   m,
 		NumSenders:     n,
 		SenderMode:     ModePortForward,
-		Target:         echo.Addr(),
-		AllowedTargets: []string{echo.Addr()},
+		Target:         srv.Addr(),
+		AllowedTargets: []string{srv.Addr()},
 	})
 	if tun.AddListener == nil {
 		t.Skip("backend does not implement hot-add (Tunnel.AddListener is nil)")
 	}
 
 	const kActive = 4
-	flows := make([]*longFlow, kActive)
+	flows := make([]*probeFlow, kActive)
 	for i := 0; i < kActive; i++ {
 		addr := tun.SenderAddrs[i%len(tun.SenderAddrs)]
-		f, err := startLongFlow(addr, 15*time.Second)
+		f, err := startProbeFlow(addr, 15*time.Second, ProbeConfig{})
 		if err != nil {
-			t.Fatalf("start long flow %d: %v", i, err)
+			t.Fatalf("start probe flow %d: %v", i, err)
 		}
 		flows[i] = f
-		t.Cleanup(f.Close)
+		t.Cleanup(f.Stop)
 	}
 
 	newListener := tun.AddListener(t)
@@ -433,7 +434,7 @@ func scenarioHotAddListener(t *testing.T, b Backend, n, m int) {
 		t.Fatalf("AddListener returned nil")
 	}
 
-	// Drive short echoes in batches until the new listener completes
+	// Drive short probes in batches until the new listener completes
 	// at least one bridge, or we exhaust the probe budget. We need
 	// the listener to be the chosen destination at least once;
 	// Azure's selection is non-uniform but biased toward freshly-
@@ -449,8 +450,7 @@ func scenarioHotAddListener(t *testing.T, b Backend, n, m int) {
 	for newListener.Completed() == 0 && sent < kMax && time.Now().Before(probeDeadline) {
 		for i := 0; i < kBatch && sent < kMax && time.Now().Before(probeDeadline); i++ {
 			addr := tun.SenderAddrs[sent%len(tun.SenderAddrs)]
-			payload := fmt.Sprintf("probe-%d\n", sent)
-			if err := runEchoOnce(addr, payload, 10*time.Second); err != nil {
+			if err := probeOnce(addr, defaultProbeBody, defaultProbeBody, 10*time.Second); err != nil {
 				t.Fatalf("probe %d via %s: %v", sent, addr, err)
 			}
 			sent++
@@ -467,14 +467,17 @@ func scenarioHotAddListener(t *testing.T, b Backend, n, m int) {
 		t.Logf("hot-add converged: new listener completed=%d after %d probes", c, sent)
 	}
 
-	// Existing flows must still be alive.
+	// Existing flows must still be alive and making forward progress.
 	for i, f := range flows {
 		if f.broken() {
 			t.Errorf("existing flow %d broken after hot-add", i)
+			f.Dump(t, srv, fmt.Sprintf("hotadd-flow-%d", i))
 			continue
 		}
-		if err := f.exchange(fmt.Sprintf("existing-%d\n", i), 5*time.Second); err != nil {
-			t.Errorf("existing flow %d exchange failed: %v", i, err)
+		base := f.acked()
+		if !waitProgress(f, base, 5*time.Second) {
+			t.Errorf("existing flow %d made no progress after hot-add (acked stuck at %d)", i, base)
+			f.Dump(t, srv, fmt.Sprintf("hotadd-flow-%d", i))
 		}
 	}
 }
@@ -706,109 +709,6 @@ func waitForSumActive(tun *Tunnel, want int64, timeout time.Duration) bool {
 		time.Sleep(50 * time.Millisecond)
 	}
 	return false
-}
-
-// longFlow is a holds-open echo connection used by hot-drop and hot-
-// add scenarios that need to observe in-flight bridges.
-type longFlow struct {
-	conn net.Conn
-	mu   sync.Mutex
-	bad  bool
-}
-
-func startLongFlow(addr string, dialTimeout time.Duration) (*longFlow, error) {
-	c, err := net.DialTimeout("tcp", addr, dialTimeout)
-	if err != nil {
-		return nil, err
-	}
-	// Sanity exchange so we know the bridge is established before
-	// callers move on to topology changes. Without this, race-y
-	// behaviour where the bridge hasn't yet bumped Active() can give
-	// false A0=0 readings in hot-drop.
-	f := &longFlow{conn: c}
-	if err := f.exchange("init\n", 10*time.Second); err != nil {
-		_ = c.Close()
-		return nil, fmt.Errorf("init: %w", err)
-	}
-	return f, nil
-}
-
-// exchange writes payload and reads it back; returns an error if
-// either side fails. On any error, the flow is marked broken so
-// future broken() calls return true.
-func (f *longFlow) exchange(payload string, timeout time.Duration) error {
-	if f == nil {
-		return errors.New("nil flow")
-	}
-	f.mu.Lock()
-	defer f.mu.Unlock()
-	if f.bad {
-		return errors.New("flow already broken")
-	}
-	_ = f.conn.SetDeadline(time.Now().Add(timeout))
-	defer func() { _ = f.conn.SetDeadline(time.Time{}) }()
-
-	if err := writeFull(f.conn, []byte(payload)); err != nil {
-		f.bad = true
-		return fmt.Errorf("write: %w", err)
-	}
-	buf := make([]byte, len(payload))
-	if _, err := io.ReadFull(f.conn, buf); err != nil {
-		f.bad = true
-		return fmt.Errorf("read: %w", err)
-	}
-	if !bytes.Equal(buf, []byte(payload)) {
-		f.bad = true
-		return fmt.Errorf("mismatch: got %q want %q", buf, payload)
-	}
-	return nil
-}
-
-// broken probes the flow with a tiny non-destructive read deadline.
-// If the underlying TCP has been torn down (peer closed), Read
-// returns EOF / RST immediately and we mark the flow broken.
-//
-// We intentionally do NOT call broken() in parallel with exchange()
-// from the same flow — the mutex serialises both, but the broken
-// check sets a 1 ms read deadline that would race a concurrent
-// exchange.
-func (f *longFlow) broken() bool {
-	f.mu.Lock()
-	defer f.mu.Unlock()
-	if f.bad {
-		return true
-	}
-	_ = f.conn.SetReadDeadline(time.Now().Add(1 * time.Millisecond))
-	buf := make([]byte, 1)
-	_, err := f.conn.Read(buf)
-	_ = f.conn.SetReadDeadline(time.Time{})
-	if err == nil {
-		// Got a byte unexpectedly. Treat as broken (echo is full-
-		// duplex; a stray byte means something is wrong).
-		f.bad = true
-		return true
-	}
-	var ne net.Error
-	if errors.As(err, &ne) && ne.Timeout() {
-		// No data; still alive.
-		return false
-	}
-	// Any other error means EOF / RST / closed.
-	f.bad = true
-	return true
-}
-
-// Close closes the underlying connection. Safe to call multiple times.
-func (f *longFlow) Close() {
-	if f == nil {
-		return
-	}
-	f.mu.Lock()
-	defer f.mu.Unlock()
-	if f.conn != nil {
-		_ = f.conn.Close()
-		f.conn = nil
-	}
 }
 
 // ScenarioListenerRestart_Recovers: bring up one listener and one

--- a/e2e/scenarios/topology.go
+++ b/e2e/scenarios/topology.go
@@ -2,7 +2,6 @@ package scenarios
 
 import (
 	"context"
-	"encoding/binary"
 	"fmt"
 	"net"
 	"sync"
@@ -574,13 +573,18 @@ func scenarioMaxConnBackPressure(t *testing.T, b Backend, n, m int) {
 	}
 }
 
-// probeWithHold dials addr, runs one probe exchange against srv, holds
-// the bridge open (idle) for hold, then closes. Used by
-// scenarioMaxConnBackPressure to give the 20 ms metric sampler a chance
-// to observe the steady-state Active count across all listeners; short
-// exchanges that complete in single-digit milliseconds race the sampler
-// and produce observed=0 spuriously. On failure the returned error
-// carries the same per-leg server-side attribution probeOnce provides.
+// probeWithHold dials addr, runs one probe exchange against srv with
+// the same validation probeOnce performs (header, nonce, response
+// size, pattern), holds the bridge open (idle) for hold, then closes.
+// Used by scenarioMaxConnBackPressure to give the 20 ms metric sampler
+// a chance to observe the steady-state Active count across all
+// listeners; short exchanges that complete in single-digit milliseconds
+// race the sampler and produce observed=0 spuriously.
+//
+// On failure the returned error carries the same per-leg server-side
+// attribution probeOnce provides (outbound break vs. server stall vs.
+// return-leg failure), and the server-side record is always consumed
+// so a partial exchange does not leak a probeStats entry.
 func probeWithHold(srv *WorkloadServer, addr string, hold, timeout time.Duration) error {
 	conn, err := net.DialTimeout("tcp", addr, timeout)
 	if err != nil {
@@ -590,24 +594,15 @@ func probeWithHold(srv *WorkloadServer, addr string, hold, timeout time.Duration
 	_ = conn.SetDeadline(time.Now().Add(timeout + hold))
 
 	nonce := randNonce()
-	buf := make([]byte, probeHdrLen+defaultProbeBody)
-	binary.BigEndian.PutUint64(buf[probeOffClient:], uint64(probeNanos()))
-	fillPattern(buf[probeHdrLen:], nonce, 0)
-	if err := writeFrame(conn, frameProbeReq, nonce, buf); err != nil {
-		return fmt.Errorf("write: %w", err)
-	}
-	typ, n, payload, err := readFrame(conn)
-	if err != nil {
-		return fmt.Errorf("read: %w", err)
-	}
-	if n != nonce || typ != frameProbeResp || len(payload) < probeHdrLen {
-		return fmt.Errorf("bad probe response: typ=%d nonce=%d hdrlen=%d", typ, n, len(payload))
+	if err := probeExchangeOnConn(conn, nonce, defaultProbeBody, defaultProbeBody); err != nil {
+		return localizeProbeError(srv, nonce, err)
 	}
 	// Hold the conn open so the sampler observes the elevated Active
 	// count; both server and client retain their bridge bookkeeping
 	// until the deferred Close fires after the sleep.
 	time.Sleep(hold)
-	_, _ = srv.ConsumeProbeRecord(nonce) // free server record before return
+	// Successful exchange — drop the record so it doesn't linger.
+	_, _ = srv.ConsumeProbeRecord(nonce)
 	return nil
 }
 

--- a/e2e/scenarios/topology.go
+++ b/e2e/scenarios/topology.go
@@ -1,10 +1,9 @@
 package scenarios
 
 import (
-	"bytes"
 	"context"
+	"encoding/binary"
 	"fmt"
-	"io"
 	"net"
 	"sync"
 	"sync/atomic"
@@ -84,13 +83,13 @@ func topologyCases() []scenarioCase {
 func scenarioNMEcho(t *testing.T, b Backend, n, m int) {
 	t.Helper()
 	AssertNoLeaks(t)
-	echo := StartPlainEcho(t)
+	srv := StartWorkloadServer(t, ServerBehavior{Mode: ServerProbe, RespSize: defaultProbeBody})
 	tun := b.Setup(t, SetupOptions{
 		NumListeners:   m,
 		NumSenders:     n,
 		SenderMode:     ModePortForward,
-		Target:         echo.Addr(),
-		AllowedTargets: []string{echo.Addr()},
+		Target:         srv.Addr(),
+		AllowedTargets: []string{srv.Addr()},
 	})
 
 	const k = 8
@@ -101,7 +100,7 @@ func scenarioNMEcho(t *testing.T, b Backend, n, m int) {
 		go func(i int) {
 			defer wg.Done()
 			addr := tun.SenderAddrs[i%len(tun.SenderAddrs)]
-			if err := runEchoOnce(addr, fmt.Sprintf("hello %d\n", i), 15*time.Second); err != nil {
+			if err := probeOnce(srv, addr, defaultProbeBody, defaultProbeBody, 15*time.Second); err != nil {
 				errs <- fmt.Errorf("flow %d via %s: %w", i, addr, err)
 			}
 		}(i)
@@ -126,13 +125,13 @@ func scenarioNMEcho(t *testing.T, b Backend, n, m int) {
 func scenarioDistributionPerListener(t *testing.T, b Backend, n, m int) {
 	t.Helper()
 	AssertNoLeaks(t)
-	echo := StartPlainEcho(t)
+	srv := StartWorkloadServer(t, ServerBehavior{Mode: ServerProbe, RespSize: defaultProbeBody})
 	tun := b.Setup(t, SetupOptions{
 		NumListeners:   m,
 		NumSenders:     n,
 		SenderMode:     ModePortForward,
-		Target:         echo.Addr(),
-		AllowedTargets: []string{echo.Addr()},
+		Target:         srv.Addr(),
+		AllowedTargets: []string{srv.Addr()},
 	})
 
 	const (
@@ -149,9 +148,8 @@ func scenarioDistributionPerListener(t *testing.T, b Backend, n, m int) {
 				t.Fatalf("convergence deadline exceeded after %d echoes", sent)
 			}
 			addr := tun.SenderAddrs[sent%len(tun.SenderAddrs)]
-			payload := fmt.Sprintf("ser-%d\n", sent)
-			if err := runEchoOnce(addr, payload, 10*time.Second); err != nil {
-				t.Fatalf("echo %d via %s: %v", sent, addr, err)
+			if err := probeOnce(srv, addr, defaultProbeBody, defaultProbeBody, 10*time.Second); err != nil {
+				t.Fatalf("probe %d via %s: %v", sent, addr, err)
 			}
 			sent++
 		}
@@ -195,13 +193,13 @@ func scenarioDistributionPerListener(t *testing.T, b Backend, n, m int) {
 func scenarioDistributionPerSender(t *testing.T, b Backend, n, m int) {
 	t.Helper()
 	AssertNoLeaks(t)
-	echo := StartPlainEcho(t)
+	srv := StartWorkloadServer(t, ServerBehavior{Mode: ServerProbe, RespSize: defaultProbeBody})
 	tun := b.Setup(t, SetupOptions{
 		NumListeners:   m,
 		NumSenders:     n,
 		SenderMode:     ModePortForward,
-		Target:         echo.Addr(),
-		AllowedTargets: []string{echo.Addr()},
+		Target:         srv.Addr(),
+		AllowedTargets: []string{srv.Addr()},
 	})
 
 	const (
@@ -218,9 +216,8 @@ func scenarioDistributionPerSender(t *testing.T, b Backend, n, m int) {
 				t.Fatalf("convergence deadline exceeded after %d echoes", sent)
 			}
 			addr := tun.SenderAddrs[sent%len(tun.SenderAddrs)]
-			payload := fmt.Sprintf("ser-%d\n", sent)
-			if err := runEchoOnce(addr, payload, 10*time.Second); err != nil {
-				t.Fatalf("echo %d via %s: %v", sent, addr, err)
+			if err := probeOnce(srv, addr, defaultProbeBody, defaultProbeBody, 10*time.Second); err != nil {
+				t.Fatalf("probe %d via %s: %v", sent, addr, err)
 			}
 			sent++
 		}
@@ -387,7 +384,7 @@ func scenarioHotDropListener(t *testing.T, b Backend, n, m int) {
 	}
 
 	// A fresh dial after drop must succeed via the surviving listener.
-	if err := probeOnce(tun.SenderAddr, defaultProbeBody, defaultProbeBody, 15*time.Second); err != nil {
+	if err := probeOnce(echo, tun.SenderAddr, defaultProbeBody, defaultProbeBody, 15*time.Second); err != nil {
 		t.Errorf("post-drop fresh dial: %v", err)
 	}
 }
@@ -450,7 +447,7 @@ func scenarioHotAddListener(t *testing.T, b Backend, n, m int) {
 	for newListener.Completed() == 0 && sent < kMax && time.Now().Before(probeDeadline) {
 		for i := 0; i < kBatch && sent < kMax && time.Now().Before(probeDeadline); i++ {
 			addr := tun.SenderAddrs[sent%len(tun.SenderAddrs)]
-			if err := probeOnce(addr, defaultProbeBody, defaultProbeBody, 10*time.Second); err != nil {
+			if err := probeOnce(srv, addr, defaultProbeBody, defaultProbeBody, 10*time.Second); err != nil {
 				t.Fatalf("probe %d via %s: %v", sent, addr, err)
 			}
 			sent++
@@ -497,14 +494,14 @@ func scenarioHotAddListener(t *testing.T, b Backend, n, m int) {
 func scenarioMaxConnBackPressure(t *testing.T, b Backend, n, m int) {
 	t.Helper()
 	AssertNoLeaks(t)
-	echo := StartPlainEcho(t)
+	srv := StartWorkloadServer(t, ServerBehavior{Mode: ServerProbe, RespSize: defaultProbeBody})
 	const maxConn = 2
 	tun := b.Setup(t, SetupOptions{
 		NumListeners:   m,
 		NumSenders:     n,
 		SenderMode:     ModePortForward,
-		Target:         echo.Addr(),
-		AllowedTargets: []string{echo.Addr()},
+		Target:         srv.Addr(),
+		AllowedTargets: []string{srv.Addr()},
 		MaxConnections: maxConn,
 	})
 
@@ -544,11 +541,10 @@ func scenarioMaxConnBackPressure(t *testing.T, b Backend, n, m int) {
 		go func(i int) {
 			defer wg.Done()
 			addr := tun.SenderAddrs[i%len(tun.SenderAddrs)]
-			payload := fmt.Sprintf("mc-%d\n", i)
 			deadline := time.Now().Add(overall)
 			var lastErr error
 			for time.Now().Before(deadline) {
-				err := echoWithHold(addr, payload, holdDur, 5*time.Second)
+				err := probeWithHold(srv, addr, holdDur, 5*time.Second)
 				if err == nil {
 					return
 				}
@@ -578,14 +574,14 @@ func scenarioMaxConnBackPressure(t *testing.T, b Backend, n, m int) {
 	}
 }
 
-// echoWithHold dials addr, exchanges payload once, holds the bridge
-// open for hold (no I/O during the hold so the sender's bridge sits
-// idle), then closes. Used by scenarioMaxConnBackPressure to give the
-// 20 ms metric sampler a chance to observe the steady-state Active
-// count across all listeners — short echoes that complete in single-
-// digit milliseconds race the sampler and produce observed=0
-// spuriously.
-func echoWithHold(addr, payload string, hold, timeout time.Duration) error {
+// probeWithHold dials addr, runs one probe exchange against srv, holds
+// the bridge open (idle) for hold, then closes. Used by
+// scenarioMaxConnBackPressure to give the 20 ms metric sampler a chance
+// to observe the steady-state Active count across all listeners; short
+// exchanges that complete in single-digit milliseconds race the sampler
+// and produce observed=0 spuriously. On failure the returned error
+// carries the same per-leg server-side attribution probeOnce provides.
+func probeWithHold(srv *WorkloadServer, addr string, hold, timeout time.Duration) error {
 	conn, err := net.DialTimeout("tcp", addr, timeout)
 	if err != nil {
 		return fmt.Errorf("dial: %w", err)
@@ -593,45 +589,29 @@ func echoWithHold(addr, payload string, hold, timeout time.Duration) error {
 	defer conn.Close() //nolint:errcheck // best-effort
 	_ = conn.SetDeadline(time.Now().Add(timeout + hold))
 
-	if err := writeFull(conn, []byte(payload)); err != nil {
+	nonce := randNonce()
+	buf := make([]byte, probeHdrLen+defaultProbeBody)
+	binary.BigEndian.PutUint64(buf[probeOffClient:], uint64(probeNanos()))
+	fillPattern(buf[probeHdrLen:], nonce, 0)
+	if err := writeFrame(conn, frameProbeReq, nonce, buf); err != nil {
 		return fmt.Errorf("write: %w", err)
 	}
-	buf := make([]byte, len(payload))
-	if _, err := io.ReadFull(conn, buf); err != nil {
+	typ, n, payload, err := readFrame(conn)
+	if err != nil {
 		return fmt.Errorf("read: %w", err)
 	}
-	if !bytes.Equal(buf, []byte(payload)) {
-		return fmt.Errorf("echo mismatch: got %q want %q", buf, payload)
+	if n != nonce || typ != frameProbeResp || len(payload) < probeHdrLen {
+		return fmt.Errorf("bad probe response: typ=%d nonce=%d hdrlen=%d", typ, n, len(payload))
 	}
+	// Hold the conn open so the sampler observes the elevated Active
+	// count; both server and client retain their bridge bookkeeping
+	// until the deferred Close fires after the sleep.
 	time.Sleep(hold)
+	_, _ = srv.ConsumeProbeRecord(nonce) // free server record before return
 	return nil
 }
 
 // --- helpers --------------------------------------------------------
-
-// runEchoOnce opens one connection, writes payload, reads it back,
-// and closes. Returns an error if any step fails or if the echo does
-// not round-trip exactly.
-func runEchoOnce(addr, payload string, timeout time.Duration) error {
-	conn, err := net.DialTimeout("tcp", addr, timeout)
-	if err != nil {
-		return fmt.Errorf("dial: %w", err)
-	}
-	defer conn.Close() //nolint:errcheck // best-effort
-	_ = conn.SetDeadline(time.Now().Add(timeout))
-
-	if err := writeFull(conn, []byte(payload)); err != nil {
-		return fmt.Errorf("write: %w", err)
-	}
-	buf := make([]byte, len(payload))
-	if _, err := io.ReadFull(conn, buf); err != nil {
-		return fmt.Errorf("read: %w", err)
-	}
-	if !bytes.Equal(buf, []byte(payload)) {
-		return fmt.Errorf("echo mismatch: got %q want %q", buf, payload)
-	}
-	return nil
-}
 
 // drainErrors returns the first error from a closed channel, with a
 // summary mention of how many additional errors followed.
@@ -721,17 +701,17 @@ func ScenarioListenerRestart_Recovers(t *testing.T, b Backend) {
 	t.Helper()
 	AssertNoLeaks(t)
 
-	echo := StartPlainEcho(t)
+	srv := StartWorkloadServer(t, ServerBehavior{Mode: ServerProbe, RespSize: defaultProbeBody})
 	tun := b.Setup(t, SetupOptions{
 		NumListeners:   1,
 		SenderMode:     ModePortForward,
-		Target:         echo.Addr(),
-		AllowedTargets: []string{echo.Addr()},
+		Target:         srv.Addr(),
+		AllowedTargets: []string{srv.Addr()},
 	})
 
 	// Pre-restart round-trip.
-	if err := runEchoOnce(tun.SenderAddr, "before-restart\n", 15*time.Second); err != nil {
-		t.Fatalf("pre-restart echo: %v", err)
+	if err := probeOnce(srv, tun.SenderAddr, defaultProbeBody, defaultProbeBody, 15*time.Second); err != nil {
+		t.Fatalf("pre-restart probe: %v", err)
 	}
 
 	// Stop the listener and attach a fresh one.
@@ -748,12 +728,12 @@ func ScenarioListenerRestart_Recovers(t *testing.T, b Backend) {
 	deadline := time.Now().Add(20 * time.Second)
 	var lastErr error
 	for time.Now().Before(deadline) {
-		if err := runEchoOnce(tun.SenderAddr, "after-restart\n", 5*time.Second); err == nil {
+		if err := probeOnce(srv, tun.SenderAddr, defaultProbeBody, defaultProbeBody, 5*time.Second); err == nil {
 			return
 		} else {
 			lastErr = err
 		}
 		time.Sleep(500 * time.Millisecond)
 	}
-	t.Fatalf("post-restart echo never succeeded within 20s: %v", lastErr)
+	t.Fatalf("post-restart probe never succeeded within 20s: %v", lastErr)
 }

--- a/e2e/scenarios/topology.go
+++ b/e2e/scenarios/topology.go
@@ -296,7 +296,7 @@ func scenarioHotDropListener(t *testing.T, b Backend, n, m int) {
 			flows = append(flows, f)
 			t.Cleanup(f.Stop)
 		}
-		// Wait until every long-flow opened so far is bridged.
+		// Wait until every probe flow opened so far is bridged.
 		if !waitForSumActive(tun, int64(len(flows)), 10*time.Second) {
 			t.Fatalf("sum of listener Active() never reached %d after batch starting at %d",
 				len(flows), batchStart)

--- a/e2e/scenarios/topology.go
+++ b/e2e/scenarios/topology.go
@@ -74,10 +74,12 @@ func topologyCases() []scenarioCase {
 	}
 }
 
-// scenarioNMEcho drives K parallel TCP echo flows distributed round-
-// robin across SenderAddrs, all targeting a single backend echo
-// server. Asserts every flow's payload round-trips intact. This is
-// the workhorse correctness check for the topology slice; everything
+// scenarioNMEcho drives K parallel framed probe flows distributed
+// round-robin across SenderAddrs, all targeting a single ServerProbe
+// WorkloadServer. Each probeOnce validates request+response framing,
+// nonce, response size, and payload pattern; the byte-transparency
+// property is exercised separately by BulkTransfer. This is the
+// workhorse functional check for the topology slice; everything
 // downstream assumes it holds.
 func scenarioNMEcho(t *testing.T, b Backend, n, m int) {
 	t.Helper()
@@ -111,8 +113,8 @@ func scenarioNMEcho(t *testing.T, b Backend, n, m int) {
 	}
 }
 
-// scenarioDistributionPerListener drives short echoes round-robin
-// across senders until every listener has handled at least one
+// scenarioDistributionPerListener drives short framed probes round-
+// robin across senders until every listener has handled at least one
 // bridge to completion, or a bounded budget is exhausted. Azure
 // Relay's listener selection is explicitly non-uniform at small
 // sample sizes (e2e/multi_test.go documents observed ratios up to
@@ -144,7 +146,7 @@ func scenarioDistributionPerListener(t *testing.T, b Backend, n, m int) {
 	issue := func(count int) {
 		for i := 0; i < count && sent < kMax; i++ {
 			if time.Now().After(overallDeadline) {
-				t.Fatalf("convergence deadline exceeded after %d echoes", sent)
+				t.Fatalf("convergence deadline exceeded after %d probes", sent)
 			}
 			addr := tun.SenderAddrs[sent%len(tun.SenderAddrs)]
 			if err := probeOnce(srv, addr, defaultProbeBody, defaultProbeBody, 10*time.Second); err != nil {
@@ -172,15 +174,15 @@ func scenarioDistributionPerListener(t *testing.T, b Backend, n, m int) {
 
 	for i, l := range tun.Listeners {
 		c := l.Completed()
-		t.Logf("listener[%d] completed=%d (after %d echoes)", i, c, sent)
+		t.Logf("listener[%d] completed=%d (after %d probes)", i, c, sent)
 		if c <= 0 {
-			t.Errorf("listener[%d] completed=%d after %d echoes, want > 0", i, c, sent)
+			t.Errorf("listener[%d] completed=%d after %d probes, want > 0", i, c, sent)
 		}
 	}
 }
 
 // scenarioDistributionPerSender mirrors scenarioDistributionPerListener
-// for senders. With echoes dialed round-robin across N senders, every
+// for senders. With probes dialed round-robin across N senders, every
 // sender is exercised by construction for the dial count; the metric
 // assertion proves each sender actually bridged the dial to a relay
 // rendezvous (vs. accepted the TCP and failed before forwarding).
@@ -212,7 +214,7 @@ func scenarioDistributionPerSender(t *testing.T, b Backend, n, m int) {
 	issue := func(count int) {
 		for i := 0; i < count && sent < kMax; i++ {
 			if time.Now().After(overallDeadline) {
-				t.Fatalf("convergence deadline exceeded after %d echoes", sent)
+				t.Fatalf("convergence deadline exceeded after %d probes", sent)
 			}
 			addr := tun.SenderAddrs[sent%len(tun.SenderAddrs)]
 			if err := probeOnce(srv, addr, defaultProbeBody, defaultProbeBody, 10*time.Second); err != nil {
@@ -240,21 +242,21 @@ func scenarioDistributionPerSender(t *testing.T, b Backend, n, m int) {
 
 	for i, s := range tun.Senders {
 		c := s.Completed()
-		t.Logf("sender[%d] completed=%d (after %d echoes)", i, c, sent)
+		t.Logf("sender[%d] completed=%d (after %d probes)", i, c, sent)
 		if c <= 0 {
-			t.Errorf("sender[%d] completed=%d after %d echoes, want > 0", i, c, sent)
+			t.Errorf("sender[%d] completed=%d after %d probes, want > 0", i, c, sent)
 		}
 	}
 }
 
 // scenarioHotDropListener verifies the surviving-listener path. It
-// opens enough long-running flows for at least one to land on
+// opens enough held-open probe flows for at least one to land on
 // listener[0], snapshots A0 = listener[0].Active(), stops
 // listener[0], and asserts:
 //
 //   - at least A0 flows fail/EOF within bounded time;
-//   - the surviving K-A0 flows keep echoing;
-//   - a fresh dial after drop succeeds and echoes.
+//   - the surviving K-A0 flows keep making forward progress;
+//   - a fresh probeOnce dial after drop succeeds.
 //
 // Azure Relay distributes connections nonuniformly across listeners
 // (observed ratios up to 1:7 with K=8), so we open in batches of
@@ -265,13 +267,13 @@ func scenarioDistributionPerSender(t *testing.T, b Backend, n, m int) {
 func scenarioHotDropListener(t *testing.T, b Backend, n, m int) {
 	t.Helper()
 	AssertNoLeaks(t)
-	echo := StartWorkloadServer(t, ServerBehavior{Mode: ServerProbe, RespSize: defaultProbeBody})
+	srv := StartWorkloadServer(t, ServerBehavior{Mode: ServerProbe, RespSize: defaultProbeBody})
 	tun := b.Setup(t, SetupOptions{
 		NumListeners:   m,
 		NumSenders:     n,
 		SenderMode:     ModePortForward,
-		Target:         echo.Addr(),
-		AllowedTargets: []string{echo.Addr()},
+		Target:         srv.Addr(),
+		AllowedTargets: []string{srv.Addr()},
 	})
 
 	const (
@@ -371,7 +373,7 @@ func scenarioHotDropListener(t *testing.T, b Backend, n, m int) {
 			base := f.acked()
 			if !waitProgress(f, base, 5*time.Second) {
 				t.Errorf("survivor flow %d made no progress after drop (acked stuck at %d)", i, base)
-				f.Dump(t, echo, fmt.Sprintf("hotdrop-flow-%d", i))
+				f.Dump(t, srv, fmt.Sprintf("hotdrop-flow-%d", i))
 				continue
 			}
 			survivors++
@@ -383,21 +385,21 @@ func scenarioHotDropListener(t *testing.T, b Backend, n, m int) {
 	}
 
 	// A fresh dial after drop must succeed via the surviving listener.
-	if err := probeOnce(echo, tun.SenderAddr, defaultProbeBody, defaultProbeBody, 15*time.Second); err != nil {
+	if err := probeOnce(srv, tun.SenderAddr, defaultProbeBody, defaultProbeBody, 15*time.Second); err != nil {
 		t.Errorf("post-drop fresh dial: %v", err)
 	}
 }
 
 // scenarioHotAddListener verifies that adding a listener mid-flight
-// converges: existing flows keep echoing, and new flows reach the new
-// listener within a bounded window. Because Azure Relay's listener
-// selection is non-uniform at small sample sizes (e2e/multi_test.go
-// documents observed ratios up to 1:7 at K=8), a fixed-K probe count
-// would have a non-trivial spurious-failure rate when no flow lands
-// on the freshly-added listener. Instead we drive short echoes in
-// batches until newListener.Completed() > 0, capped at a hard probe
-// budget — that bounds the test runtime while making a true
-// "no traffic ever reaches the new listener" regression observable.
+// converges: existing flows keep making forward progress, and new flows
+// reach the new listener within a bounded window. Because Azure Relay's
+// listener selection is non-uniform at small sample sizes
+// (e2e/multi_test.go documents observed ratios up to 1:7 at K=8), a
+// fixed-K probe count would have a non-trivial spurious-failure rate
+// when no flow lands on the freshly-added listener. Instead we drive
+// short probes in batches until newListener.Completed() > 0, capped at
+// a hard probe budget — that bounds the test runtime while making a
+// true "no traffic ever reaches the new listener" regression observable.
 func scenarioHotAddListener(t *testing.T, b Backend, n, m int) {
 	t.Helper()
 	AssertNoLeaks(t)
@@ -487,8 +489,8 @@ func scenarioHotAddListener(t *testing.T, b Backend, n, m int) {
 // retry. This scenario asserts both invariants.
 //
 // Each successful client holds its bridge open for holdDur after the
-// initial echo so the metric sampler (20 ms ticker) reliably catches
-// the steady-state concurrent count. Without the hold, short echoes
+// initial probe so the metric sampler (20 ms ticker) reliably catches
+// the steady-state concurrent count. Without the hold, short probes
 // complete in single-digit milliseconds and the sampler races them.
 func scenarioMaxConnBackPressure(t *testing.T, b Backend, n, m int) {
 	t.Helper()
@@ -626,7 +628,7 @@ func drainErrors(errs <-chan error) error {
 }
 
 // waitForListenerSum polls Tunnel.Listeners for sum-of-Completed to
-// reach want. Used after a burst of short echoes where the last few
+// reach want. Used after a burst of short probes where the last few
 // Done() callbacks may still be in flight when the sender goroutine
 // returns. Fails the test on deadline.
 func waitForListenerSum(t *testing.T, tun *Tunnel, want int64, timeout time.Duration) {

--- a/e2e/scenarios/workloadserver.go
+++ b/e2e/scenarios/workloadserver.go
@@ -50,6 +50,13 @@ type WorkloadServer struct {
 	serveDone chan struct{}
 	connWg    sync.WaitGroup
 	done      atomic.Bool
+
+	// probeMu guards probeStats (ServerProbe mode only). Each probe
+	// connection is keyed by its stream nonce so a test holding a
+	// probeFlow can read the server's last-seen sequence and terminating
+	// error to localize a break the client only sees as silence.
+	probeMu    sync.Mutex
+	probeStats map[uint64]*probeConnStat
 }
 
 // ServerMode selects a WorkloadServer's per-connection behavior. The zero
@@ -61,6 +68,15 @@ const (
 	ServerEcho ServerMode = iota
 	ServerRespond
 	ServerStream
+	// ServerProbe is a continuous full-duplex request/response loop used
+	// by the held-flow topology scenarios and (later) a bidirectional
+	// perf shape. Each request frame carries a sequence number and the
+	// client's monotonic send timestamp; the server echoes both back
+	// alongside its own receive and send timestamps, so the client can
+	// split the round-trip into request leg, server think, and response
+	// leg. Unlike ServerEcho it is framed, so it is never the byte-
+	// transparency oracle.
+	ServerProbe
 )
 
 // ServerBehavior is the construction-time configuration of a
@@ -103,7 +119,7 @@ type ServerBehavior struct {
 func StartWorkloadServer(t testing.TB, behavior ServerBehavior) *WorkloadServer {
 	t.Helper()
 	switch behavior.Mode {
-	case ServerEcho, ServerRespond, ServerStream:
+	case ServerEcho, ServerRespond, ServerStream, ServerProbe:
 	default:
 		t.Fatalf("workload server: unknown ServerBehavior.Mode %d", behavior.Mode)
 	}
@@ -111,7 +127,12 @@ func StartWorkloadServer(t testing.TB, behavior ServerBehavior) *WorkloadServer 
 	if err != nil {
 		t.Fatalf("workload server listen: %v", err)
 	}
-	s := &WorkloadServer{behavior: behavior, ln: ln, serveDone: make(chan struct{})}
+	s := &WorkloadServer{
+		behavior:   behavior,
+		ln:         ln,
+		serveDone:  make(chan struct{}),
+		probeStats: make(map[uint64]*probeConnStat),
+	}
 	go s.serve()
 	t.Cleanup(s.Stop)
 	return s
@@ -157,6 +178,8 @@ func (s *WorkloadServer) handle(c net.Conn) {
 		_ = serveRespond(c, s.behavior)
 	case ServerStream:
 		_ = serveStream(c, s.behavior)
+	case ServerProbe:
+		_ = s.serveProbe(c)
 	default:
 		// Modes are validated at construction (StartWorkloadServer); a
 		// value reaching here means the server was built another way with
@@ -190,6 +213,8 @@ const (
 	frameStreamChunk byte = 4 // server -> client (ServerStream)
 	frameStreamEnd   byte = 5 // server -> client (ServerStream): clean completion
 	frameError       byte = 6 // either direction: integrity failure detected
+	frameProbeReq    byte = 7 // client -> server (ServerProbe)
+	frameProbeResp   byte = 8 // server -> client (ServerProbe)
 )
 
 var errBadMagic = errors.New("workload frame: bad magic")
@@ -382,4 +407,129 @@ func doRespondRequest(conn net.Conn, nonce uint64, reqSize, wantRespSize int) er
 		return fmt.Errorf("response pattern mismatch at offset %d", off)
 	}
 	return nil
+}
+
+// probeConnStat is the server's per-connection record for one ServerProbe
+// flow, keyed by the flow's nonce. It exists so that when a flow breaks
+// and the client only observes silence, the test can ask the server what
+// it last saw and localize the break: no record at all means the request
+// never reached the server; lastSeqSeen set with no matching write means
+// the server stalled before replying; lastWriteStart set without
+// lastWriteDone means the server->tunnel write itself blocked.
+//
+// All fields and the terminal flag are written under WorkloadServer.probeMu.
+// Timestamps are probeNanos() values (one shared monotonic epoch across the
+// whole test process), directly comparable with the client's stamps.
+type probeConnStat struct {
+	lastSeqSeen    int64 // highest request seq read (-1 before the first request)
+	lastRecvNano   int64 // probeNanos at the read of lastSeqSeen's request
+	lastWriteStart int64 // probeNanos just before writing lastSeqSeen's response
+	lastWriteDone  int64 // probeNanos just after that write returned
+	termErr        error // serveProbe's terminating error (nil on clean EOF)
+	terminal       bool  // true once serveProbe has returned for this conn
+}
+
+// ProbeRecord returns a snapshot copy of the server's record for the
+// probe flow identified by nonce, and whether such a record exists. The
+// terminal field reports whether the server has finished with the
+// connection; a non-terminal record is a live snapshot and its
+// lastSeqSeen may still advance.
+func (s *WorkloadServer) ProbeRecord(nonce uint64) (probeConnStat, bool) {
+	s.probeMu.Lock()
+	defer s.probeMu.Unlock()
+	st, ok := s.probeStats[nonce]
+	if !ok {
+		return probeConnStat{}, false
+	}
+	return *st, true
+}
+
+// serveProbe runs the ServerProbe per-connection loop: read a request
+// frame, stamp the receive time, verify its pattern, optionally think,
+// then reply with a frame echoing the request's seq and client-send
+// timestamp plus the server's receive and send timestamps and RespSize
+// bytes of the nonce's pattern. The per-connection record is published
+// under probeMu so a test can localize a break by nonce.
+func (s *WorkloadServer) serveProbe(c net.Conn) error {
+	b := s.behavior
+	var (
+		nonce    uint64
+		stat     *probeConnStat
+		haveStat bool
+		retErr   error
+	)
+	defer func() {
+		if haveStat {
+			s.probeMu.Lock()
+			stat.termErr = retErr
+			stat.terminal = true
+			s.probeMu.Unlock()
+		}
+	}()
+
+	for {
+		typ, n, payload, err := readFrame(c)
+		recv := probeNanos()
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				return nil
+			}
+			retErr = err
+			return err
+		}
+		if typ != frameProbeReq {
+			retErr = fmt.Errorf("serveProbe: unexpected frame type %d", typ)
+			return retErr
+		}
+		if len(payload) < probeHdrLen {
+			retErr = fmt.Errorf("serveProbe: short probe header: %d < %d", len(payload), probeHdrLen)
+			return retErr
+		}
+		if !haveStat {
+			nonce = n
+			stat = &probeConnStat{lastSeqSeen: -1}
+			s.probeMu.Lock()
+			s.probeStats[nonce] = stat
+			s.probeMu.Unlock()
+			haveStat = true
+		}
+		seq := binary.BigEndian.Uint32(payload[0:4])
+		reqBody := payload[probeHdrLen:]
+		if off, ok := verifyPattern(reqBody, nonce, int(seq)*len(reqBody)); !ok {
+			_ = writeFrame(c, frameError, nonce, nil)
+			retErr = fmt.Errorf("serveProbe: request pattern mismatch at offset %d (seq %d)", off, seq)
+			return retErr
+		}
+
+		s.probeMu.Lock()
+		stat.lastSeqSeen = int64(seq)
+		stat.lastRecvNano = recv
+		s.probeMu.Unlock()
+
+		if b.ProcessingDelay > 0 {
+			time.Sleep(b.ProcessingDelay)
+		}
+
+		// Response payload: [seq | clientSend | serverRecv | serverSend | pattern].
+		resp := make([]byte, probeHdrLen+b.RespSize)
+		copy(resp[0:4], payload[0:4])   // echo seq
+		copy(resp[4:12], payload[4:12]) // echo client-send timestamp
+		binary.BigEndian.PutUint64(resp[12:20], uint64(recv))
+		fillPattern(resp[probeHdrLen:], nonce, int(seq)*b.RespSize)
+
+		writeStart := probeNanos()
+		binary.BigEndian.PutUint64(resp[20:28], uint64(writeStart))
+		s.probeMu.Lock()
+		stat.lastWriteStart = writeStart
+		s.probeMu.Unlock()
+
+		if err := writeFrame(c, frameProbeResp, nonce, resp); err != nil {
+			retErr = err
+			return err
+		}
+		writeDone := probeNanos()
+		s.probeMu.Lock()
+		stat.lastWriteDone = writeDone
+		s.probeMu.Unlock()
+	}
 }

--- a/e2e/scenarios/workloadserver.go
+++ b/e2e/scenarios/workloadserver.go
@@ -434,6 +434,12 @@ type probeConnStat struct {
 // terminal field reports whether the server has finished with the
 // connection; a non-terminal record is a live snapshot and its
 // lastSeqSeen may still advance.
+//
+// ProbeRecord is non-destructive: the entry stays in probeStats until
+// the WorkloadServer is stopped. Diagnostic consumers that only need
+// the record once should prefer ConsumeProbeRecord so the entry does
+// not linger for the rest of the server's lifetime — important when
+// many short-lived probes (e.g., probeOnce dials) share one server.
 func (s *WorkloadServer) ProbeRecord(nonce uint64) (probeConnStat, bool) {
 	s.probeMu.Lock()
 	defer s.probeMu.Unlock()
@@ -441,6 +447,27 @@ func (s *WorkloadServer) ProbeRecord(nonce uint64) (probeConnStat, bool) {
 	if !ok {
 		return probeConnStat{}, false
 	}
+	return *st, true
+}
+
+// ConsumeProbeRecord is like ProbeRecord but removes the entry from
+// probeStats after returning the snapshot. It is the right call from a
+// diagnostic path that reports a record exactly once (probeFlow.Dump /
+// localize) so the record does not linger for the rest of the server's
+// lifetime.
+//
+// Note: probeOnce dials do not consume their record. In test-only
+// servers with single-test lifetimes the resulting accumulation is
+// bounded by the test duration; long-running scenarios that hammer
+// probeOnce should consider a periodic eviction strategy.
+func (s *WorkloadServer) ConsumeProbeRecord(nonce uint64) (probeConnStat, bool) {
+	s.probeMu.Lock()
+	defer s.probeMu.Unlock()
+	st, ok := s.probeStats[nonce]
+	if !ok {
+		return probeConnStat{}, false
+	}
+	delete(s.probeStats, nonce)
 	return *st, true
 }
 

--- a/e2e/scenarios/workloadserver.go
+++ b/e2e/scenarios/workloadserver.go
@@ -492,6 +492,14 @@ func (s *WorkloadServer) serveProbe(c net.Conn) error {
 			s.probeStats[nonce] = stat
 			s.probeMu.Unlock()
 			haveStat = true
+		} else if n != nonce {
+			// A probe connection is keyed by the first frame's nonce; a
+			// later frame with a different nonce would otherwise be
+			// verified and stat-recorded against the original nonce,
+			// silently producing confusing integrity failures and
+			// misleading localization data. Reject the connection.
+			retErr = fmt.Errorf("serveProbe: nonce changed mid-connection: got %d want %d", n, nonce)
+			return retErr
 		}
 		seq := binary.BigEndian.Uint32(payload[0:4])
 		reqBody := payload[probeHdrLen:]

--- a/e2e/scenarios/workloadserver.go
+++ b/e2e/scenarios/workloadserver.go
@@ -506,10 +506,15 @@ func (s *WorkloadServer) serveProbe(c net.Conn) error {
 		// at -1, so the first request (seq=0) passes; thereafter only
 		// strictly greater seqs are accepted. Without this, a buggy
 		// client repeating or decreasing seq would regress the stat
-		// record and produce misleading localize() output.
-		if int64(seq) <= stat.lastSeqSeen {
+		// record and produce misleading localize() output. Read
+		// lastSeqSeen under probeMu since ProbeRecord() may snapshot
+		// the struct concurrently from the test goroutine.
+		s.probeMu.Lock()
+		prevSeen := stat.lastSeqSeen
+		s.probeMu.Unlock()
+		if int64(seq) <= prevSeen {
 			_ = writeFrame(c, frameError, nonce, nil)
-			retErr = fmt.Errorf("serveProbe: non-monotonic seq %d (last seen %d)", seq, stat.lastSeqSeen)
+			retErr = fmt.Errorf("serveProbe: non-monotonic seq %d (last seen %d)", seq, prevSeen)
 			return retErr
 		}
 		reqBody := payload[probeHdrLen:]

--- a/e2e/scenarios/workloadserver.go
+++ b/e2e/scenarios/workloadserver.go
@@ -502,6 +502,16 @@ func (s *WorkloadServer) serveProbe(c net.Conn) error {
 			return retErr
 		}
 		seq := binary.BigEndian.Uint32(payload[0:4])
+		// Enforce strict per-connection monotonic seq. lastSeqSeen starts
+		// at -1, so the first request (seq=0) passes; thereafter only
+		// strictly greater seqs are accepted. Without this, a buggy
+		// client repeating or decreasing seq would regress the stat
+		// record and produce misleading localize() output.
+		if int64(seq) <= stat.lastSeqSeen {
+			_ = writeFrame(c, frameError, nonce, nil)
+			retErr = fmt.Errorf("serveProbe: non-monotonic seq %d (last seen %d)", seq, stat.lastSeqSeen)
+			return retErr
+		}
 		reqBody := payload[probeHdrLen:]
 		if off, ok := verifyPattern(reqBody, nonce, int(seq)*len(reqBody)); !ok {
 			_ = writeFrame(c, frameError, nonce, nil)

--- a/e2e/scenarios/workloadserver.go
+++ b/e2e/scenarios/workloadserver.go
@@ -456,10 +456,12 @@ func (s *WorkloadServer) ProbeRecord(nonce uint64) (probeConnStat, bool) {
 // localize) so the record does not linger for the rest of the server's
 // lifetime.
 //
-// Note: probeOnce dials do not consume their record. In test-only
-// servers with single-test lifetimes the resulting accumulation is
-// bounded by the test duration; long-running scenarios that hammer
-// probeOnce should consider a periodic eviction strategy.
+// probeOnce and probeWithHold both call this on every exit path
+// (success and failure), so a long-running scenario that hammers
+// probeOnce against one server does NOT accumulate per-nonce records
+// — every record is consumed within microseconds of the exchange's
+// completion or error. A probeFlow's record is consumed by Dump /
+// localize, or stays live until the test holding the flow ends.
 func (s *WorkloadServer) ConsumeProbeRecord(nonce uint64) (probeConnStat, bool) {
 	s.probeMu.Lock()
 	defer s.probeMu.Unlock()


### PR DESCRIPTION
## Why

Three related test-harness gaps the previous functional/perf scenarios surfaced:

1. **Held-flow stalls were RCA-blind.** `HotDropListener` and `HotAddListener` used a single blind ping-pong to prove a held flow was still alive after a topology change. When that ping timed out in CI we could only say "something stalled at T+5s" — we could not tell which leg of the bridge held the message. Repeated investigations bottomed out in "we have no evidence."

2. **One-shot echo scenarios were RCA-blind too.** Every scenario that used `runEchoOnce` against a `StartPlainEcho` target — Distribution_PerListener, NMEcho, MaxConn_BackPressure, ListenerRestart_Recovers, ControlSessionID, Metrics_*, ListenerID_* — surfaced the same "i/o timeout" with no per-leg attribution. The Azure entra `Distribution_PerListener/N1M2` failure that motivated finishing this work was a perfect example.

3. **No bidirectional perf shape, no usable cross-run comparison.** The harness had `WorkloadShape` (short-conn rtt) and `StreamShape` (server-paced trickle) but nothing measuring sustained bidirectional load. And the `perf-compare` tool only paired rows within a single run, so the natural workflow of two ad-hoc runs with different pinned config could not be diffed.

## What

A universal probe-based observability mechanism, plus the duplex perf shape that consumes it and a comparison/gating story that actually works.

**Diagnostic probe core:**

- New `ServerProbe` mode on `WorkloadServer`. Every request carries a seq + monotonic client-send timestamp; the server stamps recv/send under a per-nonce `probeConnStat` and the client correlates them into request leg / server think / response leg.
- `probeFlow` (sender + reader goroutines, bounded MaxOutstanding window, rolling aggregates, optional sample ring buffer for percentile aggregation). `Dump` logs the worst-by-RTT exchange and `localize` attributes a break to the outbound or return path. `broken()` is read-side only so survivor `Stop()` doesn't falsely flip it. Read-side breaks signal `stopCh` + close the conn so waiters and the peer-side server unblock promptly.
- `probeOnce(srv, addr, …)` is the one-shot equivalent; on failure it consumes the server's per-nonce record and enriches the returned error with the same per-leg attribution (request never reached server vs. server stalled vs. return-leg break). Always cleans up the record on every path.

**Migrated scenarios** (everything that drove an echo for its own sake — i.e., the trigger, not the byte content, was the assertion):

- `topology.go`: HotDropListener, HotAddListener, NMEcho, Distribution_PerListener, Distribution_PerSender, MaxConn_BackPressure (via new `probeWithHold`), ListenerRestart_Recovers.
- `observability.go`: ControlSessionID_OnConnectedLine, Metrics_BothSidesConverge, Metrics_DialDuration, ListenerID_PropagatesAndChangesOnRestart.

Legacy helpers deleted (`runEchoOnce`, `runEchoOnceBest`, `echoWithHold`). `StartPlainEcho` retained only where it's the byte-transparency oracle (BulkTransfer's SHA-256 fidelity assertion) or a no-echo TCP-target stand-in.

**Duplex perf shape:**

- `DuplexShape` + `runDuplexWorkload` (barrier-released, modeled on `runStreamRound`) drive concurrent probe flows against `ServerProbe` targets and aggregate per-leg p50/p95 + acks/sec + bytes/sec per direction + per-flow ack-spread fairness.
- Two scenarios: `Duplex_Probe_SOCKS5_FanOut` (4 flows × 4 targets) and `Duplex_Probe_PortForward` (4 flows × 1 target).
- Flow "success" enforces a minimum absolute ack count so a stalled-after-one-ack flow doesn't masquerade as healthy.

**Perf matrix integration:**

- New `duplex` metric family in `perfMatrixRow`/`perfMatrixRecord` (no schema bump — optional fields, same precedent as the stream addition).
- `renderDuplexTable` + `renderDuplexReportTable` (in `cmd/perfreport`) + `renderDuplexCompare` + `duplexGateVerdict` so `make perf-table` / `perf-compare` / `perf-gate` all handle duplex alongside rtt and stream.
- `errNoRTTRows` / `errNoStreamRows` / `errNoDuplexRows`: each family's "nothing to compare yet" is skippable, no family blocks another.

**Cross-run comparison fallback:**

- `perf-compare`/`perf-gate` for every family now auto-fall-back to cross-run pairing when within-run produces zero matches, with a `note: pairing rows across runs` line. So two separate single-value runs (the natural "compare delay=zero vs delay=default" workflow) work without needing both values in one run.
- `putNewestByCell` ensures deterministic newest-wins on multi-run artifacts (run ids are UTC-timestamp-prefixed; lex-ascending matches chronological).
- The `run` column is hidden when cross-run pairing is active, since each side of the comparison comes from a different run id.

**Matrix labeling fixes — every row carries its full identity:**

- Backend label auto-derived from `Backend.Name()` (registered on the sink in `RunAllScenarios`); `PERF_MATRIX_BACKEND` env var stays as an override. Every e2e target produces correctly-labeled history without ceremony.
- New `Backend.Pins() map[string]string` reports the dimensions a backend has baked in (auth/delay for mock, auth for azure). `matrixIdentity` merges pins into the row's `axes` map. A row from `E2E_DELAY=zero` now carries `axes={"auth":"sas","delay":"zero"}` even though no delay-axis sub-layer existed in the test path. Cross-run comparison along a pinned dimension just works.

## Scope of changes

- `e2e/scenarios/` — `ServerProbe`, `probeFlow`, `probeOnce`/`probeWithHold`, duplex shape, all migrated scenarios, matrix family + pin-merge, sink cleanup on RunAllScenarios end.
- `e2e/cmd/perfreport/` — duplex family render + compare + gate, cross-run pairing fallback + newest-wins, render-column hiding in cross-run mode.
- `e2e/backends/{mock,azure}/` — new `Pins()` method on each backend.
- `e2e/scenarios/backend.go` — `Pins()` added to the `Backend` interface.
- **No shipped aztunnel code (`internal/**`) is touched.** The byte-transparency `ServerEcho` mode (literal `io.Copy`) is unchanged and remains the binary-fidelity oracle.

## Out of scope (intentional, documented in commits)

- `WorkloadShape`-driven perf scenarios still use `StartPlainEcho` via the perf framework's own `requestFn`. Migrating those is a perf-framework refactor for a follow-up.
- `BulkTransfer` uses `StartPlainEcho` because SHA-256 fidelity over arbitrary random bytes is the whole point.

## Tests

Unit tests at every layer (28 new tests across `probe_test.go`, `duplexworkload_test.go`, `matrix_run_test.go`, `cmd/perfreport/main_test.go`):

- Probe protocol: round-trip integrity, pattern-mismatch frame-error, nonce-change rejected, non-monotonic seq rejected, `ConsumeProbeRecord` semantics, ring-buffer chronological order, non-positive config clamps, reader-closes-conn-on-break, `waitFirstAck` fast-fails on write error, `Samples()` ring behaviour.
- Probe flow: continuous progress + worst-by-rtt invariant, broken on peer close, `Stop()` doesn't break a survivor, `localize` outbound-break.
- Duplex shape: validation, aggregate per-leg percentiles + throughput + ack spread, all-failed-zero-safe, `minProgressFloor`, record→matrix row round-trip, render-by-family.
- Matrix: backend label env-precedence and sink-fallback, pin merge into axes map, axis values override pins.
- Compare/gate: duplex cross-run delta math, no-duplex-rows-skippable, duplex gate threshold + floor, paired-but-uncomparable, cross-run fallback success + newest-wins + hidden run column, true-no-overlap error.

End-to-end:

- Mock e2e (`TestE2E_Mock`) on the full scenario set: HotDrop, HotAdd, Distribution_*, NMEcho, MaxConn_BackPressure, ListenerRestart, ControlSessionID, Metrics_*, ListenerID_*, both Duplex_Probe scenarios all pass on both `sas` and `entra` cells under `-race`.
- Cross-run `perf-compare DIM=delay` verified locally: two separate `E2E_DELAY=zero` / `=default` runs pair via fallback, all three families (rtt, stream, duplex) render with deltas.
- Every CI check run locally (each module's `golangci-lint v2.12`, `go test -race ./...` on root + mockrelay + e2e, `gofmt -d`, `prettier --check .`).