### PR TITLE
test(e2e): include process logs on Azure readiness timeout

### DIFF
--- a/e2e/backends/azure/helpers_test.go
+++ b/e2e/backends/azure/helpers_test.go
@@ -21,6 +21,7 @@ import (
 	"sync"
 	"testing"
 	"time"
+	"unicode/utf8"
 
 	"github.com/philsphicas/aztunnel/e2e/azrelay"
 )
@@ -388,6 +389,12 @@ type logBuffer struct {
 	waiters []logWaiter
 }
 
+const (
+	waitForLogTailBytes = 64 * 1024
+	waitForLogTailLines = 200
+	logTailTruncated    = "...[truncated]...\n"
+)
+
 type logWaiter struct {
 	substr string
 	ch     chan string
@@ -431,6 +438,49 @@ func (lb *logBuffer) String() string {
 	lb.mu.Lock()
 	defer lb.mu.Unlock()
 	return strings.Join(lb.lines, "\n")
+}
+
+// tailSnapshot returns a bounded suffix of the captured output, including an
+// incomplete final line. It prefers whole lines when trimming by bytes and
+// always starts at a UTF-8 boundary when one oversized line must be sliced.
+func (lb *logBuffer) tailSnapshot(maxBytes, maxLines int) string {
+	if maxBytes <= 0 || maxLines <= 0 {
+		return ""
+	}
+
+	lb.mu.Lock()
+	defer lb.mu.Unlock()
+
+	recordCount := len(lb.lines)
+	if lb.partial != "" {
+		recordCount++
+	}
+	start := max(recordCount-maxLines, 0)
+	records := make([]string, 0, recordCount-start)
+	for i := start; i < len(lb.lines); i++ {
+		records = append(records, lb.lines[i])
+	}
+	if lb.partial != "" {
+		records = append(records, lb.partial)
+	}
+
+	snapshot := strings.Join(records, "\n")
+	if len(snapshot) <= maxBytes {
+		return snapshot
+	}
+	if maxBytes <= len(logTailTruncated) {
+		return logTailTruncated[:maxBytes]
+	}
+
+	suffixBytes := maxBytes - len(logTailTruncated)
+	cut := len(snapshot) - suffixBytes
+	for cut < len(snapshot) && !utf8.RuneStart(snapshot[cut]) {
+		cut++
+	}
+	if newline := strings.IndexByte(snapshot[cut:], '\n'); newline >= 0 {
+		cut += newline + 1
+	}
+	return logTailTruncated + snapshot[cut:]
 }
 
 // waitFor blocks until a log line containing substr appears, or times out.
@@ -583,9 +633,54 @@ func waitForLog(t testing.TB, proc *aztunnelProcess, substr string, timeout time
 	t.Helper()
 	line, ok := proc.logs.waitFor(substr, timeout)
 	if !ok {
-		t.Fatalf("timed out waiting for log: %q\n--- process logs ---\n%s", substr, proc.logs.String())
+		t.Fatalf("timed out waiting for log: %q\n--- process log tail ---\n%s",
+			substr, proc.logs.tailSnapshot(waitForLogTailBytes, waitForLogTailLines))
 	}
 	return line
+}
+
+func TestLogBufferTailSnapshotIncludesPartialLine(t *testing.T) {
+	var logs logBuffer
+	if _, err := logs.Write([]byte("complete\npartial")); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	if got, want := logs.tailSnapshot(1024, 10), "complete\npartial"; got != want {
+		t.Fatalf("tailSnapshot() = %q, want %q", got, want)
+	}
+}
+
+func TestLogBufferTailSnapshotBoundsLines(t *testing.T) {
+	var logs logBuffer
+	if _, err := logs.Write([]byte("oldest\nolder\nnewest\npartial")); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	if got, want := logs.tailSnapshot(1024, 2), "newest\npartial"; got != want {
+		t.Fatalf("tailSnapshot() = %q, want %q", got, want)
+	}
+}
+
+func TestLogBufferTailSnapshotBoundsBytesAndPreservesUTF8(t *testing.T) {
+	var logs logBuffer
+	if _, err := logs.Write([]byte(strings.Repeat("x", 64) + "\n最新の診断")); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	const maxBytes = 40
+	got := logs.tailSnapshot(maxBytes, 2)
+	if len(got) > maxBytes {
+		t.Fatalf("tailSnapshot() length = %d, want <= %d", len(got), maxBytes)
+	}
+	if !utf8.ValidString(got) {
+		t.Fatalf("tailSnapshot() returned invalid UTF-8: %q", got)
+	}
+	if !strings.HasPrefix(got, logTailTruncated) {
+		t.Fatalf("tailSnapshot() = %q, want truncation marker", got)
+	}
+	if !strings.HasSuffix(got, "最新の診断") {
+		t.Fatalf("tailSnapshot() = %q, want newest partial line", got)
+	}
 }
 
 // addrRe extracts addr=host:port from log lines.

--- a/e2e/backends/azure/helpers_test.go
+++ b/e2e/backends/azure/helpers_test.go
@@ -441,46 +441,100 @@ func (lb *logBuffer) String() string {
 }
 
 // tailSnapshot returns a bounded suffix of the captured output, including an
-// incomplete final line. It prefers whole lines when trimming by bytes and
-// always starts at a UTF-8 boundary when one oversized line must be sliced.
+// incomplete final line. It selects only bounded string slices while holding
+// the lock, then copies at most maxBytes after unlocking.
 func (lb *logBuffer) tailSnapshot(maxBytes, maxLines int) string {
 	if maxBytes <= 0 || maxLines <= 0 {
 		return ""
 	}
 
 	lb.mu.Lock()
-	defer lb.mu.Unlock()
-
 	recordCount := len(lb.lines)
 	if lb.partial != "" {
 		recordCount++
 	}
+	if recordCount == 0 {
+		lb.mu.Unlock()
+		return ""
+	}
 	start := max(recordCount-maxLines, 0)
-	records := make([]string, 0, recordCount-start)
-	for i := start; i < len(lb.lines); i++ {
-		records = append(records, lb.lines[i])
-	}
-	if lb.partial != "" {
-		records = append(records, lb.partial)
-	}
-
-	snapshot := strings.Join(records, "\n")
-	if len(snapshot) <= maxBytes {
-		return snapshot
-	}
-	if maxBytes <= len(logTailTruncated) {
-		return logTailTruncated[:maxBytes]
+	recordAt := func(i int) string {
+		if i < len(lb.lines) {
+			return lb.lines[i]
+		}
+		return lb.partial
 	}
 
-	suffixBytes := maxBytes - len(logTailTruncated)
-	cut := len(snapshot) - suffixBytes
-	for cut < len(snapshot) && !utf8.RuneStart(snapshot[cut]) {
-		cut++
+	truncated := start > 0
+	windowBytes := 0
+	for i := start; i < recordCount; i++ {
+		if i > start {
+			windowBytes++
+		}
+		recordLen := len(recordAt(i))
+		if windowBytes > maxBytes || recordLen > maxBytes-windowBytes {
+			truncated = true
+			break
+		}
+		windowBytes += recordLen
 	}
-	if newline := strings.IndexByte(snapshot[cut:], '\n'); newline >= 0 {
-		cut += newline + 1
+
+	marker := ""
+	contentBudget := maxBytes
+	if truncated {
+		if maxBytes <= len(logTailTruncated) {
+			lb.mu.Unlock()
+			return logTailTruncated[:maxBytes]
+		}
+		marker = logTailTruncated
+		contentBudget -= len(marker)
 	}
-	return logTailTruncated + snapshot[cut:]
+
+	// Retain references to at most maxLines bounded suffixes. The underlying
+	// strings are immutable, so they remain safe to copy after releasing mu.
+	reversed := make([]string, 0, min(recordCount-start, maxLines))
+	contentBytes := 0
+	for i := recordCount - 1; i >= start; i-- {
+		separatorBytes := 0
+		if len(reversed) > 0 {
+			separatorBytes = 1
+		}
+		if contentBytes+separatorBytes >= contentBudget {
+			break
+		}
+
+		record := recordAt(i)
+		sliced := false
+		available := contentBudget - contentBytes - separatorBytes
+		if len(record) > available {
+			cut := len(record) - available
+			for cut < len(record) && !utf8.RuneStart(record[cut]) {
+				cut++
+			}
+			record = record[cut:]
+			sliced = true
+		}
+		if sliced && record == "" {
+			break
+		}
+		reversed = append(reversed, record)
+		contentBytes += separatorBytes + len(record)
+		if sliced {
+			break
+		}
+	}
+	lb.mu.Unlock()
+
+	var snapshot strings.Builder
+	snapshot.Grow(len(marker) + contentBytes)
+	snapshot.WriteString(marker)
+	for i := len(reversed) - 1; i >= 0; i-- {
+		if i < len(reversed)-1 {
+			snapshot.WriteByte('\n')
+		}
+		snapshot.WriteString(reversed[i])
+	}
+	return snapshot.String()
 }
 
 // waitFor blocks until a log line containing substr appears, or times out.
@@ -680,6 +734,18 @@ func TestLogBufferTailSnapshotBoundsBytesAndPreservesUTF8(t *testing.T) {
 	}
 	if !strings.HasSuffix(got, "最新の診断") {
 		t.Fatalf("tailSnapshot() = %q, want newest partial line", got)
+	}
+}
+
+func TestLogBufferTailSnapshotBoundsOversizedPartial(t *testing.T) {
+	const maxBytes = 128
+	partial := strings.Repeat("x", 2*1024*1024) + "latest-diagnostic"
+	logs := logBuffer{partial: partial}
+
+	got := logs.tailSnapshot(maxBytes, 10)
+	want := logTailTruncated + partial[len(partial)-(maxBytes-len(logTailTruncated)):]
+	if got != want {
+		t.Fatalf("tailSnapshot() length = %d, want exact bounded suffix of length %d", len(got), len(want))
 	}
 }
 

--- a/e2e/backends/azure/helpers_test.go
+++ b/e2e/backends/azure/helpers_test.go
@@ -583,7 +583,7 @@ func waitForLog(t testing.TB, proc *aztunnelProcess, substr string, timeout time
 	t.Helper()
 	line, ok := proc.logs.waitFor(substr, timeout)
 	if !ok {
-		t.Fatalf("timed out waiting for log: %q", substr)
+		t.Fatalf("timed out waiting for log: %q\n--- process logs ---\n%s", substr, proc.logs.String())
 	}
 	return line
 }


### PR DESCRIPTION
## Summary

When an Azure E2E subprocess fails to emit a readiness log such as `control_started`, include a bounded tail of that subprocess's captured output in the test failure. The final implementation also caps the diagnostic snapshot by both bytes and lines, preserves an incomplete final line and UTF-8 boundaries, marks truncated output explicitly, and avoids copying an unbounded log buffer while holding the mutex.

## Why

Before this change, readiness failures reported only:

```text
timed out waiting for log: "control_started"
```

The listener or sender stderr that could distinguish a crash, authentication error, WebSocket failure, or Relay-side stall was discarded. The bounded tail makes that evidence available without allowing a large subprocess log to produce an unbounded failure message or allocation.

## Final behavior

- `waitForLog` appends a subprocess log tail on timeout.
- The tail is limited to 64 KiB and 200 records.
- An incomplete final line is retained.
- UTF-8 is preserved when an oversized record must be sliced.
- `...[truncated]...` is prepended whenever byte or line limits omit older output.
- Snapshot construction copies only the bounded suffix after releasing the log mutex.

## Validation performed before merge

- `go test -c -tags=e2e ./e2e/backends/azure`
- `go test ./internal/relay ./internal/sender ./internal/listener`
- `go test ./e2e/azrelay`

## Post-merge correction

The PR's E2E jobs were skipped with `skip-e2e`, so the tagged helper tests were compiled but not executed. A stale assertion from the second commit expected line-truncated output without the truncation marker, while the final commit intentionally adds that marker. This was discovered when a later full Azure run completed every scenario but failed the helper assertion. A focused follow-up corrects that expectation.

This description was updated after merge because the original text described only the first commit and did not reflect the final three-commit diff or its validation gap.