### PR TITLE
chore: remove Go Report Card badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # aztunnel
 
 [![CI](https://github.com/philsphicas/aztunnel/actions/workflows/ci.yml/badge.svg)](https://github.com/philsphicas/aztunnel/actions/workflows/ci.yml)
-[![Go Report Card](https://goreportcard.com/badge/github.com/philsphicas/aztunnel)](https://goreportcard.com/report/github.com/philsphicas/aztunnel)
 [![Go Reference](https://pkg.go.dev/badge/github.com/philsphicas/aztunnel.svg)](https://pkg.go.dev/github.com/philsphicas/aztunnel)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 


### PR DESCRIPTION
## Summary
- remove the Go Report Card badge and link from the README

## Testing
- Not run (documentation-only change)