### PR TITLE
Restore SOCKS5 and version CLI compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ Run a local SOCKS5 proxy, forwarding any target through the relay:
 aztunnel relay-listener --relay my-ns --hyco my-hyco --allow "10.0.0.0/8:*"
 
 # Local:
-aztunnel relay-sender socks5-proxy --relay my-ns --hyco my-hyco -b 127.0.0.1:1080
+aztunnel relay-sender socks5-proxy --relay my-ns --hyco my-hyco
 
 # Use it:
 curl --socks5 127.0.0.1:1080 http://10.0.0.5:8080/health
@@ -247,9 +247,10 @@ Commands:
   relay-sender connect                  One-shot stdin/stdout connection (ProxyCommand)
   arc connect                           One-shot connection through an Arc relay (ProxyCommand)
   arc port-forward                      Forward a local port through an Arc relay
+  version                               Print the version and exit
 
 Global flags:
-  --version                 Print the version and exit
+  --version                   Print the version and exit (preferred)
   --log-level string          Log level: debug, info, warn, error (default "info")
   --metrics-addr string       Address for Prometheus metrics server (e.g. :9090); disabled if empty
   --metrics-max-targets int   Max unique target labels in metrics (default 500, 0 = unlimited)
@@ -290,7 +291,7 @@ aztunnel relay-sender socks5-proxy [flags]
 Flags:
   --relay string       Azure Relay namespace name
   --hyco string            Hybrid connection name
-  -b, --bind string        Local bind address:port (default "127.0.0.1:0")
+  -b, --bind string        Local bind address:port (default "127.0.0.1:1080")
   --gateway                Bind to 0.0.0.0 instead of 127.0.0.1
   --tcp-keepalive duration TCP keepalive interval (default 30s)
 ```

--- a/cmd/aztunnel/arc_port_forward.go
+++ b/cmd/aztunnel/arc_port_forward.go
@@ -16,7 +16,8 @@ import (
 
 // ArcPortForwardCmd forwards a local port through an Arc relay.
 type ArcPortForwardCmd struct {
-	BindFlags
+	LocalListenerFlags
+	Bind string `short:"b" help:"Local bind address:port." default:"127.0.0.1:0"`
 }
 
 // Run executes the arc port-forward command.
@@ -25,16 +26,9 @@ func (p *ArcPortForwardCmd) Run(globals *Globals, arcCmd *ArcCmd) error {
 	if err != nil {
 		return err
 	}
-	bind := p.Bind
-	if p.Gateway {
-		_, port, err := net.SplitHostPort(bind)
-		if err != nil {
-			return fmt.Errorf("invalid --bind address %q: %w", bind, err)
-		}
-		if port == "" {
-			port = "0"
-		}
-		bind = "0.0.0.0:" + port
+	bind, err := resolveBindAddress(p.Bind, p.Gateway)
+	if err != nil {
+		return err
 	}
 	logger := newLogger(globals.LogLevel)
 

--- a/cmd/aztunnel/cli.go
+++ b/cmd/aztunnel/cli.go
@@ -2,22 +2,27 @@ package main
 
 import (
 	"fmt"
+	"io"
+	"net"
 	"time"
 
 	"github.com/alecthomas/kong"
 	"github.com/willabides/kongplete"
 )
 
-// CLI defines the top-level command structure.
-var CLI struct {
+// CLIConfig defines the top-level command structure.
+type CLIConfig struct {
 	Globals
 
 	RelayListener RelayListenerCmd             `cmd:"" name:"relay-listener" help:"Listen on Azure Relay and forward connections to local targets."`
 	RelaySender   RelaySenderCmd               `cmd:"" name:"relay-sender" help:"Send connections through Azure Relay."`
 	Arc           ArcCmd                       `cmd:"" help:"Connect through Azure Arc managed relays."`
-	Version       VersionFlag                  `name:"version" help:"Print version and exit."`
+	VersionFlag   VersionFlag                  `name:"version" help:"Print version and exit (preferred)."`
+	Version       VersionCmd                   `cmd:"" help:"Print version and exit."`
 	Completion    kongplete.InstallCompletions `cmd:"" help:"Output shell completion script." hidden:""`
 }
+
+var CLI CLIConfig
 
 // Globals holds flags inherited by all commands.
 type Globals struct {
@@ -31,9 +36,22 @@ type VersionFlag bool
 
 // BeforeApply prints the version and exits.
 func (v VersionFlag) BeforeApply(app *kong.Kong) error {
-	_, _ = fmt.Fprintln(app.Stdout, version)
+	writeVersion(app.Stdout)
 	app.Exit(0)
 	return nil
+}
+
+// VersionCmd supports the backwards-compatible `aztunnel version` form.
+type VersionCmd struct{}
+
+// Run prints the version.
+func (*VersionCmd) Run(app *kong.Kong) error {
+	writeVersion(app.Stdout)
+	return nil
+}
+
+func writeVersion(w io.Writer) {
+	_, _ = fmt.Fprintln(w, version)
 }
 
 // AuthFlags holds Azure Relay authentication flags shared across relay commands.
@@ -45,11 +63,24 @@ type AuthFlags struct {
 	RelayInsecureTLS bool   `name:"relay-insecure-tls" help:"Skip TLS certificate verification (mock/self-hosted only)."`
 }
 
-// BindFlags holds local bind flags shared across port-forward and socks5 commands.
-type BindFlags struct {
-	Bind         string        `short:"b" help:"Local bind address:port." default:"127.0.0.1:0"`
+// LocalListenerFlags holds behavior shared by local TCP listener commands.
+type LocalListenerFlags struct {
 	Gateway      bool          `help:"Bind to 0.0.0.0 instead of 127.0.0.1."`
 	TCPKeepAlive time.Duration `name:"tcp-keepalive" help:"TCP keepalive interval." default:"30s"`
+}
+
+func resolveBindAddress(bind string, gateway bool) (string, error) {
+	if !gateway {
+		return bind, nil
+	}
+	_, port, err := net.SplitHostPort(bind)
+	if err != nil {
+		return "", fmt.Errorf("invalid --bind address %q: %w", bind, err)
+	}
+	if port == "" {
+		port = "0"
+	}
+	return "0.0.0.0:" + port, nil
 }
 
 // RelaySenderCmd is a grouping command for relay sender subcommands.

--- a/cmd/aztunnel/cli_test.go
+++ b/cmd/aztunnel/cli_test.go
@@ -1,0 +1,206 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/alecthomas/kong"
+)
+
+type errorWriter struct{}
+
+func (errorWriter) Write([]byte) (int, error) {
+	return 0, errors.New("write failed")
+}
+
+func TestVersionFormsIgnoreWriteErrors(t *testing.T) {
+	exitCode := -1
+	parser := kong.Must(
+		&struct{}{},
+		kong.Writers(errorWriter{}, errorWriter{}),
+		kong.Exit(func(code int) { exitCode = code }),
+	)
+
+	if err := (VersionFlag(true)).BeforeApply(parser); err != nil {
+		t.Errorf("VersionFlag.BeforeApply() error = %v, want nil", err)
+	}
+	if exitCode != 0 {
+		t.Errorf("VersionFlag.BeforeApply() exit code = %d, want 0", exitCode)
+	}
+	if err := (&VersionCmd{}).Run(parser); err != nil {
+		t.Errorf("VersionCmd.Run() error = %v, want nil", err)
+	}
+}
+
+func TestCLICommandBindDefaults(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		bind func(*CLIConfig) string
+		want string
+	}{
+		{
+			name: "relay port-forward remains ephemeral",
+			args: []string{"relay-sender", "port-forward", "--hyco", "tunnel", "target:22"},
+			bind: func(cli *CLIConfig) string { return cli.RelaySender.PortForward.Bind },
+			want: "127.0.0.1:0",
+		},
+		{
+			name: "socks5 uses conventional port",
+			args: []string{"relay-sender", "socks5-proxy", "--hyco", "tunnel"},
+			bind: func(cli *CLIConfig) string { return cli.RelaySender.Socks5Proxy.Bind },
+			want: "127.0.0.1:1080",
+		},
+		{
+			name: "arc port-forward remains ephemeral",
+			args: []string{"arc", "port-forward"},
+			bind: func(cli *CLIConfig) string { return cli.Arc.PortForward.Bind },
+			want: "127.0.0.1:0",
+		},
+		{
+			name: "socks5 explicit ephemeral override",
+			args: []string{"relay-sender", "socks5-proxy", "--hyco", "tunnel", "-b", "127.0.0.1:0"},
+			bind: func(cli *CLIConfig) string { return cli.RelaySender.Socks5Proxy.Bind },
+			want: "127.0.0.1:0",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var cli CLIConfig
+			parser := kong.Must(&cli)
+			if _, err := parser.Parse(tt.args); err != nil {
+				t.Fatalf("parse %q: %v", tt.args, err)
+			}
+			if got := tt.bind(&cli); got != tt.want {
+				t.Errorf("bind = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCLIHycoRemainsFlagOnly(t *testing.T) {
+	var cli CLIConfig
+	parser := kong.Must(&cli)
+	if _, err := parser.Parse([]string{"relay-sender", "socks5-proxy", "legacy-positional-hyco"}); err == nil {
+		t.Fatal("expected positional hybrid connection name to be rejected")
+	}
+	if cli.RelaySender.Socks5Proxy.Hyco != "" {
+		t.Errorf("hyco = %q, want empty without --hyco", cli.RelaySender.Socks5Proxy.Hyco)
+	}
+}
+
+func TestTopLevelHelpBindDefaults(t *testing.T) {
+	portForwardHelp := helpSection(t, topLevelHelp, "Relay Sender - Port Forward:", "Relay Sender - Connect:")
+	if !strings.Contains(portForwardHelp, `default "127.0.0.1:0"`) {
+		t.Errorf("port-forward help does not retain the ephemeral bind default:\n%s", portForwardHelp)
+	}
+
+	socksHelp := helpSection(t, topLevelHelp, "Relay Sender - SOCKS5 Proxy:", "Arc Connect:")
+	if !strings.Contains(socksHelp, `default "127.0.0.1:1080"`) {
+		t.Errorf("SOCKS5 help does not show the conventional bind default:\n%s", socksHelp)
+	}
+}
+
+func helpSection(t *testing.T, help, startMarker, endMarker string) string {
+	t.Helper()
+
+	start := strings.Index(help, startMarker)
+	if start == -1 {
+		t.Fatalf("help is missing start marker %q", startMarker)
+	}
+	sectionStart := start + len(startMarker)
+	relativeEnd := strings.Index(help[sectionStart:], endMarker)
+	if relativeEnd == -1 {
+		t.Fatalf("help is missing end marker %q", endMarker)
+	}
+	end := sectionStart + relativeEnd
+	return help[start:end]
+}
+
+func TestResolveBindAddress(t *testing.T) {
+	tests := []struct {
+		name    string
+		bind    string
+		gateway bool
+		want    string
+		wantErr bool
+	}{
+		{name: "unchanged without gateway", bind: "127.0.0.1:1080", want: "127.0.0.1:1080"},
+		{name: "gateway preserves socks5 port", bind: "127.0.0.1:1080", gateway: true, want: "0.0.0.0:1080"},
+		{name: "gateway preserves ephemeral port", bind: "127.0.0.1:0", gateway: true, want: "0.0.0.0:0"},
+		{name: "gateway defaults empty port to ephemeral", bind: "127.0.0.1:", gateway: true, want: "0.0.0.0:0"},
+		{name: "invalid bind", bind: "1080", gateway: true, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := resolveBindAddress(tt.bind, tt.gateway)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("resolveBindAddress: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("resolveBindAddress = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCLIVersionFormsAndHelpDefaults(t *testing.T) {
+	binary := buildAztunnelForTest(t)
+
+	run := func(t *testing.T, args ...string) (string, string) {
+		t.Helper()
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		cmd := exec.CommandContext(ctx, binary, args...) //nolint:gosec // test-controlled binary path and args
+		var stdout, stderr bytes.Buffer
+		cmd.Stdout = &stdout
+		cmd.Stderr = &stderr
+		if err := cmd.Run(); err != nil {
+			t.Fatalf("aztunnel %s: %v\nstderr:\n%s", strings.Join(args, " "), err, stderr.String())
+		}
+		return stdout.String(), stderr.String()
+	}
+
+	flagOutput, flagStderr := run(t, "--version")
+	commandOutput, commandStderr := run(t, "version")
+	if flagOutput != commandOutput {
+		t.Errorf("--version output %q differs from version command output %q", flagOutput, commandOutput)
+	}
+	if flagOutput != version+"\n" {
+		t.Errorf("version output = %q, want %q", flagOutput, version+"\n")
+	}
+	if flagStderr != "" || commandStderr != "" {
+		t.Errorf("version forms wrote stderr: --version=%q version=%q", flagStderr, commandStderr)
+	}
+
+	helpTests := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{name: "relay port-forward", args: []string{"relay-sender", "port-forward", "--help"}, want: `--bind="127.0.0.1:0"`},
+		{name: "SOCKS5 proxy", args: []string{"relay-sender", "socks5-proxy", "--help"}, want: `--bind="127.0.0.1:1080"`},
+		{name: "Arc port-forward", args: []string{"arc", "port-forward", "--help"}, want: `--bind="127.0.0.1:0"`},
+	}
+	for _, tt := range helpTests {
+		t.Run(tt.name+" help", func(t *testing.T) {
+			output, _ := run(t, tt.args...)
+			if !strings.Contains(output, tt.want) {
+				t.Errorf("help does not contain %q:\n%s", tt.want, output)
+			}
+		})
+	}
+}

--- a/cmd/aztunnel/help.go
+++ b/cmd/aztunnel/help.go
@@ -34,13 +34,14 @@ Usage:
   aztunnel relay-sender connect <host:port> [flags]
   aztunnel arc connect [flags]
   aztunnel arc port-forward [flags]
+  aztunnel version
 
 Global Options:
       --log-level string            Log level: debug, info, warn, error (default "info")
       --metrics-addr string         Prometheus metrics server address (e.g. :9090); disabled if empty
       --metrics-max-targets int     Max unique target labels in metrics; 0 = unlimited (default 500)
       --help, -h                    Show this help message
-      --version                     Print version and exit
+      --version                     Print version and exit (preferred)
 
 Relay Listener:
   Start a relay-listener that accepts connections from the Azure Relay
@@ -82,7 +83,7 @@ Relay Sender - SOCKS5 Proxy:
       --relay string                Azure Relay namespace name, FQDN, or URI
       --hyco string                 Hybrid connection name
       --relay-suffix string         Namespace suffix for sovereign clouds
-  -b, --bind string                 Local bind address:port (default "127.0.0.1:0")
+  -b, --bind string                 Local bind address:port (default "127.0.0.1:1080")
       --gateway                     Bind to 0.0.0.0 instead of 127.0.0.1
       --tcp-keepalive duration      TCP keepalive interval (default 30s)
 

--- a/cmd/aztunnel/main.go
+++ b/cmd/aztunnel/main.go
@@ -40,7 +40,7 @@ func main() {
 	ctx, err := parser.Parse(os.Args[1:])
 	parser.FatalIfErrorf(err)
 
-	parser.FatalIfErrorf(ctx.Run(&CLI.Globals))
+	parser.FatalIfErrorf(ctx.Run(&CLI.Globals, parser))
 }
 
 // resolveMetrics creates a Metrics instance and starts the HTTP server if

--- a/cmd/aztunnel/port_forward.go
+++ b/cmd/aztunnel/port_forward.go
@@ -2,8 +2,6 @@ package main
 
 import (
 	"context"
-	"fmt"
-	"net"
 	"os"
 	"os/signal"
 
@@ -13,7 +11,8 @@ import (
 // PortForwardCmd forwards a local port through the relay.
 type PortForwardCmd struct {
 	AuthFlags
-	BindFlags
+	LocalListenerFlags
+	Bind   string `short:"b" help:"Local bind address:port." default:"127.0.0.1:0"`
 	Target string `arg:"" required:"" help:"Target host:port."`
 }
 
@@ -29,16 +28,9 @@ func (p *PortForwardCmd) Run(globals *Globals) error {
 		return err
 	}
 
-	bind := p.Bind
-	if p.Gateway {
-		_, port, err := net.SplitHostPort(bind)
-		if err != nil {
-			return fmt.Errorf("invalid --bind address %q: %w", bind, err)
-		}
-		if port == "" {
-			port = "0"
-		}
-		bind = "0.0.0.0:" + port
+	bind, err := resolveBindAddress(p.Bind, p.Gateway)
+	if err != nil {
+		return err
 	}
 	logger := newLogger(globals.LogLevel)
 	warnInsecureTLS(opts, logger)

--- a/cmd/aztunnel/socks5_proxy.go
+++ b/cmd/aztunnel/socks5_proxy.go
@@ -2,8 +2,6 @@ package main
 
 import (
 	"context"
-	"fmt"
-	"net"
 	"os"
 	"os/signal"
 
@@ -13,7 +11,8 @@ import (
 // Socks5ProxyCmd runs a local SOCKS5 proxy through the relay.
 type Socks5ProxyCmd struct {
 	AuthFlags
-	BindFlags
+	LocalListenerFlags
+	Bind string `short:"b" help:"Local bind address:port." default:"127.0.0.1:1080"`
 }
 
 // Run executes the socks5-proxy command.
@@ -28,16 +27,9 @@ func (s *Socks5ProxyCmd) Run(globals *Globals) error {
 		return err
 	}
 
-	bind := s.Bind
-	if s.Gateway {
-		_, port, err := net.SplitHostPort(bind)
-		if err != nil {
-			return fmt.Errorf("invalid --bind address %q: %w", bind, err)
-		}
-		if port == "" {
-			port = "0"
-		}
-		bind = "0.0.0.0:" + port
+	bind, err := resolveBindAddress(s.Bind, s.Gateway)
+	if err != nil {
+		return err
 	}
 	logger := newLogger(globals.LogLevel)
 	warnInsecureTLS(opts, logger)

--- a/docs/guides/sender-socks5-proxy.md
+++ b/docs/guides/sender-socks5-proxy.md
@@ -26,8 +26,7 @@ Start the SOCKS5 proxy:
 ```sh
 aztunnel relay-sender socks5-proxy \
   --relay my-relay-ns \
-  --hyco my-tunnel \
-  --bind 127.0.0.1:1080
+  --hyco my-tunnel
 ```
 
 The proxy listens on `127.0.0.1:1080` and forwards each connection through
@@ -143,11 +142,12 @@ ssh -o ProxyCommand="nc -x 127.0.0.1:1080 %h %p" user@10.0.0.5
 
 ## Ephemeral port
 
-If you don't care which port the proxy binds to, omit `--bind` or use
-port `0`. The OS picks an available port automatically:
+The default bind is `127.0.0.1:1080`. To have the OS pick an available
+ephemeral port instead, explicitly pass port `0`:
 
 ```sh
-aztunnel relay-sender socks5-proxy --relay my-relay-ns --hyco my-tunnel
+aztunnel relay-sender socks5-proxy --relay my-relay-ns --hyco my-tunnel \
+  --bind 127.0.0.1:0
 ```
 
 aztunnel logs the assigned port:
@@ -160,7 +160,7 @@ If you're running it as a [bgtask](https://github.com/philsphicas/bgtask),
 `bgtask ls` shows the listening port automatically:
 
 ```sh
-bgtask run --name proxy -- aztunnel relay-sender socks5-proxy
+bgtask run --name proxy -- aztunnel relay-sender socks5-proxy --bind 127.0.0.1:0
 bgtask ls
 # → proxy  running  :52431  aztunnel relay-sender socks5-proxy
 ```
@@ -204,7 +204,7 @@ export AZTUNNEL_HYCO_NAME=my-tunnel
 export AZTUNNEL_KEY_NAME=send-policy
 export AZTUNNEL_KEY='<your-sas-key>'
 
-aztunnel relay-sender socks5-proxy --bind 127.0.0.1:1080
+aztunnel relay-sender socks5-proxy
 ```
 
 ## Debugging

--- a/internal/sender/sender_test.go
+++ b/internal/sender/sender_test.go
@@ -18,6 +18,25 @@ import (
 	"github.com/philsphicas/aztunnel/internal/protocol"
 )
 
+func TestSOCKS5ProxyOccupiedBindReturnsError(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("reserve bind address: %v", err)
+	}
+	defer ln.Close() //nolint:errcheck // test cleanup
+
+	err = SOCKS5Proxy(context.Background(), SOCKS5Config{
+		BindAddress: ln.Addr().String(),
+		Logger:      slog.New(slog.NewTextHandler(io.Discard, nil)),
+	})
+	if err == nil {
+		t.Fatal("expected occupied bind address to return an error")
+	}
+	if !strings.Contains(err.Error(), "listen "+ln.Addr().String()) {
+		t.Errorf("error = %q, want bind failure for %s", err, ln.Addr())
+	}
+}
+
 // --- stdioConn tests ---
 
 type fakeReadCloser struct {


### PR DESCRIPTION
## Summary

- Default `relay-sender socks5-proxy` to the conventional `127.0.0.1:1080` endpoint.
- Preserve ephemeral `127.0.0.1:0` defaults for Relay and Arc port-forward commands.
- Add the backwards-compatible `aztunnel version` command alongside `aztunnel --version`; both print identical output.
- Centralize gateway bind-address rewriting while allowing each command to declare its own bind default.
- Document explicit `--bind 127.0.0.1:0` for users who want an ephemeral SOCKS5 port.

If port 1080 is occupied, SOCKS5 startup returns the normal bind error instead of silently selecting another port.

## Command behavior

| Command | Default bind |
| --- | --- |
| `relay-sender socks5-proxy` | `127.0.0.1:1080` |
| `relay-sender port-forward` | `127.0.0.1:0` |
| `arc port-forward` | `127.0.0.1:0` |

Both version forms are supported:

```sh
aztunnel --version
aztunnel version
```

## Validation

- `go test -race ./...`
- `go vet ./...`
- focused CLI default, version, gateway-bind, empty-port, and occupied-port tests
- gofmt check on edited Go files
- Prettier 3.6.2 check on edited Markdown
- `go install ./cmd/aztunnel`
- built with an injected validation version; both version forms printed the same value
- inspected built-binary help for all three command-specific bind defaults