### PR TITLE
Improve listener control dial diagnostics

### DIFF
--- a/e2e/backends/azure/backend_test.go
+++ b/e2e/backends/azure/backend_test.go
@@ -18,6 +18,10 @@ import (
 	"github.com/philsphicas/aztunnel/e2e/scenarios"
 )
 
+// listenerStartupTimeout covers the listener's 30s control dial timeout,
+// the 1s initial reconnect delay, and a short second connection attempt.
+const listenerStartupTimeout = 40 * time.Second
+
 // azureBackend implements scenarios.Backend against a real Azure
 // Relay namespace. It is the source-of-truth side of the mock-vs-Azure
 // conformance matrix: any scenario divergence between this backend and
@@ -268,7 +272,7 @@ func (b *azureBackend) Setup(t testing.TB, opts scenarios.SetupOptions) *scenari
 	spawnListener := func(t testing.TB) *scenarios.Listener {
 		t.Helper()
 		lst := startListener(t, env, auth, listenerArgs...)
-		waitForLog(t, lst, "control_started", 30*time.Second)
+		waitForLog(t, lst, "control_started", listenerStartupTimeout)
 		metricsAddr := lst.MetricsAddr(t, 15*time.Second)
 		return &scenarios.Listener{
 			Addr:             metricsAddr,
@@ -575,7 +579,7 @@ func (b *azureBackend) SetupExpectingFailure(t testing.TB, opts scenarios.SetupO
 	if opts.NumListeners > 0 {
 		lp := startListener(t, env, auth, "--metrics-addr", "127.0.0.1:0", "--log-level", "debug")
 		listenerLogs = func() string { return lp.logs.String() }
-		waitForLog(t, lp, "control_started", 30*time.Second)
+		waitForLog(t, lp, "control_started", listenerStartupTimeout)
 	}
 
 	if opts.SenderMode == scenarios.ModeConnect {

--- a/internal/relay/control.go
+++ b/internal/relay/control.go
@@ -201,8 +201,13 @@ func runControlLoop(ctx context.Context, cfg ControlConfig) (connected bool, err
 
 	dialCtx, dialCancel := context.WithTimeout(ctx, cfg.DialTimeout)
 	defer dialCancel()
+	var trace *dialTrace
+	if logger.Enabled(ctx, slog.LevelDebug) {
+		dialCtx, trace = newDialTrace(dialCtx, time.Now())
+	}
 	ws, resp, dialErr := websocket.Dial(dialCtx, listenURL, cfg.Options.dialOptions())
 	if dialErr != nil {
+		trace.log(ctx, logger, "control channel dial trace (dial failed)")
 		// Operator-driven cancellation propagated through dialCtx
 		// is classified as context_cancelled (no setEnd call —
 		// the classifier sees ctx.Err and maps it). Other dial
@@ -216,6 +221,7 @@ func runControlLoop(ctx context.Context, cfg ControlConfig) (connected bool, err
 		}
 		return false, fmt.Errorf("dial control: %w", sanitizeErr(dialErr))
 	}
+	trace.log(ctx, logger, "control channel dial trace")
 	defer func() { _ = ws.CloseNow() }()
 
 	// control_started fires here, after the dial has succeeded —

--- a/internal/relay/control_test.go
+++ b/internal/relay/control_test.go
@@ -935,6 +935,40 @@ func TestRunControlLoop(t *testing.T) {
 	})
 }
 
+func TestRunControlLoop_ControlDialTrace(t *testing.T) {
+	useInsecureTransport(t)
+
+	t.Run("success", func(t *testing.T) {
+		logger, rec := captureLogger()
+		drivenControlLoop(t, logger)
+		if !waitForRecord(t, rec, "control channel dial trace", time.Second) {
+			t.Fatalf("missing successful control dial trace in records: %v", rec.records(t))
+		}
+	})
+
+	t.Run("failure", func(t *testing.T) {
+		logger, rec := captureLogger()
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+
+		_, err := runControlLoop(ctx, ControlConfig{
+			Endpoint:      "127.0.0.1:1",
+			EntityPath:    "test-entity",
+			TokenProvider: &mockTokenProvider{token: "test-token"},
+			Handler:       func(context.Context, *websocket.Conn) {},
+			DialTimeout:   time.Second,
+			Logger:        logger,
+		})
+		if err == nil {
+			t.Fatal("expected control dial failure")
+		}
+
+		if !waitForRecord(t, rec, "control channel dial trace (dial failed)", time.Second) {
+			t.Fatalf("missing failed control dial trace in records: %v", rec.records(t))
+		}
+	})
+}
+
 // ---------- TestListenAndServe ----------
 
 func TestListenAndServe(t *testing.T) {


### PR DESCRIPTION
## Summary

- attach the existing DEBUG-gated `httptrace` instrumentation to the listener's initial control-channel dial
- emit distinct `control channel dial trace` DEBUG records for successful and failed dials without logging the URL or token, while leaving auth/dial error classification unchanged
- use a named 40-second Azure listener startup budget at every `control_started` wait so a 30-second first dial can emit `control_ended` and the 1-second reconnect warning, with time left for a short second attempt
- cover both successful and failed control-dial trace emission with focused unit tests

## Validation

- `go test ./internal/relay -run 'TestRunControlLoop_ControlDialTrace|TestRunControlLoop|TestListenAndServe' -count=1`
- `go test ./internal/relay -count=1`
- `go test ./internal/relay -run '^TestRunControlLoop_ControlDialTrace$' -count=1`
- with `AZURE_SUBSCRIPTION_ID`, `E2E_RESOURCE_GROUP`, `E2E_RELAY_NAME`, and `E2E_AUTH=sas` set for the command: `go test -c -tags=e2e -o <session-artifact> ./e2e/backends/azure`

A direct no-test Azure invocation (`go test -tags=e2e ./e2e/backends/azure -run '^$' -count=1`) was also attempted with those per-command environment variables, but its `TestMain` stopped before tests because repository-root discovery does not recognize this Windows worktree path (`repo root not found`). The tagged package compilation above passed.

## Scope

This is observability and retry-budget hardening only. It makes listener control startup failures diagnosable and prevents the harness from killing the process at the same instant as the first control-dial timeout. It does not fix or mask the separate Azure Relay service incident observed in West US 2.