### PR TITLE
fix(arc): retry stalled websocket handshakes

### DIFF
--- a/internal/arc/arc.go
+++ b/internal/arc/arc.go
@@ -15,6 +15,7 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -204,11 +205,18 @@ func Dial(ctx context.Context, info *RelayInfo, port int) (*websocket.Conn, erro
 
 // Retry parameters for DialWithOptions.
 const (
-	retryInitial    = 1 * time.Second
-	retryMax        = 5 * time.Second
-	retryMultiplier = 2
-	dialTimeout     = 30 * time.Second
+	retryAttemptTimeout = 10 * time.Second
+	retryInitial        = 1 * time.Second
+	retryMax            = 5 * time.Second
+	retryMultiplier     = 2
 )
+
+type retryConfig struct {
+	attemptTimeout time.Duration
+	initialDelay   time.Duration
+	maxDelay       time.Duration
+	multiplier     int
+}
 
 // Progress-log timings are vars (not consts) so tests can shorten them
 // without using real time.
@@ -242,8 +250,8 @@ type DialOptions struct {
 }
 
 // DialWithLogger is like Dial but logs the connection attempt and retries
-// on transient 404/503 errors (no active listener) with exponential backoff
-// until ctx expires.
+// on transient 404/503 errors (no active listener) and pre-response attempt
+// deadlines with exponential backoff until ctx expires.
 func DialWithLogger(ctx context.Context, info *RelayInfo, port int, logger *slog.Logger) (*websocket.Conn, error) {
 	return DialWithOptions(ctx, info, port, logger, DialOptions{})
 }
@@ -251,6 +259,15 @@ func DialWithLogger(ctx context.Context, info *RelayInfo, port int, logger *slog
 // DialWithOptions is like DialWithLogger but accepts options that adjust
 // progress logging during retries.
 func DialWithOptions(ctx context.Context, info *RelayInfo, port int, logger *slog.Logger, opts DialOptions) (*websocket.Conn, error) {
+	return dialWithOptions(ctx, info, port, logger, opts, retryConfig{
+		attemptTimeout: retryAttemptTimeout,
+		initialDelay:   retryInitial,
+		maxDelay:       retryMax,
+		multiplier:     retryMultiplier,
+	})
+}
+
+func dialWithOptions(ctx context.Context, info *RelayInfo, port int, logger *slog.Logger, opts DialOptions, cfg retryConfig) (*websocket.Conn, error) {
 	if port == 0 {
 		port = defaultPort
 	}
@@ -268,7 +285,7 @@ func DialWithOptions(ctx context.Context, info *RelayInfo, port int, logger *slo
 	headers.Set("Service-Configuration-Token", info.ServiceConfigurationToken)
 	headers.Set("Microsoft-Guestgateway-Target", fmt.Sprintf("localhost:%d", port))
 
-	delay := retryInitial
+	delay := cfg.initialDelay
 	start := time.Now()
 	attempts := 0
 	var lastStatus int
@@ -279,7 +296,7 @@ func DialWithOptions(ctx context.Context, info *RelayInfo, port int, logger *slo
 		connectURL := fmt.Sprintf("wss://%s/$hc/%s?sb-hc-action=connect&sb-hc-id=%s",
 			wssHost, info.HybridConnectionName, newUUID())
 
-		dialCtx, cancel := context.WithTimeout(ctx, dialTimeout)
+		dialCtx, cancel := context.WithTimeout(ctx, cfg.attemptTimeout)
 		ws, resp, err := websocket.Dial(dialCtx, connectURL, relay.WSDialOptions(headers, nil))
 		cancel()
 
@@ -306,17 +323,28 @@ func DialWithOptions(ctx context.Context, info *RelayInfo, port int, logger *slo
 			return nil, giveUpErr(attempts, time.Since(start), lastStatus, ctxErr)
 		}
 
-		if resp == nil || !relay.IsRetryableStatus(resp.StatusCode) {
+		retryableStatus := resp != nil && relay.IsRetryableStatus(resp.StatusCode)
+		retryableAttemptDeadline := resp == nil &&
+			ctx.Err() == nil &&
+			errors.Is(err, context.DeadlineExceeded)
+		if !retryableStatus && !retryableAttemptDeadline {
 			logger.Warn("arc relay dial failed", "error", sanitizeErr(err))
 			return nil, fmt.Errorf("dial arc relay: %w", sanitizeErr(err))
 		}
 
-		lastStatus = resp.StatusCode
-		logger.Debug("arc relay dial returned retryable status",
-			"status", resp.StatusCode,
-			"attempt", attempts,
-			"delay", delay,
-			"error", sanitizeErr(err))
+		if retryableStatus {
+			lastStatus = resp.StatusCode
+			logger.Debug("arc relay dial returned retryable status",
+				"status", resp.StatusCode,
+				"attempts", attempts,
+				"delay", delay,
+				"error", sanitizeErr(err))
+		} else {
+			logger.Debug("arc relay dial attempt timed out before HTTP response",
+				"attempts", attempts,
+				"delay", delay,
+				"error", sanitizeErr(err))
+		}
 
 		// Progress logging:
 		//   - ExplainSetup=true: emit immediately on first retry, then every
@@ -328,7 +356,7 @@ func DialWithOptions(ctx context.Context, info *RelayInfo, port int, logger *slo
 		//   - ExplainSetup=false: stay quiet for progressLogQuietDelay (covers
 		//     transient hiccups), then emit progress every progressLogPeriod
 		//     so operators see real "listener never appears" cases.
-		if opts.ExplainSetup {
+		if retryableStatus && opts.ExplainSetup {
 			if attempts == 1 {
 				logger.Info("waiting for Arc agent to register a relay listener (expected after creating or updating the HybridConnectivity configuration)",
 					"status", resp.StatusCode)
@@ -341,7 +369,7 @@ func DialWithOptions(ctx context.Context, info *RelayInfo, port int, logger *slo
 				lastProgressLog = time.Now()
 				progressLogged = true
 			}
-		} else if time.Since(start) >= progressLogQuietDelay && time.Since(lastProgressLog) >= progressLogPeriod {
+		} else if retryableStatus && time.Since(start) >= progressLogQuietDelay && time.Since(lastProgressLog) >= progressLogPeriod {
 			logger.Info("still waiting for arc relay listener",
 				"elapsed", time.Since(start).Truncate(time.Second),
 				"attempts", attempts,
@@ -356,7 +384,7 @@ func DialWithOptions(ctx context.Context, info *RelayInfo, port int, logger *slo
 		case <-time.After(delay):
 		}
 
-		delay = min(delay*retryMultiplier, retryMax)
+		delay = min(delay*time.Duration(cfg.multiplier), cfg.maxDelay)
 	}
 }
 

--- a/internal/arc/arc_test.go
+++ b/internal/arc/arc_test.go
@@ -6,10 +6,13 @@ import (
 	"errors"
 	"io"
 	"log/slog"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"sync"
+	"sync/atomic"
+	"syscall"
 	"testing"
 	"time"
 
@@ -388,7 +391,216 @@ type errString string
 
 func (e errString) Error() string { return string(e) }
 
+func relayInfoForHost(t *testing.T, host string) *RelayInfo {
+	t.Helper()
+	namespace, suffix, ok := strings.Cut(host, ".")
+	if !ok {
+		t.Fatalf("host %q does not contain the Arc namespace separator", host)
+	}
+	return &RelayInfo{
+		NamespaceName:             namespace,
+		NamespaceNameSuffix:       suffix,
+		HybridConnectionName:      "test-hyco",
+		AccessKey:                 "test-key",
+		ServiceConfigurationToken: "test-token",
+	}
+}
+
+func relayInfoForTestServer(t *testing.T, srv *httptest.Server) *RelayInfo {
+	t.Helper()
+	return relayInfoForHost(t, strings.TrimPrefix(srv.URL, "https://"))
+}
+
+func isConnectionRefused(err error) bool {
+	// Winsock uses WSAECONNREFUSED (10061), while Unix platforms expose
+	// the portable ECONNREFUSED value.
+	return errors.Is(err, syscall.ECONNREFUSED) || errors.Is(err, syscall.Errno(10061))
+}
+
 func TestDialWithLoggerRetry(t *testing.T) {
+	t.Run("retries pre-response attempt deadline then succeeds", func(t *testing.T) {
+		var attempts atomic.Int32
+		firstCancelled := make(chan struct{})
+
+		srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if attempts.Add(1) == 1 {
+				<-r.Context().Done()
+				close(firstCancelled)
+				return
+			}
+			ws, err := websocket.Accept(w, r, nil)
+			if err != nil {
+				t.Errorf("accept second attempt: %v", err)
+				return
+			}
+			defer ws.CloseNow()
+			<-r.Context().Done()
+		}))
+		defer srv.Close()
+
+		origTransport := http.DefaultTransport
+		http.DefaultTransport = &http.Transport{
+			TLSClientConfig: srv.Client().Transport.(*http.Transport).TLSClientConfig,
+		}
+		defer func() { http.DefaultTransport = origTransport }()
+
+		logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+
+		ws, err := dialWithOptions(ctx, relayInfoForTestServer(t, srv), 22, logger, DialOptions{}, retryConfig{
+			attemptTimeout: 50 * time.Millisecond,
+			initialDelay:   10 * time.Millisecond,
+			maxDelay:       10 * time.Millisecond,
+			multiplier:     1,
+		})
+		if err != nil {
+			t.Fatalf("dialWithOptions: %v", err)
+		}
+		defer ws.CloseNow()
+
+		select {
+		case <-firstCancelled:
+		case <-time.After(time.Second):
+			t.Fatal("first request context was not cancelled at the per-attempt deadline")
+		}
+		if got := attempts.Load(); got != 2 {
+			t.Fatalf("attempts = %d, want 2", got)
+		}
+	})
+
+	t.Run("parent cancellation during pre-response wait is not retried", func(t *testing.T) {
+		var attempts atomic.Int32
+		requestStarted := make(chan struct{})
+
+		srv := httptest.NewTLSServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+			if attempts.Add(1) == 1 {
+				close(requestStarted)
+			}
+			<-r.Context().Done()
+		}))
+		defer srv.Close()
+
+		origTransport := http.DefaultTransport
+		http.DefaultTransport = &http.Transport{
+			TLSClientConfig: srv.Client().Transport.(*http.Transport).TLSClientConfig,
+		}
+		defer func() { http.DefaultTransport = origTransport }()
+
+		logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+		ctx, cancel := context.WithCancel(context.Background())
+		errCh := make(chan error, 1)
+		info := relayInfoForTestServer(t, srv)
+		go func() {
+			_, err := dialWithOptions(ctx, info, 22, logger, DialOptions{}, retryConfig{
+				attemptTimeout: time.Second,
+				initialDelay:   10 * time.Millisecond,
+				maxDelay:       10 * time.Millisecond,
+				multiplier:     1,
+			})
+			errCh <- err
+		}()
+
+		select {
+		case <-requestStarted:
+		case <-time.After(time.Second):
+			t.Fatal("request did not reach server")
+		}
+		cancel()
+
+		select {
+		case err := <-errCh:
+			if !errors.Is(err, context.Canceled) {
+				t.Fatalf("error = %v, want context.Canceled", err)
+			}
+		case <-time.After(time.Second):
+			t.Fatal("dialWithOptions did not exit after parent cancellation")
+		}
+		if got := attempts.Load(); got != 1 {
+			t.Fatalf("attempts = %d, want 1", got)
+		}
+	})
+
+	t.Run("pre-response connection reset fails immediately without retry", func(t *testing.T) {
+		var attempts atomic.Int32
+		srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			attempts.Add(1)
+			conn, _, err := w.(http.Hijacker).Hijack()
+			if err != nil {
+				t.Errorf("hijack: %v", err)
+				return
+			}
+			_ = conn.Close()
+		}))
+		defer srv.Close()
+
+		origTransport := http.DefaultTransport
+		http.DefaultTransport = &http.Transport{
+			TLSClientConfig: srv.Client().Transport.(*http.Transport).TLSClientConfig,
+		}
+		defer func() { http.DefaultTransport = origTransport }()
+
+		logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+
+		_, err := dialWithOptions(ctx, relayInfoForTestServer(t, srv), 22, logger, DialOptions{}, retryConfig{
+			attemptTimeout: 200 * time.Millisecond,
+			initialDelay:   10 * time.Millisecond,
+			maxDelay:       10 * time.Millisecond,
+			multiplier:     1,
+		})
+		if err == nil {
+			t.Fatal("expected reset error")
+		}
+		if got := attempts.Load(); got != 1 {
+			t.Fatalf("attempts = %d, want 1", got)
+		}
+	})
+
+	t.Run("connection refused fails immediately without retry", func(t *testing.T) {
+		listener, err := net.Listen("tcp", "127.0.0.1:0")
+		if err != nil {
+			t.Fatalf("listen: %v", err)
+		}
+		host := listener.Addr().String()
+		if err := listener.Close(); err != nil {
+			t.Fatalf("close listener: %v", err)
+		}
+
+		info := relayInfoForHost(t, host)
+		if got := info.NamespaceName + "." + info.NamespaceNameSuffix; got != host {
+			t.Fatalf("Arc relay host = %q, want closed listener %q", got, host)
+		}
+		logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+		ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+		defer cancel()
+
+		start := time.Now()
+		_, err = dialWithOptions(ctx, info, 22, logger, DialOptions{}, retryConfig{
+			attemptTimeout: 200 * time.Millisecond,
+			initialDelay:   300 * time.Millisecond,
+			maxDelay:       300 * time.Millisecond,
+			multiplier:     1,
+		})
+		if err == nil {
+			t.Fatal("expected connection-refused error")
+		}
+		var opErr *net.OpError
+		if !errors.As(err, &opErr) {
+			t.Fatalf("error = %T %v, want a network dial error", err, err)
+		}
+		if !isConnectionRefused(err) {
+			t.Fatalf("network dial error = %v, want connection refused", err)
+		}
+		if errors.Is(err, context.DeadlineExceeded) {
+			t.Fatalf("connection refusal was retried until the parent deadline: %v", err)
+		}
+		if elapsed := time.Since(start); elapsed >= 300*time.Millisecond {
+			t.Fatalf("connection refusal took %s; expected immediate failure before retry delay", elapsed)
+		}
+	})
+
 	t.Run("retries on 404 then succeeds", func(t *testing.T) {
 		var mu sync.Mutex
 		attempts := 0
@@ -403,6 +615,7 @@ func TestDialWithLoggerRetry(t *testing.T) {
 				w.WriteHeader(http.StatusNotFound)
 				return
 			}
+
 			ws, err := websocket.Accept(w, r, nil)
 			if err != nil {
 				return


### PR DESCRIPTION
## Root cause

Arc uses its own WebSocket retry loop instead of the regular Relay sender path fixed in #142. Each Arc attempt allowed 30 seconds, and any failure without an HTTP response returned immediately. Azure Relay can finish DNS/TCP/TLS and receive the upgrade request but send no first response byte, so Arc abandoned the connection after the first blackholed handshake.

## Behavior

- Cap each Arc retry-loop handshake attempt at 10 seconds.
- Retry only a nil-response `context.DeadlineExceeded` when the parent context is still active.
- Keep auth failures, refused connections, arbitrary resets, and parent cancellation non-retryable.
- Preserve the existing 404/503 listener-registration retries, exponential backoff, progress logging, and sensitive-token sanitization.
- Keep the change Arc-local so its header-based authentication and URL construction remain independent from the regular Relay sender path.

## Tests

- Added deterministic direct coverage for a blackholed first attempt followed by success.
- Added direct parent-cancellation, connection-reset, and connection-refused non-retry coverage; existing 401 and 404/503 coverage remains in place.
- `go test ./internal/arc -count=1`
- Focused retry cases repeated with `-count=5`
- `go test ./...`
- `git diff --check`

The CI Linux job will run the repository's race-enabled suite; local `-race` execution was unavailable because this Windows Go environment has CGO disabled.