### PR TITLE
Retry stalled Relay WebSocket handshakes

### DIFF
--- a/e2e/backends/azure/backend_test.go
+++ b/e2e/backends/azure/backend_test.go
@@ -209,6 +209,12 @@ func (*azureBackend) ColdStartLatencyThreshold() time.Duration {
 	return 6 * time.Second
 }
 
+// listenerStartupReadinessTimeout covers one 30s control dial, the initial
+// 1s reconnect backoff, and a short successful second attempt. West US 2 can
+// blackhole an upgrade until the first dial deadline, so waiting exactly 30s
+// races the listener's working reconnect path.
+const listenerStartupReadinessTimeout = 40 * time.Second
+
 // Setup brings up the requested topology (NumListeners listeners and
 // max(NumSenders,1) senders), waits until every listener has logged
 // "control_started" and every sender has logged its bind
@@ -268,7 +274,7 @@ func (b *azureBackend) Setup(t testing.TB, opts scenarios.SetupOptions) *scenari
 	spawnListener := func(t testing.TB) *scenarios.Listener {
 		t.Helper()
 		lst := startListener(t, env, auth, listenerArgs...)
-		waitForLog(t, lst, "control_started", 30*time.Second)
+		waitForLog(t, lst, "control_started", listenerStartupReadinessTimeout)
 		metricsAddr := lst.MetricsAddr(t, 15*time.Second)
 		return &scenarios.Listener{
 			Addr:             metricsAddr,
@@ -575,7 +581,7 @@ func (b *azureBackend) SetupExpectingFailure(t testing.TB, opts scenarios.SetupO
 	if opts.NumListeners > 0 {
 		lp := startListener(t, env, auth, "--metrics-addr", "127.0.0.1:0", "--log-level", "debug")
 		listenerLogs = func() string { return lp.logs.String() }
-		waitForLog(t, lp, "control_started", 30*time.Second)
+		waitForLog(t, lp, "control_started", listenerStartupReadinessTimeout)
 	}
 
 	if opts.SenderMode == scenarios.ModeConnect {

--- a/internal/relay/dial.go
+++ b/internal/relay/dial.go
@@ -2,6 +2,7 @@ package relay
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -15,10 +16,18 @@ const defaultDialTimeout = 30 * time.Second
 
 // Retry parameters for DialWithRetry.
 const (
-	retryInitial    = 1 * time.Second
-	retryMax        = 5 * time.Second
-	retryMultiplier = 2
+	retryAttemptTimeout = 10 * time.Second
+	retryInitial        = 1 * time.Second
+	retryMax            = 5 * time.Second
+	retryMultiplier     = 2
 )
+
+type retryConfig struct {
+	attemptTimeout time.Duration
+	initialDelay   time.Duration
+	maxDelay       time.Duration
+	multiplier     int
+}
 
 // Dial connects to the Azure Relay as a sender, establishing a rendezvous
 // WebSocket connection that will be paired with a listener.
@@ -48,14 +57,24 @@ func IsRetryableStatus(code int) bool {
 }
 
 // DialWithRetry is like Dial but retries on transient HTTP 404/503 errors
-// (no active listener) with exponential backoff until ctx expires.
+// (no active listener) and pre-response attempt deadlines with exponential
+// backoff until ctx expires.
 func DialWithRetry(ctx context.Context, endpoint, entityPath string, tp TokenProvider, opts ClientOptions, logger *slog.Logger) (*websocket.Conn, error) {
+	return dialWithRetry(ctx, endpoint, entityPath, tp, opts, logger, retryConfig{
+		attemptTimeout: retryAttemptTimeout,
+		initialDelay:   retryInitial,
+		maxDelay:       retryMax,
+		multiplier:     retryMultiplier,
+	})
+}
+
+func dialWithRetry(ctx context.Context, endpoint, entityPath string, tp TokenProvider, opts ClientOptions, logger *slog.Logger, cfg retryConfig) (*websocket.Conn, error) {
 	if logger == nil {
 		logger = slog.Default()
 	}
 	logger.Debug("dialing relay", "entityPath", entityPath)
 
-	delay := retryInitial
+	delay := cfg.initialDelay
 	for {
 		resURI := ResourceURI(endpoint, entityPath)
 		token, err := tp.GetToken(ctx, resURI)
@@ -67,7 +86,7 @@ func DialWithRetry(ctx context.Context, endpoint, entityPath string, tp TokenPro
 		connectURL := fmt.Sprintf("%s/$hc/%s?sb-hc-action=connect&sb-hc-token=%s",
 			opts.wssBase(endpoint), url.PathEscape(entityPath), url.QueryEscape(token))
 
-		dialCtx, cancel := context.WithTimeout(ctx, defaultDialTimeout)
+		dialCtx, cancel := context.WithTimeout(ctx, cfg.attemptTimeout)
 		var trace *dialTrace
 		if logger.Enabled(ctx, slog.LevelDebug) {
 			dialCtx, trace = newDialTrace(dialCtx, time.Now())
@@ -86,13 +105,24 @@ func DialWithRetry(ctx context.Context, endpoint, entityPath string, tp TokenPro
 		// phase split (local dial time vs relay hold) is most useful.
 		trace.log(ctx, logger, "relay rendezvous trace (dial failed)")
 
-		// Only retry on 404/503 (no active listener / listener transitioning).
-		if resp == nil || !IsRetryableStatus(resp.StatusCode) {
+		retryableStatus := resp != nil && IsRetryableStatus(resp.StatusCode)
+		retryableAttemptDeadline := resp == nil &&
+			ctx.Err() == nil &&
+			errors.Is(dialErr, context.DeadlineExceeded)
+		// Azure can abandon an upgrade before registration and before returning
+		// HTTP 101. Retrying that observed pre-registration failure is useful,
+		// but the protocol has no idempotency key and this is not a universal
+		// exactly-once guarantee if a response is lost after registration.
+		if !retryableStatus && !retryableAttemptDeadline {
 			logger.Warn("relay dial failed", "error", sanitizeErr(dialErr))
 			return nil, fmt.Errorf("dial relay: %w", sanitizeErr(dialErr))
 		}
 
-		logger.Warn("relay dial failed (retrying)", "status", resp.StatusCode, "delay", delay, "error", sanitizeErr(dialErr))
+		if resp != nil {
+			logger.Warn("relay dial failed (retrying)", "status", resp.StatusCode, "delay", delay, "error", sanitizeErr(dialErr))
+		} else {
+			logger.Warn("relay dial failed (retrying)", "delay", delay, "error", sanitizeErr(dialErr))
+		}
 
 		select {
 		case <-ctx.Done():
@@ -100,12 +130,12 @@ func DialWithRetry(ctx context.Context, endpoint, entityPath string, tp TokenPro
 		case <-time.After(delay):
 		}
 
-		delay = min(delay*retryMultiplier, retryMax)
+		delay = min(delay*time.Duration(cfg.multiplier), cfg.maxDelay)
 	}
 }
 
-// DialWithLogger is like Dial but logs the connection attempt and retries
-// on transient 404/503 errors.
+// DialWithLogger is like Dial but logs the connection attempt and applies
+// DialWithRetry's bounded retry policy.
 func DialWithLogger(ctx context.Context, endpoint, entityPath string, tp TokenProvider, opts ClientOptions, logger *slog.Logger) (*websocket.Conn, error) {
 	return DialWithRetry(ctx, endpoint, entityPath, tp, opts, logger)
 }

--- a/internal/relay/dial_test.go
+++ b/internal/relay/dial_test.go
@@ -12,6 +12,7 @@ import (
 	"net/url"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -224,6 +225,56 @@ func TestDialWithLogger(t *testing.T) {
 }
 
 func TestDialWithRetry(t *testing.T) {
+	t.Run("retries pre-response attempt deadline then succeeds", func(t *testing.T) {
+		var attempts atomic.Int32
+		firstCancelled := make(chan struct{})
+
+		srv := dialTestServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if attempts.Add(1) == 1 {
+				<-r.Context().Done()
+				close(firstCancelled)
+				return
+			}
+
+			ws, err := websocket.Accept(w, r, nil)
+			if err != nil {
+				t.Errorf("accept second attempt: %v", err)
+				return
+			}
+			defer ws.CloseNow()
+			<-r.Context().Done()
+		}))
+
+		tp := &mockTokenProvider{token: "test-token"}
+		endpoint := strings.TrimPrefix(srv.URL, "https://")
+		logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+
+		ws, err := dialWithRetry(ctx, endpoint, "test-entity", tp, ClientOptions{}, logger, retryConfig{
+			attemptTimeout: 50 * time.Millisecond,
+			initialDelay:   10 * time.Millisecond,
+			maxDelay:       10 * time.Millisecond,
+			multiplier:     1,
+		})
+		if err != nil {
+			t.Fatalf("dialWithRetry: %v", err)
+		}
+		defer ws.CloseNow()
+
+		select {
+		case <-firstCancelled:
+		case <-time.After(time.Second):
+			t.Fatal("first request context was not cancelled at the per-attempt deadline")
+		}
+		if got := attempts.Load(); got != 2 {
+			t.Fatalf("attempts = %d, want 2", got)
+		}
+		// This models the observed pre-registration blackhole. A retry can
+		// still duplicate work if registration succeeded but HTTP 101 was
+		// lost because the Relay protocol has no idempotency key.
+	})
+
 	t.Run("retries on 404 then succeeds", func(t *testing.T) {
 		var mu sync.Mutex
 		attempts := 0
@@ -328,6 +379,48 @@ func TestDialWithRetry(t *testing.T) {
 		}
 		if !errors.Is(err, context.DeadlineExceeded) {
 			t.Errorf("error should wrap context.DeadlineExceeded, got: %v", err)
+		}
+	})
+
+	t.Run("parent cancellation during pre-response wait is not retried", func(t *testing.T) {
+		var attempts atomic.Int32
+		requestStarted := make(chan struct{})
+
+		srv := dialTestServer(t, http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+			if attempts.Add(1) == 1 {
+				close(requestStarted)
+			}
+			<-r.Context().Done()
+		}))
+
+		tp := &mockTokenProvider{token: "test-token"}
+		endpoint := strings.TrimPrefix(srv.URL, "https://")
+		logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+		ctx, cancel := context.WithCancel(context.Background())
+
+		errCh := make(chan error, 1)
+		go func() {
+			_, err := DialWithRetry(ctx, endpoint, "test-entity", tp, ClientOptions{}, logger)
+			errCh <- err
+		}()
+
+		select {
+		case <-requestStarted:
+		case <-time.After(time.Second):
+			t.Fatal("request did not reach server")
+		}
+		cancel()
+
+		select {
+		case err := <-errCh:
+			if !errors.Is(err, context.Canceled) {
+				t.Fatalf("error = %v, want context.Canceled", err)
+			}
+		case <-time.After(time.Second):
+			t.Fatal("DialWithRetry did not exit after parent cancellation")
+		}
+		if got := attempts.Load(); got != 1 {
+			t.Fatalf("attempts = %d, want 1", got)
 		}
 	})
 

--- a/internal/sender/dial_budget.go
+++ b/internal/sender/dial_budget.go
@@ -10,10 +10,10 @@ import "time"
 // listener will then dial its target for an app that's gone. See
 // issue #94 ("ghost rendezvous").
 //
-// 30s preserves the existing 30s per-attempt dial timeout and permits
-// several 1–5s backoff cycles before giving up; longer than any
-// reasonable local-app socket timeout, so existing happy-path callers
-// see no behaviour change.
+// 30s preserves the sender's existing total connection budget. Relay
+// handshake attempts and their exponential backoffs all fit inside this
+// bound, so a stalled attempt can recover without extending how long the
+// local app socket waits.
 const defaultDialBudget = 30 * time.Second
 
 // dialBudget returns d unchanged, or defaultDialBudget when d is


### PR DESCRIPTION
## Why

West US 2 intermittently accepts a Relay WebSocket upgrade request and then returns neither an HTTP response nor HTTP 101 before the sender's full 30-second connection budget expires. The local TCP connection is consequently closed without delivery even though a fresh upgrade can succeed.

This improves client recovery from that regional service fault; it does not hide or reclassify the service fault as success.

## What changed

- Keep `relay.Dial` unchanged with its existing single 30-second attempt.
- Give only `DialWithRetry` a 10-second per-handshake ceiling while preserving exponential backoff and the sender's existing 30-second total per-connection budget.
- Retry a deadline only when the attempt produced no HTTP response, the dial error is `context.DeadlineExceeded`, and the parent context remains active. Existing HTTP 404/503 retries remain unchanged.
- Continue failing immediately for auth errors, connection refusal, arbitrary transport failures, and parent cancellation.
- Avoid reading `resp.StatusCode` when `resp` is nil; retry and terminal errors still pass through the existing sanitizer so SAS tokens remain secret.
- Raise both Azure listener `control_started` readiness waits to a named 40-second budget, covering one 30-second control attempt, 1-second reconnect backoff, and a short successful retry.

## Safety boundary

The observed blackhole occurs before Relay registration, which makes retry useful for this failure mode. The protocol has no idempotency key, however, so this change does **not** claim universal exactly-once behavior if registration succeeds but HTTP 101 is lost.

## Validation

- Deterministic TLS test: first upgrade blocks until its request context is canceled; the second accepts WebSocket; retry succeeds.
- Parent cancellation during a blocked pre-response attempt exits without retry.
- Existing 401, connection-refused, retry-status, sender total-budget, and successful-bridge tests pass.
- Focused retry/cancellation/non-retry cases: 10/10.
- `go test ./internal/relay ./internal/sender -count=1`: pass.
- `go test ./... -count=1`: pass.
- `go vet ./...` in root and `e2e`: pass.
- West US 2 SAS `TestE2E_Azure/sas/NSenderMListener_Echo/N2M1 -count=10`: 10/10 pass. Three runs completed in 15–18 seconds instead of the normal 4–5 seconds, consistent with recovery after a stalled 10-second handshake attempt.
- Azure cleanup confirmed zero Hybrid Connections remained after the run.

`cd e2e && go test ./... -count=1` still exposes the unrelated existing Windows failure in `TestProbeFlow_ContinuousProgress` (`worstByRTT` remains zero); touched E2E packages and the live tagged Azure test pass.