### PR TITLE
ci: stop bundling aztunnel-relay in release tgz/zip archives

### DIFF
--- a/.github/actions/package-release/action.yml
+++ b/.github/actions/package-release/action.yml
@@ -3,7 +3,7 @@ description: Cross-build and package one aztunnel release target
 
 inputs:
   version:
-    description: Version embedded in both binaries and the bundle name
+    description: Version embedded in the binary and the bundle name
     required: true
   goos:
     description: Target operating system
@@ -44,17 +44,7 @@ runs:
           go build -trimpath -ldflags="-s -w -X main.version=${VERSION}" \
           -o "${stage}/aztunnel${extension}" ./cmd/aztunnel
 
-        CGO_ENABLED=0 GOOS="$TARGET_OS" GOARCH="$TARGET_ARCH" \
-          GOWORK="${GITHUB_WORKSPACE}/go.work" \
-          go build -trimpath -ldflags="-s -w -X main.version=${VERSION}" \
-          -o "${stage}/aztunnel-relay${extension}" ./mockrelay/cmd/aztunnel-relay
-
         cp LICENSE README.md "$stage/"
-        cat > "${stage}/RELAY-NOTICE.txt" <<'EOF'
-        aztunnel-relay is a non-production mock/development relay.
-        It is bundled to preserve the existing release contract, but is not supported
-        as a production relay service. See mockrelay/README.md in the source repository.
-        EOF
 
         if [[ "$TARGET_OS" == "windows" ]]; then
           asset="${bundle}.zip"
@@ -65,7 +55,7 @@ runs:
           )
         else
           asset="${bundle}.tar.gz"
-          chmod 0755 "${stage}/aztunnel" "${stage}/aztunnel-relay"
+          chmod 0755 "${stage}/aztunnel"
           tar --sort=name \
             --mtime="UTC 1970-01-01" \
             --owner=0 \

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -694,7 +694,6 @@ jobs:
 
           This rolling prerelease is built from the latest successfully validated commit on \`main\`.
           Development builds are short-lived snapshots and receive best-effort support.
-          The bundled \`aztunnel-relay\` is a non-production mock/development relay.
 
           Publication stages versioned assets before moving the \`dev\` tag and metadata. GitHub
           Releases and GHCR do not support an atomic transaction, so a failed promotion is surfaced

--- a/README.md
+++ b/README.md
@@ -79,8 +79,9 @@ and the rolling [`dev` prerelease](https://github.com/philsphicas/aztunnel/relea
 provide Linux amd64/arm64, macOS amd64/arm64, and Windows amd64 bundles.
 Unix bundles are `.tar.gz` archives that preserve executable permissions;
 Windows bundles are `.zip` archives. Each bundle contains `aztunnel`,
-the non-production `aztunnel-relay`, `README.md`, `LICENSE`, and a relay
-support notice.
+`README.md`, and `LICENSE`. `aztunnel-relay` is a non-production
+mock/development relay and is not included in these bundles; use its
+[Docker image](#docker) if you need it.
 
 Each release also includes `aztunnel-<version>-checksums.txt`. Verify a
 download from the directory containing the bundle and manifest with:

--- a/mockrelay/README.md
+++ b/mockrelay/README.md
@@ -216,8 +216,8 @@ ports.
 
 ## Limitations
 
-This is a test fixture, not a production relay. It intentionally does
-not support the following:
+This is a test fixture, not a production relay. It has the following
+limitations:
 
 - **Dummy-key auth only.** The relay accepts any SAS token signed with
   the configured key (default: a hard-coded dev key), OR a JWT-shaped

--- a/mockrelay/README.md
+++ b/mockrelay/README.md
@@ -216,8 +216,8 @@ ports.
 
 ## Limitations
 
-This is a test fixture, not a production relay — file issues if you
-need any of the following:
+This is a test fixture, not a production relay. It intentionally does
+not support the following:
 
 - **Dummy-key auth only.** The relay accepts any SAS token signed with
   the configured key (default: a hard-coded dev key), OR a JWT-shaped


### PR DESCRIPTION
## What
Release archives (`aztunnel-<version>-<os>-<arch>.tar.gz`/`.zip`) no longer include the `aztunnel-relay` binary or the `RELAY-NOTICE.txt`. Bundles now contain only `aztunnel`, `README.md`, and `LICENSE`.

## Why
`aztunnel-relay` is a non-production mock/development relay intended for internal use (local dev, CI, tests) — it was never meant to be a public release artifact. It ended up in the release picker unexpectedly (only ever published to the `dev` prerelease, never a tagged release), which is confusing for users installing `aztunnel` via the release tgz.

## Changes
- `.github/actions/package-release/action.yml`: drop the `aztunnel-relay` cross-build step and the relay notice file from the packaging stage.
- `README.md`: update the release bundle description; note that `aztunnel-relay` is available via its Docker image instead.
- `.github/workflows/publish-release.yml`: remove the now-stale mention of the bundled relay from dev prerelease notes.
- `mockrelay/README.md`: reword the "Limitations" section — it previously said "file issues if you need any of the following," which reads as an invitation to request production-grade features for a tool that's intentionally scoped as a test fixture.

## Not in scope
The `aztunnel-relay` Docker image is unaffected by this PR — that's a separate decision to make later if desired.