### PR TITLE
test(e2e): expect truncated log-tail marker

### DIFF
--- a/e2e/backends/azure/helpers_test.go
+++ b/e2e/backends/azure/helpers_test.go
@@ -710,7 +710,7 @@ func TestLogBufferTailSnapshotBoundsLines(t *testing.T) {
 		t.Fatalf("Write: %v", err)
 	}
 
-	if got, want := logs.tailSnapshot(1024, 2), "newest\npartial"; got != want {
+	if got, want := logs.tailSnapshot(1024, 2), logTailTruncated+"newest\npartial"; got != want {
 		t.Fatalf("tailSnapshot() = %q, want %q", got, want)
 	}
 }


### PR DESCRIPTION
## Summary

Correct the stale `TestLogBufferTailSnapshotBoundsLines` expectation left by #136 so it includes `logTailTruncated` when the line limit omits older records. Production `tailSnapshot` behavior is unchanged.

## Validation

- `go test -tags=e2e ./backends/azure -run '^TestLogBufferTailSnapshotBoundsLines$' -count=1 -v` (SAS-only East US 2 sandbox)
- normalized `gofmt` comparison for `e2e/backends/azure/helpers_test.go`
- `git diff --check`