### PR TITLE
Fix Windows compatibility across the test suite

### DIFF
--- a/e2e/backends/azure/helpers_test.go
+++ b/e2e/backends/azure/helpers_test.go
@@ -42,7 +42,7 @@ func repoRoot() (string, error) {
 	for {
 		modPath := filepath.Join(dir, "go.mod")
 		if data, err := os.ReadFile(modPath); err == nil {
-			if bytes.Contains(data, []byte("module github.com/philsphicas/aztunnel\n")) {
+			if isAztunnelModule(data) {
 				return dir, nil
 			}
 		}
@@ -51,6 +51,39 @@ func repoRoot() (string, error) {
 			return "", errors.New("repo root not found")
 		}
 		dir = parent
+	}
+}
+
+func isAztunnelModule(data []byte) bool {
+	scanner := bufio.NewScanner(bytes.NewReader(data))
+	for scanner.Scan() {
+		if strings.TrimSpace(scanner.Text()) == "module github.com/philsphicas/aztunnel" {
+			return true
+		}
+	}
+	return false
+}
+
+func TestIsAztunnelModule(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		data string
+		want bool
+	}{
+		"LF":             {"module github.com/philsphicas/aztunnel\n\ngo 1.27\n", true},
+		"CRLF":           {"module github.com/philsphicas/aztunnel\r\n\r\ngo 1.27\r\n", true},
+		"surrounding ws": {"  module github.com/philsphicas/aztunnel  \r\n", true},
+		"other module":   {"module example.com/aztunnel\n", false},
+		"comment only":   {"// module github.com/philsphicas/aztunnel\n", false},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			if got := isAztunnelModule([]byte(tt.data)); got != tt.want {
+				t.Fatalf("isAztunnelModule() = %t, want %t", got, tt.want)
+			}
+		})
 	}
 }
 
@@ -327,7 +360,7 @@ func buildAztunnelBinary() error {
 			buildErr = fmt.Errorf("locate repo root: %w", err)
 			return
 		}
-		builtBinary = filepath.Join(root, "bin", "aztunnel")
+		builtBinary = filepath.Join(root, "bin", aztunnelBinaryName(runtime.GOOS))
 		cmd := exec.Command("go", "build", "-o", builtBinary, "./cmd/aztunnel")
 		cmd.Dir = root
 		out, err := cmd.CombinedOutput()
@@ -336,6 +369,34 @@ func buildAztunnelBinary() error {
 		}
 	})
 	return buildErr
+}
+
+func aztunnelBinaryName(goos string) string {
+	if goos == "windows" {
+		return "aztunnel.exe"
+	}
+	return "aztunnel"
+}
+
+func TestAztunnelBinaryName(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		goos string
+		want string
+	}{
+		"windows": {"windows", "aztunnel.exe"},
+		"linux":   {"linux", "aztunnel"},
+		"darwin":  {"darwin", "aztunnel"},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			if got := aztunnelBinaryName(tt.goos); got != tt.want {
+				t.Fatalf("aztunnelBinaryName(%q) = %q, want %q", tt.goos, got, tt.want)
+			}
+		})
+	}
 }
 
 // aztunnelBinary returns the path to the pre-built aztunnel binary.

--- a/e2e/scenarios/proxycommand_unix.go
+++ b/e2e/scenarios/proxycommand_unix.go
@@ -1,0 +1,36 @@
+//go:build !windows
+
+package scenarios
+
+import (
+	"context"
+	"os/exec"
+	"strings"
+)
+
+func joinProxyCommand(argv []string) string {
+	var sb strings.Builder
+	for i, arg := range argv {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		if strings.ContainsAny(arg, " \t\"\\$`") || strings.Contains(arg, "'") {
+			sb.WriteByte('\'')
+			sb.WriteString(strings.ReplaceAll(arg, "'", `'\''`))
+			sb.WriteByte('\'')
+		} else {
+			sb.WriteString(arg)
+		}
+	}
+	return sb.String()
+}
+
+func newShellCommand(command string) *exec.Cmd {
+	return exec.Command("sh", "-c", command) //nolint:gosec // test-controlled SSH command
+}
+
+func runSSHCommand(ctx context.Context, args, env []string, _ []byte) ([]byte, error) {
+	cmd := exec.CommandContext(ctx, "ssh", args...) //nolint:gosec // test-controlled args
+	cmd.Env = env
+	return cmd.CombinedOutput()
+}

--- a/e2e/scenarios/proxycommand_windows.go
+++ b/e2e/scenarios/proxycommand_windows.go
@@ -1,0 +1,91 @@
+package scenarios
+
+import (
+	"bytes"
+	"context"
+	"os/exec"
+	"strings"
+	"sync"
+	"syscall"
+)
+
+func joinProxyCommand(argv []string) string {
+	escaped := make([]string, len(argv))
+	for i, arg := range argv {
+		escaped[i] = syscall.EscapeArg(arg)
+	}
+	return strings.Join(escaped, " ")
+}
+
+func newShellCommand(command string) *exec.Cmd {
+	return exec.Command("cmd.exe", "/d", "/s", "/c", command) //nolint:gosec // test-controlled SSH command
+}
+
+func runSSHCommand(ctx context.Context, args, env []string, successMarker []byte) ([]byte, error) {
+	cmd := exec.CommandContext(ctx, "ssh", args...) //nolint:gosec // test-controlled args
+	cmd.Env = env
+
+	output := newMarkerBuffer(successMarker)
+	cmd.Stdout = output
+	cmd.Stderr = output
+	if err := cmd.Start(); err != nil {
+		return output.Bytes(), err
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		done <- cmd.Wait()
+	}()
+
+	select {
+	case err := <-done:
+		if output.Found() {
+			return output.Bytes(), nil
+		}
+		return output.Bytes(), err
+	case <-output.found:
+		_ = cmd.Process.Kill()
+		<-done
+		return output.Bytes(), nil
+	case <-ctx.Done():
+		err := <-done
+		return output.Bytes(), err
+	}
+}
+
+type markerBuffer struct {
+	mu     sync.Mutex
+	buf    bytes.Buffer
+	marker []byte
+	found  chan struct{}
+	once   sync.Once
+}
+
+func newMarkerBuffer(marker []byte) *markerBuffer {
+	return &markerBuffer{
+		marker: marker,
+		found:  make(chan struct{}),
+	}
+}
+
+func (b *markerBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	n, err := b.buf.Write(p)
+	if bytes.Contains(b.buf.Bytes(), b.marker) {
+		b.once.Do(func() { close(b.found) })
+	}
+	return n, err
+}
+
+func (b *markerBuffer) Found() bool {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return bytes.Contains(b.buf.Bytes(), b.marker)
+}
+
+func (b *markerBuffer) Bytes() []byte {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return bytes.Clone(b.buf.Bytes())
+}

--- a/e2e/scenarios/proxycommand_windows.go
+++ b/e2e/scenarios/proxycommand_windows.go
@@ -3,6 +3,8 @@ package scenarios
 import (
 	"bytes"
 	"context"
+	"errors"
+	"fmt"
 	"os/exec"
 	"strings"
 	"sync"
@@ -39,18 +41,26 @@ func runSSHCommand(ctx context.Context, args, env []string, successMarker []byte
 
 	select {
 	case err := <-done:
-		if output.Found() {
-			return output.Bytes(), nil
-		}
-		return output.Bytes(), err
+		return sshCommandResult(output, err)
 	case <-output.found:
 		_ = cmd.Process.Kill()
 		<-done
 		return output.Bytes(), nil
 	case <-ctx.Done():
 		err := <-done
-		return output.Bytes(), err
+		return sshCommandResult(output, errors.Join(ctx.Err(), err))
 	}
+}
+
+func sshCommandResult(output *markerBuffer, err error) ([]byte, error) {
+	data := output.Bytes()
+	if output.Found() {
+		return data, nil
+	}
+	if err != nil {
+		return data, fmt.Errorf("ssh exited before success marker %q: %w", output.marker, err)
+	}
+	return data, fmt.Errorf("ssh exited before success marker %q", output.marker)
 }
 
 type markerBuffer struct {

--- a/e2e/scenarios/proxycommand_windows_test.go
+++ b/e2e/scenarios/proxycommand_windows_test.go
@@ -1,0 +1,32 @@
+package scenarios
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestJoinProxyCommandWindows(t *testing.T) {
+	got := joinProxyCommand([]string{
+		`C:\Program Files\aztunnel.exe`,
+		"relay-sender",
+		"connect",
+		"%h:%p",
+	})
+
+	if strings.Contains(got, "'") {
+		t.Fatalf("Windows ProxyCommand must not use POSIX single quotes: %q", got)
+	}
+	if !strings.HasPrefix(got, `"C:\Program Files\aztunnel.exe" `) {
+		t.Fatalf("executable path was not Windows-escaped: %q", got)
+	}
+}
+
+func TestNewShellCommandWindows(t *testing.T) {
+	out, err := newShellCommand("echo tunnel-works").CombinedOutput()
+	if err != nil {
+		t.Fatalf("run command: %v", err)
+	}
+	if !strings.Contains(string(out), "tunnel-works") {
+		t.Fatalf("unexpected command output: %q", out)
+	}
+}

--- a/e2e/scenarios/proxycommand_windows_test.go
+++ b/e2e/scenarios/proxycommand_windows_test.go
@@ -1,6 +1,7 @@
 package scenarios
 
 import (
+	"errors"
 	"strings"
 	"testing"
 )
@@ -29,4 +30,42 @@ func TestNewShellCommandWindows(t *testing.T) {
 	if !strings.Contains(string(out), "tunnel-works") {
 		t.Fatalf("unexpected command output: %q", out)
 	}
+}
+
+func TestSSHCommandResultRequiresSuccessMarker(t *testing.T) {
+	t.Run("missing marker after successful exit", func(t *testing.T) {
+		output := newMarkerBuffer([]byte("success"))
+		_, _ = output.Write([]byte("other output"))
+
+		got, err := sshCommandResult(output, nil)
+		if err == nil {
+			t.Fatal("sshCommandResult returned nil error without success marker")
+		}
+		if string(got) != "other output" {
+			t.Fatalf("output = %q, want %q", got, "other output")
+		}
+	})
+
+	t.Run("missing marker preserves process error", func(t *testing.T) {
+		output := newMarkerBuffer([]byte("success"))
+		processErr := errors.New("process failed")
+
+		_, err := sshCommandResult(output, processErr)
+		if !errors.Is(err, processErr) {
+			t.Fatalf("error = %v, want wrapped process error", err)
+		}
+	})
+
+	t.Run("marker overrides forced process termination", func(t *testing.T) {
+		output := newMarkerBuffer([]byte("success"))
+		_, _ = output.Write([]byte("success"))
+
+		got, err := sshCommandResult(output, errors.New("process killed"))
+		if err != nil {
+			t.Fatalf("sshCommandResult returned error after marker: %v", err)
+		}
+		if string(got) != "success" {
+			t.Fatalf("output = %q, want %q", got, "success")
+		}
+	})
 }

--- a/e2e/scenarios/scenarios.go
+++ b/e2e/scenarios/scenarios.go
@@ -11,8 +11,6 @@ import (
 	"io"
 	"net"
 	"os"
-	"os/exec"
-	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -486,7 +484,7 @@ func ScenarioSSH_ProxyCommand(t *testing.T, b Backend) {
 	if !ok {
 		t.Skipf("SSH ProxyCommand: %s backend's Tunnel does not expose SSHProxyCommand", b.Name())
 	}
-	proxyCmdStr := joinShellSafe(proxyArgs)
+	proxyCmdStr := joinProxyCommand(proxyArgs)
 
 	host, port, err := net.SplitHostPort(sshd.Addr())
 	if err != nil {
@@ -497,6 +495,7 @@ func ScenarioSSH_ProxyCommand(t *testing.T, b Backend) {
 		"-o", "UserKnownHostsFile=/dev/null",
 		"-o", "ProxyCommand=" + proxyCmdStr,
 		"-o", "BatchMode=yes",
+		"-o", "IdentitiesOnly=yes",
 		"-p", port,
 		"-i", sshd.HostKeyPath(),
 		fmt.Sprintf("e2etest@%s", host),
@@ -504,9 +503,7 @@ func ScenarioSSH_ProxyCommand(t *testing.T, b Backend) {
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
-	cmd := exec.CommandContext(ctx, "ssh", args...) //nolint:gosec // test-controlled args
-	cmd.Env = append(os.Environ(), proxyExtraEnv...)
-	out, err := cmd.CombinedOutput()
+	out, err := runSSHCommand(ctx, args, append(os.Environ(), proxyExtraEnv...), []byte("tunnel-works"))
 	if err != nil {
 		t.Fatalf("ssh failed: %v\noutput: %s", err, out)
 	}
@@ -572,29 +569,4 @@ func ScenarioSOCKS5_DistinctTargets(t *testing.T, b Backend) {
 	for err := range errs {
 		t.Error(err)
 	}
-}
-
-// joinShellSafe joins argv with spaces, single-quoting any element
-// that contains shell-significant characters so ssh's ProxyCommand
-// (parsed by /bin/sh -c) preserves the elements as-is. The ssh
-// ProxyCommand option is the only callsite; production code uses
-// os/exec which does not need this.
-func joinShellSafe(argv []string) string {
-	var sb strings.Builder
-	for i, a := range argv {
-		if i > 0 {
-			sb.WriteByte(' ')
-		}
-		// %h / %p are sshd format substitutions and stay
-		// unquoted; anything else with a metacharacter gets
-		// single-quoted.
-		if strings.ContainsAny(a, " \t\"\\$`") || strings.Contains(a, "'") {
-			sb.WriteByte('\'')
-			sb.WriteString(strings.ReplaceAll(a, "'", `'\''`))
-			sb.WriteByte('\'')
-		} else {
-			sb.WriteString(a)
-		}
-	}
-	return sb.String()
 }

--- a/e2e/scenarios/sshserver.go
+++ b/e2e/scenarios/sshserver.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"net"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"testing"
 
@@ -17,7 +16,7 @@ import (
 
 // sshServer is a minimal in-process SSH server used by
 // ScenarioSSH_ProxyCommand. It accepts pubkey auth with a generated
-// key pair and runs every exec request through /bin/sh -c locally.
+// key pair and runs every exec request through the platform shell.
 type sshServer struct {
 	addr    string
 	keyPath string
@@ -140,7 +139,7 @@ func handleSSHSession(ch ssh.Channel, reqs <-chan *ssh.Request) {
 		command := string(req.Payload[4 : 4+cmdLen])
 		_ = req.Reply(true, nil)
 
-		cmd := exec.Command("sh", "-c", command) //nolint:gosec // test fixture: ssh server runs only in scenarios
+		cmd := newShellCommand(command)
 		cmd.Stdout = ch
 		cmd.Stderr = ch.Stderr()
 		cmd.Stdin = ch

--- a/e2e/scenarios/streamworkload_test.go
+++ b/e2e/scenarios/streamworkload_test.go
@@ -55,8 +55,8 @@ func TestRunOneStream_HappyPath(t *testing.T) {
 	if got := len(res.interGaps); got != chunks-1 {
 		t.Errorf("interGaps=%d want %d", got, chunks-1)
 	}
-	if res.firstResp <= 0 {
-		t.Errorf("firstResp=%v want > 0", res.firstResp)
+	if res.firstResp < 0 {
+		t.Errorf("firstResp=%v want >= 0", res.firstResp)
 	}
 	if res.endOffset < res.lastChunkOffset {
 		t.Errorf("endOffset=%v before lastChunkOffset=%v", res.endOffset, res.lastChunkOffset)

--- a/internal/listener/dialerror_unix.go
+++ b/internal/listener/dialerror_unix.go
@@ -1,0 +1,11 @@
+//go:build !windows
+
+package listener
+
+import "syscall"
+
+var (
+	errConnectionRefused  error = syscall.ECONNREFUSED
+	errHostUnreachable    error = syscall.EHOSTUNREACH
+	errNetworkUnreachable error = syscall.ENETUNREACH
+)

--- a/internal/listener/dialerror_windows.go
+++ b/internal/listener/dialerror_windows.go
@@ -1,0 +1,13 @@
+//go:build windows
+
+package listener
+
+import "syscall"
+
+// Winsock errors use WSA values; syscall's portable errno constants are
+// synthetic on Windows and do not match errors returned by net.Dial.
+var (
+	errConnectionRefused  error = syscall.Errno(10061) // WSAECONNREFUSED
+	errHostUnreachable    error = syscall.Errno(10065) // WSAEHOSTUNREACH
+	errNetworkUnreachable error = syscall.Errno(10051) // WSAENETUNREACH
+)

--- a/internal/listener/listener.go
+++ b/internal/listener/listener.go
@@ -11,7 +11,6 @@ import (
 	"fmt"
 	"log/slog"
 	"net"
-	"syscall"
 	"time"
 
 	"github.com/coder/websocket"
@@ -264,13 +263,13 @@ func classifyDialError(err error) string {
 	if errors.As(err, &netErr) && netErr.Timeout() {
 		return protocol.CodeTimeout
 	}
-	if errors.Is(err, syscall.ECONNREFUSED) {
+	if errors.Is(err, errConnectionRefused) {
 		return protocol.CodeConnectionRefused
 	}
-	if errors.Is(err, syscall.EHOSTUNREACH) {
+	if errors.Is(err, errHostUnreachable) {
 		return protocol.CodeHostUnreachable
 	}
-	if errors.Is(err, syscall.ENETUNREACH) {
+	if errors.Is(err, errNetworkUnreachable) {
 		return protocol.CodeNetworkUnreachable
 	}
 	return ""

--- a/internal/listener/listener_test.go
+++ b/internal/listener/listener_test.go
@@ -153,22 +153,27 @@ func TestClassifyDialError_OtherErrors(t *testing.T) {
 }
 
 func TestClassifyDialError_RealRefusedConnection(t *testing.T) {
-	ln, err := net.Listen("tcp", "127.0.0.1:0")
-	if err != nil {
-		t.Fatalf("listen: %v", err)
-	}
-	addr := ln.Addr().String()
-	if err := ln.Close(); err != nil {
-		t.Fatalf("close listener: %v", err)
-	}
+	for attempt := 0; attempt < 10; attempt++ {
+		ln, err := net.Listen("tcp", "127.0.0.1:0")
+		if err != nil {
+			t.Fatalf("listen: %v", err)
+		}
+		addr := ln.Addr().String()
+		if err := ln.Close(); err != nil {
+			t.Fatalf("close listener: %v", err)
+		}
 
-	_, err = net.DialTimeout("tcp", addr, time.Second)
-	if err == nil {
-		t.Fatal("dial unexpectedly succeeded")
+		conn, err := net.DialTimeout("tcp", addr, time.Second)
+		if err == nil {
+			_ = conn.Close()
+			continue
+		}
+		if got := classifyDialError(err); got != protocol.CodeConnectionRefused {
+			t.Fatalf("classifyDialError(%v) = %q, want %q", err, got, protocol.CodeConnectionRefused)
+		}
+		return
 	}
-	if got := classifyDialError(err); got != protocol.CodeConnectionRefused {
-		t.Fatalf("classifyDialError(%v) = %q, want %q", err, got, protocol.CodeConnectionRefused)
-	}
+	t.Fatal("dial unexpectedly succeeded after 10 attempts")
 }
 
 // --- listener_id tests ---

--- a/internal/listener/listener_test.go
+++ b/internal/listener/listener_test.go
@@ -12,7 +12,6 @@ import (
 	"net/http/httptest"
 	"strings"
 	"sync"
-	"syscall"
 	"testing"
 	"time"
 
@@ -138,9 +137,9 @@ func TestClassifyDialError_OtherErrors(t *testing.T) {
 		err  error
 		want string
 	}{
-		{"refused", &net.OpError{Op: "dial", Err: syscall.ECONNREFUSED}, protocol.CodeConnectionRefused},
-		{"host unreachable", &net.OpError{Op: "dial", Err: syscall.EHOSTUNREACH}, protocol.CodeHostUnreachable},
-		{"net unreachable", &net.OpError{Op: "dial", Err: syscall.ENETUNREACH}, protocol.CodeNetworkUnreachable},
+		{"refused", &net.OpError{Op: "dial", Err: errConnectionRefused}, protocol.CodeConnectionRefused},
+		{"host unreachable", &net.OpError{Op: "dial", Err: errHostUnreachable}, protocol.CodeHostUnreachable},
+		{"net unreachable", &net.OpError{Op: "dial", Err: errNetworkUnreachable}, protocol.CodeNetworkUnreachable},
 		{"context deadline", context.DeadlineExceeded, protocol.CodeTimeout},
 		{"unclassified", errors.New("something broke"), ""},
 	}
@@ -150,6 +149,25 @@ func TestClassifyDialError_OtherErrors(t *testing.T) {
 				t.Errorf("classifyDialError(%v) = %q, want %q", tt.err, got, tt.want)
 			}
 		})
+	}
+}
+
+func TestClassifyDialError_RealRefusedConnection(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	addr := ln.Addr().String()
+	if err := ln.Close(); err != nil {
+		t.Fatalf("close listener: %v", err)
+	}
+
+	_, err = net.DialTimeout("tcp", addr, time.Second)
+	if err == nil {
+		t.Fatal("dial unexpectedly succeeded")
+	}
+	if got := classifyDialError(err); got != protocol.CodeConnectionRefused {
+		t.Fatalf("classifyDialError(%v) = %q, want %q", err, got, protocol.CodeConnectionRefused)
 	}
 }
 
@@ -554,7 +572,7 @@ func runDialFailureHandler(t *testing.T, target string,
 
 func TestListener_DialFailed_LogIncludesCode_Refused(t *testing.T) {
 	stub := func(ctx context.Context, network, addr string) (net.Conn, error) {
-		return nil, &net.OpError{Op: "dial", Net: network, Err: syscall.ECONNREFUSED}
+		return nil, &net.OpError{Op: "dial", Net: network, Err: errConnectionRefused}
 	}
 	logs := runDialFailureHandler(t, "127.0.0.1:9", stub)
 

--- a/mockrelay/cmd/aztunnel-relay/helpers_test.go
+++ b/mockrelay/cmd/aztunnel-relay/helpers_test.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"sync"
 	"testing"
@@ -86,7 +87,7 @@ func binaries(t *testing.T) (aztunnelPath, relayPath string) {
 }
 
 func buildPkg(binDir, name, pkgPath string) (string, error) {
-	exe := filepath.Join(binDir, name)
+	exe := filepath.Join(binDir, executableName(name, runtime.GOOS))
 	cmd := exec.Command("go", "build", "-o", exe, pkgPath) //nolint:gosec // test-only build of in-tree packages
 	cmd.Env = os.Environ()
 	var out bytes.Buffer
@@ -96,6 +97,34 @@ func buildPkg(binDir, name, pkgPath string) (string, error) {
 		return "", fmt.Errorf("go build %s: %w\n%s", pkgPath, err, out.String())
 	}
 	return exe, nil
+}
+
+func executableName(name, goos string) string {
+	if goos == "windows" {
+		return name + ".exe"
+	}
+	return name
+}
+
+func TestExecutableName(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		goos string
+		want string
+	}{
+		"windows": {"windows", "aztunnel.exe"},
+		"linux":   {"linux", "aztunnel"},
+		"darwin":  {"darwin", "aztunnel"},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			if got := executableName("aztunnel", tt.goos); got != tt.want {
+				t.Fatalf("executableName(%q, %q) = %q, want %q", "aztunnel", tt.goos, got, tt.want)
+			}
+		})
+	}
 }
 
 // relayProc is a running aztunnel-relay subprocess.
@@ -147,7 +176,7 @@ func startRelay(t *testing.T, ctx context.Context, extraArgs ...string) *relayPr
 		out:      out,
 	}
 	t.Cleanup(func() {
-		_ = cmd.Process.Signal(os.Interrupt)
+		stopProcess(cmd.Process)
 		_ = cmd.Wait()
 		if t.Failed() {
 			t.Logf("relay output:\n%s", out.String())
@@ -246,7 +275,7 @@ func startConnectSender(t *testing.T, ctx context.Context, relayAddr, entity, ta
 	}
 	proc := &clientProc{cmd: cmd, out: out}
 	t.Cleanup(func() {
-		_ = cmd.Process.Signal(os.Interrupt)
+		stopProcess(cmd.Process)
 		_ = cmd.Wait()
 		if t.Failed() {
 			t.Logf("connect output:\n%s", out.String())
@@ -269,7 +298,7 @@ func startClient(t *testing.T, ctx context.Context, binary, label string, args [
 	}
 	proc := &clientProc{cmd: cmd, out: out}
 	t.Cleanup(func() {
-		_ = cmd.Process.Signal(os.Interrupt)
+		stopProcess(cmd.Process)
 		_ = cmd.Wait()
 		if t.Failed() {
 			t.Logf("%s output:\n%s", label, out.String())
@@ -278,11 +307,19 @@ func startClient(t *testing.T, ctx context.Context, binary, label string, args [
 	return proc
 }
 
-// stopAndWait sends SIGINT and waits for the process to exit. Used
-// when a test needs deterministic teardown earlier than t.Cleanup.
+// stopAndWait terminates the process and waits for it to exit. Used when
+// a test needs deterministic teardown earlier than t.Cleanup.
 func (p *clientProc) stopAndWait() {
-	_ = p.cmd.Process.Signal(os.Interrupt)
+	stopProcess(p.cmd.Process)
 	_ = p.cmd.Wait()
+}
+
+func stopProcess(p *os.Process) {
+	if runtime.GOOS == "windows" {
+		_ = p.Kill()
+		return
+	}
+	_ = p.Signal(os.Interrupt)
 }
 
 // waitForLog blocks until substr appears in the captured output or


### PR DESCRIPTION
## Summary
Makes the full Go test surface (root, `e2e`, `e2e/infra`, `mockrelay`, and tagged mock/Azure E2E) runnable natively on Windows. Non-Windows production behavior is unchanged.

## Changes
- **`e2e/backends/azure`**: detect the repository root via line-based `go.mod` parsing instead of an exact CRLF-sensitive byte match; build and execute the OS-appropriate binary name (`aztunnel.exe` on Windows).
- **`mockrelay`**: build subprocess test binaries with the OS-appropriate executable name; terminate subprocesses with `Process.Kill` on Windows because `os.Interrupt` is not supported for arbitrary Windows child processes.
- **`internal/listener`**: replace portable `syscall` constants that do not match real Winsock error values with platform-specific refused/unreachable sentinels. The real refused-connection regression test retries with a fresh ephemeral port if an address is unexpectedly reused.
- **`e2e/scenarios`**:
  - Accept zero elapsed duration from Windows' coarser timer resolution while still rejecting negative timing.
  - Make `SSH_ProxyCommand` platform-aware: Windows argv escaping, `cmd.exe` for the server-side exec request, and marker-based completion for Windows OpenSSH.
  - Require the expected success marker before reporting SSH success. A clean process exit, timeout, or process error without that marker now fails and preserves the underlying error; marker-triggered process termination remains successful.

## Validation
Verified on Windows:
- root module: `go test ./...`
- `e2e`, `e2e/infra`, and `mockrelay` modules
- full tagged mock E2E suite
- full Azure SAS and Entra E2E matrices against a dedicated namespace
- Linux compilation of the platform-specific scenario split
- refused-connection classification stress run (`-count=20`)
- Windows ProxyCommand helper tests, including missing-marker behavior (`-count=20`)

After rebasing onto the dependency-maintenance update, CI build, unit tests, formatting, lint, vulnerability checks, mock E2E, and East US 2 Azure SAS/Entra E2E are rerunning under policy-controlled auto-merge.